### PR TITLE
Rename Coverage page to Dashboard

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -151,6 +151,7 @@
   "menuTripsTitle": "Trips",
   "menuRankingTitle": "Ranking",
   "menuStatisticsTitle": "Statistics",
+  "menuDashboardTitle": "Dashboard",
   "menuCoverageTitle": "Coverage",
   "menuTagsTitle": "Tags",    
   "menuTicketsTitle": "Tickets", 

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -123,6 +123,7 @@
   "menuTripsTitle": "Trajets",
   "menuRankingTitle": "Classement",
   "menuStatisticsTitle": "Statistiques",
+  "menuDashboardTitle": "Tableau de bord",
   "menuCoverageTitle": "Couverture",
   "menuTagsTitle": "Tags",    
   "menuTicketsTitle": "Tickets", 

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -123,6 +123,7 @@
   "menuTripsTitle": "旅行",
   "menuRankingTitle": "ランキング",
   "menuStatisticsTitle": "統計",
+  "menuDashboardTitle": "ダッシュボード",
   "menuCoverageTitle": "走破率",
   "menuTagsTitle": "タグ",
   "menuTicketsTitle": "乗車券",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -834,6 +834,12 @@ abstract class AppLocalizations {
   /// **'Statistics'**
   String get menuStatisticsTitle;
 
+  /// No description provided for @menuDashboardTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Dashboard'**
+  String get menuDashboardTitle;
+
   /// No description provided for @menuCoverageTitle.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -398,6 +398,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get menuStatisticsTitle => 'Statistics';
 
   @override
+  String get menuDashboardTitle => 'Dashboard';
+
+  @override
   String get menuCoverageTitle => 'Coverage';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -404,6 +404,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get menuStatisticsTitle => 'Statistiques';
 
   @override
+  String get menuDashboardTitle => 'Tableau de bord';
+
+  @override
   String get menuCoverageTitle => 'Couverture';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -389,6 +389,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get menuStatisticsTitle => '統計';
 
   @override
+  String get menuDashboardTitle => 'ダッシュボード';
+
+  @override
   String get menuCoverageTitle => '走破率';
 
   @override

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -404,6 +404,9 @@ class AppLocalizationsTl extends AppLocalizations {
   String get menuStatisticsTitle => 'Istatistika';
 
   @override
+  String get menuDashboardTitle => 'Dashboard';
+
+  @override
   String get menuCoverageTitle => 'Sakop';
 
   @override

--- a/lib/l10n/app_tl.arb
+++ b/lib/l10n/app_tl.arb
@@ -147,6 +147,7 @@
   "menuTripsTitle": "Byahe",
   "menuRankingTitle": "Ranking",
   "menuStatisticsTitle": "Istatistika",
+  "menuDashboardTitle": "Dashboard",
   "menuCoverageTitle": "Sakop",
   "menuTagsTitle": "Tags",
   "menuTicketsTitle": "Tiket",

--- a/lib/navigation/cupertino_shell.dart
+++ b/lib/navigation/cupertino_shell.dart
@@ -8,7 +8,7 @@ import 'package:trainlog_app/platform/cupertino_fab.dart';
 import 'package:trainlog_app/utils/platform_utils.dart';
 
 import 'package:trainlog_app/pages/about_page.dart';
-import 'package:trainlog_app/pages/coverage_page.dart';
+import 'package:trainlog_app/pages/dashboard_page.dart';
 import 'package:trainlog_app/pages/friends_page.dart';
 import 'package:trainlog_app/pages/map_page.dart';
 import 'package:trainlog_app/pages/ranking_page.dart';
@@ -272,9 +272,9 @@ class _MorePage extends StatelessWidget {
                   //_sectionHeader('Pages'),
                   _moreTile(
                     context,
-                    icon: AdaptiveIcons.coverage,
-                    title: l10n.menuCoverageTitle,
-                    push: () => _pushSimple(context, l10n.menuCoverageTitle, const CoveragePage()),
+                    icon: AdaptiveIcons.dashboard,
+                    title: l10n.menuDashboardTitle,
+                    push: () => _pushSimple(context, l10n.menuDashboardTitle, const DashboardPage()),
                   ),
                   _moreTile(
                     context,

--- a/lib/navigation/material_shell.dart
+++ b/lib/navigation/material_shell.dart
@@ -10,6 +10,7 @@ import 'package:trainlog_app/widgets/menu_header.dart';
 
 import 'package:trainlog_app/pages/about_page.dart';
 import 'package:trainlog_app/pages/coverage_page.dart';
+import 'package:trainlog_app/pages/dashboard_page.dart';
 import 'package:trainlog_app/pages/friends_page.dart';
 import 'package:trainlog_app/pages/map_page.dart';
 import 'package:trainlog_app/pages/ranking_page.dart';
@@ -154,6 +155,12 @@ class _MaterialShellState extends State<MaterialShell> {
 
       // Drawer pages
       AppPage(
+        id: AppPageId.dashboard,
+        view: const DashboardPage(),
+        titleBuilder: (c) => AppLocalizations.of(c)!.menuDashboardTitle,
+        icon: AdaptiveIcons.dashboard,
+      ),
+      AppPage(
         id: AppPageId.coverage,
         view: const CoveragePage(),
         titleBuilder: (c) => AppLocalizations.of(c)!.menuCoverageTitle,
@@ -279,7 +286,7 @@ class _MaterialShellState extends State<MaterialShell> {
                       child: ListView(
                         padding: EdgeInsets.zero,
                         children: [
-                          _buildDrawerItem(context, _indexOf(AppPageId.coverage)),
+                          _buildDrawerItem(context, _indexOf(AppPageId.dashboard)),
                           _buildDrawerItem(context, _indexOf(AppPageId.tags)),
                           _buildDrawerItem(context, _indexOf(AppPageId.tickets)),
                           //_buildDrawerItem(context, _indexOf(AppPageId.friends)), TODO

--- a/lib/navigation/nav_models.dart
+++ b/lib/navigation/nav_models.dart
@@ -25,6 +25,7 @@ enum AppPageId {
   trips,
   ranking,
   statistics,
+  dashboard,
   coverage,
   tags,
   tickets,

--- a/lib/pages/coverage_page.dart
+++ b/lib/pages/coverage_page.dart
@@ -1,28 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:trainlog_app/widgets/dismissible_error_banner_block.dart';
-import 'package:trainlog_app/widgets/error_banner.dart';
-import 'package:trainlog_app/widgets/trainlog_web_page.dart';
-import 'package:trainlog_app/l10n/app_localizations.dart';
 
 class CoveragePage extends StatelessWidget {
   const CoveragePage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final loc = AppLocalizations.of(context)!;
-
-    return Column(
-      children: [
-        DismissibleErrorBannerBlock(
-          message: loc.pageNotImplementedYet,
-          severity: ErrorSeverity.warning,
-        ),
-        Expanded(
-          child: TrainlogWebPage(
-            trainlogPage: "dashboard",
-          ),
-        ),
-      ],
-    );
+    return const SizedBox.shrink();
   }
 }

--- a/lib/pages/dashboard_page.dart
+++ b/lib/pages/dashboard_page.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:trainlog_app/widgets/dismissible_error_banner_block.dart';
+import 'package:trainlog_app/widgets/error_banner.dart';
+import 'package:trainlog_app/widgets/trainlog_web_page.dart';
+import 'package:trainlog_app/l10n/app_localizations.dart';
+
+class DashboardPage extends StatelessWidget {
+  const DashboardPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
+
+    return Column(
+      children: [
+        DismissibleErrorBannerBlock(
+          message: loc.pageNotImplementedYet,
+          severity: ErrorSeverity.warning,
+        ),
+        Expanded(
+          child: TrainlogWebPage(
+            trainlogPage: "dashboard",
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/utils/platform_utils.dart
+++ b/lib/utils/platform_utils.dart
@@ -46,6 +46,7 @@ class AdaptiveIcons {
   static final IconData other =       isA ? CupertinoIcons.ellipsis : Icons.more_horiz;
 
   // Drawer menu
+  static final IconData dashboard =   isA ? CupertinoIcons.square_grid_2x2_fill : Icons.dashboard;
   static final IconData coverage =    isA ? CupertinoIcons.percent : Icons.percent;
   static final IconData tags =        isA ? CupertinoIcons.tag_fill : Icons.label;
   static final IconData tickets =     isA ? CupertinoIcons.ticket_fill : Icons.confirmation_number;


### PR DESCRIPTION
- Create dashboard_page.dart with DashboardPage class (former CoveragePage content)
- Leave coverage_page.dart as an empty stub (not accessible from the drawer)
- Add menuDashboardTitle translation in EN/FR/JA/TL (EN: Dashboard, FR: Tableau de bord, JA: ダッシュボード, TL: Dashboard)
- Keep menuCoverageTitle and coverage icon for future use
- Add AdaptiveIcons.dashboard (Icons.dashboard / CupertinoIcons.square_grid_2x2_fill)
- Add AppPageId.dashboard to nav_models enum
- Wire DashboardPage into the Material drawer and Cupertino more-menu

https://claude.ai/code/session_01HfpKrGdVGtVBjYkeYFjwnj