### PR TITLE
fix: update suggestions when typing in overlay search field

### DIFF
--- a/lib/widgets/operator_selector.dart
+++ b/lib/widgets/operator_selector.dart
@@ -122,12 +122,12 @@ class OperatorSelectorState extends State<OperatorSelector> {
   }
 
   void _onOverlayTextChanged(String value) {
-    // Commit parts separated by commas
     if (value.contains(',')) {
       final parts = value.split(',');
-
       _addOperator(parts.first.trim());
       _closeOverlayAndReset();
+    } else {
+      _updateSuggestionsOverlay();
     }
   }
 


### PR DESCRIPTION
_onOverlayTextChanged was not calling _updateSuggestionsOverlay(), so the list would not appear when the user explicitly clicked into the overlay's text field before typing.

https://claude.ai/code/session_01PQYqorTM9c1K5Fep72aPcg