### PR TITLE
Hard refresh trip data when new DB columns are detected

### DIFF
--- a/lib/data/trips_repository.dart
+++ b/lib/data/trips_repository.dart
@@ -804,10 +804,17 @@ class TripsRepository {
     return trips;
   }
 
+  static Future<bool> needsSchemaUpdate() async {
+    final db = await DatabaseManager.database;
+    final columns = await db.rawQuery('PRAGMA table_info(${TripsTable.tableName})');
+    final existingColumns = columns.map((col) => col['name'] as String).toSet();
+    return TripsTable.columns.keys.any((key) => !existingColumns.contains(key));
+  }
+
   Future<void> _ensureTripsTableSchema() async {
     final columns = await _db.rawQuery('PRAGMA table_info(${TripsTable.tableName})');
     final existingColumns = columns.map((col) => col['name'] as String).toSet();
-    
+
     // Add missing columns
     for (final entry in TripsTable.columns.entries) {
       if (!existingColumns.contains(entry.key)) {

--- a/lib/providers/trips_provider.dart
+++ b/lib/providers/trips_provider.dart
@@ -163,6 +163,14 @@ class TripsProvider extends ChangeNotifier {
     DateTime? lastRefresh = hardRefresh ? null : _settings!.lastFetchingTrips;
     if(lastRefresh == forceRefreshDate.toUtc()) lastRefresh = null; // treat forceRefreshDate as hard refresh
 
+    // If doing incremental refresh, check if new DB columns were added - force hard refresh to fill them
+    bool schemaTriggeredHardRefresh = false;
+    if (lastRefresh != null && await TripsRepository.needsSchemaUpdate()) {
+      debugPrint("🔄 Schema update detected, forcing hard refresh to fill new columns");
+      lastRefresh = null;
+      schemaTriggeredHardRefresh = true;
+    }
+
     try {
       if (lastRefresh == null) {
         debugPrint("🔄 Hard refreshing all trips data");
@@ -172,7 +180,7 @@ class TripsProvider extends ChangeNotifier {
           content,
           replace: true,
           path: false,
-        );        
+        );
       } else {
         debugPrint("🔄 Refreshing only necessary $_username's trips from ${lastRefresh.toIso8601String()}");
         final trips = await _service!.fetchLastUpdatedTripsData(_username??"", lastRefresh);
@@ -189,8 +197,8 @@ class TripsProvider extends ChangeNotifier {
 
       await _refreshDerivedLists();
 
-      _polylineRevision++;
-      _revision++;      
+      if (!schemaTriggeredHardRefresh) _polylineRevision++;
+      _revision++;
       final count = await _repository!.count();
       debugPrint("✅ Finished loading trips. Total $count rows");
       _settings!.setLastFetchingTripsNowUtc();


### PR DESCRIPTION
When an app update adds new DB columns, the incremental refresh only fetched recently modified trips, leaving those columns empty for older entries. Now detects missing columns before deciding the refresh strategy and forces a full trip data fetch in that case, without reloading polylines.

https://claude.ai/code/session_01RygErrE6Mp8pQwL58HSyrD