### PR TITLE
Show loading indicator immediately on app start instead of blank screen

### DIFF
--- a/lib/providers/polyline_provider.dart
+++ b/lib/providers/polyline_provider.dart
@@ -41,7 +41,7 @@ class PolylineProvider extends ChangeNotifier {
   List<PolylineEntry> _polylines = [];
   List<Polyline<int>> _renderedPolylines = const [];
 
-  bool _isLoading = false;
+  bool _isLoading = true;
   Object? _error;
 
   int _renderRevision = 0;
@@ -311,7 +311,15 @@ class PolylineProvider extends ChangeNotifier {
   void _syncWithTrips() {
     final trips = _trips;
     if (trips == null) return;
-    if (trips.isLoading || trips.repository == null) return;
+
+    if (trips.isLoading || trips.repository == null) {
+      // Trips finished loading but failed (no repository) – nothing to show.
+      if (!trips.isLoading && _isLoading) {
+        _isLoading = false;
+        notifyListeners();
+      }
+      return;
+    }
 
     final newRevision = trips.polylineRevision;
 


### PR DESCRIPTION
PolylineProvider previously initialized _isLoading = false, causing the map to display a blank screen while TripsProvider fetched data. The loading spinner only appeared after trips finished loading and triggered _syncWithTrips().

Starting _isLoading = true ensures the loading indicator is visible from the very first frame. The error path in _syncWithTrips now explicitly clears the loading state when trips finish but have no repository (network/auth failure).

https://claude.ai/code/session_01CGyRQQnxNjjL9nkabEnSed