### PR TITLE
Also trigger polyline revision if trips were modified since last refresh

### DIFF
--- a/lib/data/trips_repository.dart
+++ b/lib/data/trips_repository.dart
@@ -154,6 +154,14 @@ class TripsRepository {
     return Sqflite.firstIntValue(result) ?? 0;
   }
 
+  Future<bool> hasTripsModifiedSince(DateTime since) async {
+    final result = await _db.rawQuery(
+      'SELECT COUNT(*) FROM ${TripsTable.tableName} WHERE last_modified > ?',
+      [since.toUtc().toIso8601String()],
+    );
+    return (Sqflite.firstIntValue(result) ?? 0) > 0;
+  }
+
   Future<int> countFilteredTrips({required bool showFutureTrips, TripsFilterResult? filter,}) async {
     final whereInfo = _buildWhereClause(showFutureTrips: showFutureTrips, filter: filter);
 

--- a/lib/providers/trips_provider.dart
+++ b/lib/providers/trips_provider.dart
@@ -164,11 +164,10 @@ class TripsProvider extends ChangeNotifier {
     if(lastRefresh == forceRefreshDate.toUtc()) lastRefresh = null; // treat forceRefreshDate as hard refresh
 
     // If doing incremental refresh, check if new DB columns were added - force hard refresh to fill them
-    bool schemaTriggeredHardRefresh = false;
+    DateTime? originalLastRefresh = lastRefresh;
     if (lastRefresh != null && await TripsRepository.needsSchemaUpdate()) {
       debugPrint("🔄 Schema update detected, forcing hard refresh to fill new columns");
       lastRefresh = null;
-      schemaTriggeredHardRefresh = true;
     }
 
     try {
@@ -197,7 +196,11 @@ class TripsProvider extends ChangeNotifier {
 
       await _refreshDerivedLists();
 
-      if (!schemaTriggeredHardRefresh) _polylineRevision++;
+      // Skip polyline refresh for schema-triggered hard refreshes, unless trips were
+      // also modified since the last update (which may include path changes)
+      final hadModifications = originalLastRefresh == null
+          || await _repository!.hasTripsModifiedSince(originalLastRefresh);
+      if (hadModifications) _polylineRevision++;
       _revision++;
       final count = await _repository!.count();
       debugPrint("✅ Finished loading trips. Total $count rows");


### PR DESCRIPTION
When a schema-triggered hard refresh runs, polyline revision is now only skipped if no trips were actually modified since the previous sync. Uses a last_modified DB query after the hard refresh to decide.

https://claude.ai/code/session_01RygErrE6Mp8pQwL58HSyrD