### PR TITLE
Fix use-after-dispose crash in SettingsVm.init()

### DIFF
--- a/lib/features/settings/settings_vm.dart
+++ b/lib/features/settings/settings_vm.dart
@@ -36,6 +36,14 @@ class SettingsVm extends ChangeNotifier {
   bool _isInitDone = false;
   bool get isInitDone => _isInitDone;
 
+  bool _disposed = false;
+
+  @override
+  void dispose() {
+    _disposed = true;
+    super.dispose();
+  }
+
   void refreshCacheSize() {
     totalCacheSize = AppCacheFilePath.computeAllCacheFileSize();
     debugPrint('Cache size refreshed: $totalCacheSize bytes');
@@ -55,6 +63,7 @@ class SettingsVm extends ChangeNotifier {
     refreshCacheSize();
 
     accountSettings = await trainlog.fetchAccountSettings();
+    if (_disposed) return;
 
     accountVisibility = accountSettings[accountSettingsKeyVisibility] != null
         ? int.tryParse(accountSettings[accountSettingsKeyVisibility]!)
@@ -68,10 +77,11 @@ class SettingsVm extends ChangeNotifier {
 
     if (trainlog.availableCurrencies.isEmpty) {
       await trainlog.reloadAvailableCurrencies();
+      if (_disposed) return;
     }
 
     _isInitDone = true;
-    notifyListeners(); // TODO check FlutterError (A SettingsVm was used after being disposed. Once you have called dispose() on a SettingsVm, it can no longer be used.)
+    notifyListeners();
   }
 
   String _visibilityHelperText(AppLocalizations l10n, int? v) {


### PR DESCRIPTION
The async init() method could call notifyListeners() on a disposed ChangeNotifier when the user navigated away (e.g. reset onboarding) while awaits were still pending. Added a _disposed flag checked after each await so init() exits cleanly instead of crashing.

https://claude.ai/code/session_013E4PWFMAy1DnkooQvH1HNJ