### PR TITLE
Claude/add onboarding screen 387 j2

### DIFF
--- a/lib/app/home_gate.dart
+++ b/lib/app/home_gate.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
 
+import 'package:trainlog_app/pages/onboarding_screen.dart';
 import 'package:trainlog_app/pages/welcome_page.dart';
+import 'package:trainlog_app/providers/settings_provider.dart';
 import 'package:trainlog_app/providers/trainlog_provider.dart';
 import 'package:trainlog_app/widgets/trips_loader.dart';
 
@@ -15,8 +17,12 @@ class HomeGate extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Consumer<TrainlogProvider>(
-      builder: (_, auth, __) {
+    return Consumer2<SettingsProvider, TrainlogProvider>(
+      builder: (_, settings, auth, __) {
+        if (!settings.onboardingCompleted) {
+          return const OnboardingScreen();
+        }
+
         if (!auth.isAuthenticated) {
           return const WelcomePage();
         }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -522,5 +522,15 @@
     }
   },
 
-  "trainglogStatusPageTitle": "Trainlog Status"
+  "trainglogStatusPageTitle": "Trainlog Status",
+
+  "onboardingGetStarted": "Get started",
+  "onboardingPage1Title": "Visualise your travels",
+  "onboardingPage1Subtitle": "Keeping track of your journeys made easy. See all your train, bus, ferry, and aeroplane journeys neatly on a map.",
+  "onboardingPage2Title": "Explore your statistics",
+  "onboardingPage2Subtitle": "See a statistical breakdown of how, when, and where you have travelled.\n\nGet useful statistics on your most frequently visited stations, most frequently used operators, and how much of your country's railway network you have been on.",
+  "onboardingPage3Title": "Share your travels",
+  "onboardingPage3Subtitle": "Create shareable links about your trips to share your travel plans with anyone.",
+  "onboardingPage4Title": "Leaderboards",
+  "onboardingPage4Subtitle": "Are you a frequent traveller? See how your travels stack up against other members worldwide."
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -334,5 +334,15 @@
   "inboxModified": "(modifié)",
   "inboxModifiedIndication": "(modifié le {date})",
 
-  "trainglogStatusPageTitle": "État de Trainlog"
+  "trainglogStatusPageTitle": "État de Trainlog",
+
+  "onboardingGetStarted": "Commencer",
+  "onboardingPage1Title": "Visualisez vos voyages",
+  "onboardingPage1Subtitle": "Gardez la trace de vos trajets en toute simplicité. Retrouvez tous vos voyages en train, bus, ferry et avion sur une carte.",
+  "onboardingPage2Title": "Explorez vos statistiques",
+  "onboardingPage2Subtitle": "Consultez une analyse détaillée de vos déplacements : comment, quand et où vous avez voyagé.\n\nDécouvrez vos gares les plus fréquentées, vos opérateurs les plus utilisés et la part du réseau ferroviaire de votre pays que vous avez parcourue.",
+  "onboardingPage3Title": "Partagez vos voyages",
+  "onboardingPage3Subtitle": "Créez des liens partageables pour vos trajets et communiquez vos projets de voyage à qui vous voulez.",
+  "onboardingPage4Title": "Classements",
+  "onboardingPage4Subtitle": "Êtes-vous un grand voyageur ? Comparez vos voyages avec ceux des autres membres du monde entier."
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -336,5 +336,15 @@
   "inboxModifiedIndication": "({date}に変更)",
 
 
-  "trainglogStatusPageTitle": "Trainlogの状態"
+  "trainglogStatusPageTitle": "Trainlogの状態",
+
+  "onboardingGetStarted": "はじめる",
+  "onboardingPage1Title": "旅を可視化",
+  "onboardingPage1Subtitle": "旅の記録を簡単に。電車・バス・フェリー・飛行機のすべての移動を地図上で見やすく確認できます。",
+  "onboardingPage2Title": "統計を探索",
+  "onboardingPage2Subtitle": "いつ、どこへ、どのように旅したかを統計で確認できます。\n\n最もよく訪れた駅や最も利用した交通事業者、自国の鉄道網をどれだけ乗ったかなど、役立つ情報が一目でわかります。",
+  "onboardingPage3Title": "旅をシェア",
+  "onboardingPage3Subtitle": "旅のリンクを作成して、移動の計画を誰とでも共有できます。",
+  "onboardingPage4Title": "リーダーボード",
+  "onboardingPage4Subtitle": "よく旅をするあなたへ。世界中のメンバーと旅の記録を比べてみましょう。"
 }

--- a/lib/l10n/app_tl.arb
+++ b/lib/l10n/app_tl.arb
@@ -499,5 +499,15 @@
   "addTripDelay": "Delay",
   "addTripRealTime": "Tamang oras",
   "addTripOriginDayLabel": "Araw ng byahe",
-  "addTripResetToScheduled": "Ireset sa scheduled time"
+  "addTripResetToScheduled": "Ireset sa scheduled time",
+
+  "onboardingGetStarted": "Magsimula",
+  "onboardingPage1Title": "Biswalisa ang iyong mga paglalakbay",
+  "onboardingPage1Subtitle": "Madaling subaybayan ang iyong mga biyahe. Makita ang lahat ng iyong biyahe sa tren, bus, barko, at eroplano sa isang mapa.",
+  "onboardingPage2Title": "Tuklasin ang iyong mga istatistika",
+  "onboardingPage2Subtitle": "Tingnan ang estadistikang detalye kung paano, kailan, at saan ka naglakbay.\n\nMakakuha ng kapaki-pakinabang na istatistika tungkol sa mga istasyong pinaka-madalas mong binibisita, mga operator na pinaka-madalas mong ginagamit, at kung gaano karami sa riles ng iyong bansa ang iyong nalakbay.",
+  "onboardingPage3Title": "Ibahagi ang iyong mga paglalakbay",
+  "onboardingPage3Subtitle": "Gumawa ng mga link na maaaring ibahagi para sa iyong mga biyahe upang ibahagi ang iyong mga plano sa paglalakbay sa sinuman.",
+  "onboardingPage4Title": "Mga Leaderboard",
+  "onboardingPage4Subtitle": "Ikaw ba ay madalas maglakbay? Tingnan kung paano ang iyong mga paglalakbay kumpara sa ibang mga miyembro sa buong mundo."
 }

--- a/lib/pages/onboarding_screen.dart
+++ b/lib/pages/onboarding_screen.dart
@@ -1,0 +1,204 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:trainlog_app/providers/settings_provider.dart';
+
+class OnboardingScreen extends StatefulWidget {
+  const OnboardingScreen({super.key});
+
+  @override
+  State<OnboardingScreen> createState() => _OnboardingScreenState();
+}
+
+class _OnboardingScreenState extends State<OnboardingScreen> {
+  final _controller = PageController();
+  int _currentPage = 0;
+
+  static const _pageCount = 4;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _next() {
+    if (_currentPage < _pageCount - 1) {
+      _controller.nextPage(
+        duration: const Duration(milliseconds: 350),
+        curve: Curves.easeInOut,
+      );
+    } else {
+      context.read<SettingsProvider>().completeOnboarding();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    final pages = [
+      _OnboardingPage(
+        icon: Icons.travel_explore,
+        title: 'Visualise your travels',
+        subtitle:
+            'Keeping track of your journeys made easy. See all your train, bus, ferry, and aeroplane journeys neatly on a map.',
+        color: colorScheme.primaryContainer,
+        iconColor: colorScheme.primary,
+      ),
+      _OnboardingPage(
+        icon: Icons.bar_chart_rounded,
+        title: 'Explore your statistics',
+        subtitle:
+            'See a statistical breakdown of how, when, and where you have travelled.\n\nGet useful statistics on your most frequently visited stations, most frequently used operators, and how much of your country\'s railway network you have been on.',
+        color: colorScheme.secondaryContainer,
+        iconColor: colorScheme.secondary,
+      ),
+      _OnboardingPage(
+        icon: Icons.share,
+        title: 'Share your travels',
+        subtitle:
+            'Create shareable links about your trips to share your travel plans with anyone.',
+        color: colorScheme.tertiaryContainer,
+        iconColor: colorScheme.tertiary,
+      ),
+      _OnboardingPage(
+        icon: Icons.emoji_events,
+        title: 'Leaderboards',
+        subtitle:
+            'Are you a frequent traveller? See how your travels stack up against other members worldwide.',
+        color: colorScheme.errorContainer,
+        iconColor: colorScheme.error,
+      ),
+    ];
+
+    return Scaffold(
+      body: SafeArea(
+        child: Column(
+          children: [
+            Expanded(
+              child: PageView.builder(
+                controller: _controller,
+                onPageChanged: (i) => setState(() => _currentPage = i),
+                itemCount: pages.length,
+                itemBuilder: (_, i) => pages[i],
+              ),
+            ),
+            _BottomControls(
+              currentPage: _currentPage,
+              pageCount: _pageCount,
+              onNext: _next,
+              isLast: _currentPage == _pageCount - 1,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _OnboardingPage extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final Color color;
+  final Color iconColor;
+
+  const _OnboardingPage({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    required this.color,
+    required this.iconColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 32),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Container(
+            width: 120,
+            height: 120,
+            decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+            child: Icon(icon, size: 60, color: iconColor),
+          ),
+          const SizedBox(height: 40),
+          Text(
+            title,
+            style: textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.bold),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 16),
+          Text(
+            subtitle,
+            style: textTheme.bodyLarge?.copyWith(
+              color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.7),
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _BottomControls extends StatelessWidget {
+  final int currentPage;
+  final int pageCount;
+  final VoidCallback onNext;
+  final bool isLast;
+
+  const _BottomControls({
+    required this.currentPage,
+    required this.pageCount,
+    required this.onNext,
+    required this.isLast,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(32, 16, 32, 32),
+      child: Column(
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: List.generate(
+              pageCount,
+              (i) => AnimatedContainer(
+                duration: const Duration(milliseconds: 250),
+                margin: const EdgeInsets.symmetric(horizontal: 4),
+                width: i == currentPage ? 24 : 8,
+                height: 8,
+                decoration: BoxDecoration(
+                  color: i == currentPage
+                      ? colorScheme.primary
+                      : colorScheme.outlineVariant,
+                  borderRadius: BorderRadius.circular(4),
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(height: 24),
+          FilledButton(
+            onPressed: onNext,
+            style: FilledButton.styleFrom(
+              minimumSize: const Size(double.infinity, 52),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(16),
+              ),
+            ),
+            child: Text(
+              isLast ? 'Get started' : 'Next',
+              style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/onboarding_screen.dart
+++ b/lib/pages/onboarding_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:trainlog_app/l10n/app_localizations.dart';
 import 'package:trainlog_app/providers/settings_provider.dart';
 
 class OnboardingScreen extends StatefulWidget {
@@ -35,37 +36,34 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
+    final loc = AppLocalizations.of(context)!;
 
     final pages = [
       _OnboardingPage(
         icon: Icons.travel_explore,
-        title: 'Visualise your travels',
-        subtitle:
-            'Keeping track of your journeys made easy. See all your train, bus, ferry, and aeroplane journeys neatly on a map.',
+        title: loc.onboardingPage1Title,
+        subtitle: loc.onboardingPage1Subtitle,
         color: colorScheme.primaryContainer,
         iconColor: colorScheme.primary,
       ),
       _OnboardingPage(
         icon: Icons.bar_chart_rounded,
-        title: 'Explore your statistics',
-        subtitle:
-            'See a statistical breakdown of how, when, and where you have travelled.\n\nGet useful statistics on your most frequently visited stations, most frequently used operators, and how much of your country\'s railway network you have been on.',
+        title: loc.onboardingPage2Title,
+        subtitle: loc.onboardingPage2Subtitle,
         color: colorScheme.secondaryContainer,
         iconColor: colorScheme.secondary,
       ),
       _OnboardingPage(
         icon: Icons.share,
-        title: 'Share your travels',
-        subtitle:
-            'Create shareable links about your trips to share your travel plans with anyone.',
+        title: loc.onboardingPage3Title,
+        subtitle: loc.onboardingPage3Subtitle,
         color: colorScheme.tertiaryContainer,
         iconColor: colorScheme.tertiary,
       ),
       _OnboardingPage(
         icon: Icons.emoji_events,
-        title: 'Leaderboards',
-        subtitle:
-            'Are you a frequent traveller? See how your travels stack up against other members worldwide.',
+        title: loc.onboardingPage4Title,
+        subtitle: loc.onboardingPage4Subtitle,
         color: colorScheme.errorContainer,
         iconColor: colorScheme.error,
       ),
@@ -88,6 +86,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
               pageCount: _pageCount,
               onNext: _next,
               isLast: _currentPage == _pageCount - 1,
+              loc: AppLocalizations.of(context)!,
             ),
           ],
         ),
@@ -150,12 +149,14 @@ class _BottomControls extends StatelessWidget {
   final int pageCount;
   final VoidCallback onNext;
   final bool isLast;
+  final AppLocalizations loc;
 
   const _BottomControls({
     required this.currentPage,
     required this.pageCount,
     required this.onNext,
     required this.isLast,
+    required this.loc,
   });
 
   @override
@@ -193,7 +194,7 @@ class _BottomControls extends StatelessWidget {
               ),
             ),
             child: Text(
-              isLast ? 'Get started' : 'Next',
+              isLast ? loc.onboardingGetStarted : loc.nextButton,
               style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
             ),
           ),

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -26,6 +26,7 @@ class SettingsProvider with ChangeNotifier {
   String _userInstanceUrl = ""; // Cannot be changed in settings, only on welcome page before login, and only if not authenticated yet.
 
   // _SP members are stored in the Shared Preferences only, they cannot be modified by the user in settings
+  bool _SP_onboardingCompleted = false;
   LatLng? _SP_userPosition;
   bool _SP_refusedToSharePosition = false;
   String? _SP_authUsername;
@@ -65,6 +66,7 @@ class SettingsProvider with ChangeNotifier {
   int get sprRadius => _sprRadius;
   String get userInstanceUrl => _userInstanceUrl;
 
+  bool get onboardingCompleted => _SP_onboardingCompleted;
   LatLng? get userPosition => _SP_userPosition;
   bool get refusedToSharePosition => _SP_refusedToSharePosition;
   String? get authUsername => _SP_authUsername;
@@ -96,6 +98,7 @@ class SettingsProvider with ChangeNotifier {
     _loadUserInstanceUrl();
 
     // Shared Preference only (_SP) i.e. internal to the app
+    _loadOnboardingCompleted();
     _loadLastUserPosition();
     _loadRefusedToSharePosition();
     _loadUsername();
@@ -506,7 +509,23 @@ class SettingsProvider with ChangeNotifier {
   }
 
   // ------------------------------------------------------------------------------
-  
+
+  void _loadOnboardingCompleted() async {
+    final prefs = await SharedPreferences.getInstance();
+    _SP_onboardingCompleted = prefs.getBool('onboarding_completed') ?? false;
+    notifyListeners();
+  }
+
+  Future<void> completeOnboarding() async {
+    if (_SP_onboardingCompleted) return;
+    _SP_onboardingCompleted = true;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('onboarding_completed', true);
+    notifyListeners();
+  }
+
+  // ------------------------------------------------------------------------------
+
   void _loadMapPolylineFilterState() async {
     final prefs = await SharedPreferences.getInstance();
 


### PR DESCRIPTION
Add onboarding screen shown on first launch before login
Introduces a 4-page onboarding flow (map visualisation, statistics,
sharing, leaderboards) gated by a new `onboardingCompleted` flag
persisted in SharedPreferences. HomeGate now shows OnboardingScreen
until the flag is set, then falls through to the existing auth gate.