### PR TITLE
Add AdaptiveSegmentedButton and update four selector widgets

### DIFF
--- a/lib/platform/adaptive_segmented_button.dart
+++ b/lib/platform/adaptive_segmented_button.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:trainlog_app/utils/platform_utils.dart';
+
+class AdaptiveSegmentedButtonSegment<T extends Object> {
+  final T value;
+  final Widget? label;
+  final Widget? icon;
+
+  const AdaptiveSegmentedButtonSegment({
+    required this.value,
+    this.label,
+    this.icon,
+  });
+}
+
+class AdaptiveSegmentedButton {
+  static Widget build<T extends Object>({
+    required BuildContext context,
+    required List<AdaptiveSegmentedButtonSegment<T>> segments,
+    required T selectedValue,
+    required ValueChanged<T> onChanged,
+    bool showSelectedIcon = true,
+    ButtonStyle? style,
+  }) {
+    if (AppPlatform.isApple) {
+      return _cupertino<T>(
+        context: context,
+        segments: segments,
+        selectedValue: selectedValue,
+        onChanged: onChanged,
+      );
+    }
+    return _material<T>(
+      context: context,
+      segments: segments,
+      selectedValue: selectedValue,
+      onChanged: onChanged,
+      showSelectedIcon: showSelectedIcon,
+      style: style,
+    );
+  }
+
+  static Widget _cupertino<T extends Object>({
+    required BuildContext context,
+    required List<AdaptiveSegmentedButtonSegment<T>> segments,
+    required T selectedValue,
+    required ValueChanged<T> onChanged,
+  }) {
+    final children = <T, Widget>{
+      for (final seg in segments) seg.value: _cupertinoChild(seg),
+    };
+
+    return CupertinoSlidingSegmentedControl<T>(
+      children: children,
+      groupValue: selectedValue,
+      onValueChanged: (T? newValue) {
+        if (newValue != null) onChanged(newValue);
+      },
+    );
+  }
+
+  static Widget _cupertinoChild<T extends Object>(
+    AdaptiveSegmentedButtonSegment<T> seg,
+  ) {
+    if (seg.icon != null && seg.label != null) {
+      return Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 4),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            seg.icon!,
+            const SizedBox(width: 4),
+            seg.label!,
+          ],
+        ),
+      );
+    }
+    if (seg.icon != null) {
+      return Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 4),
+        child: seg.icon!,
+      );
+    }
+    if (seg.label != null) {
+      return Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 4),
+        child: seg.label!,
+      );
+    }
+    return const SizedBox.shrink();
+  }
+
+  static Widget _material<T extends Object>({
+    required BuildContext context,
+    required List<AdaptiveSegmentedButtonSegment<T>> segments,
+    required T selectedValue,
+    required ValueChanged<T> onChanged,
+    bool showSelectedIcon = true,
+    ButtonStyle? style,
+  }) {
+    return SegmentedButton<T>(
+      segments: segments
+          .map((seg) => ButtonSegment<T>(
+                value: seg.value,
+                label: seg.label,
+                icon: seg.icon,
+              ))
+          .toList(),
+      selected: {selectedValue},
+      onSelectionChanged: (Set<T> newSelection) {
+        onChanged(newSelection.first);
+      },
+      showSelectedIcon: showSelectedIcon,
+      style: style,
+    );
+  }
+}

--- a/lib/widgets/past_future_selector.dart
+++ b/lib/widgets/past_future_selector.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:trainlog_app/l10n/app_localizations.dart';
+import 'package:trainlog_app/platform/adaptive_segmented_button.dart';
 
 enum TimeMoment { past, future }
 
@@ -24,17 +25,24 @@ class _PastFutureSelectorState extends State<PastFutureSelector> {
 
   @override
   Widget build(BuildContext context) {
-    return SegmentedButton<TimeMoment>(
+    final loc = AppLocalizations.of(context)!;
+    return AdaptiveSegmentedButton.build<TimeMoment>(
+      context: context,
       segments: [
-          ButtonSegment(value: TimeMoment.past, label: Text(AppLocalizations.of(context)!.yearPastList), icon: Icon(Icons.restore)),
-          ButtonSegment(value: TimeMoment.future, label: Text(AppLocalizations.of(context)!.yearFutureList), icon: Icon(Icons.next_plan)),
-        ],
-      selected: <TimeMoment>{timeMomentView},
-      onSelectionChanged: (Set<TimeMoment> newSelection) {
-        final newValue = newSelection.first;
-        setState(() {
-          timeMomentView = newValue;
-        });
+        AdaptiveSegmentedButtonSegment(
+          value: TimeMoment.past,
+          label: Text(loc.yearPastList),
+          icon: const Icon(Icons.restore),
+        ),
+        AdaptiveSegmentedButtonSegment(
+          value: TimeMoment.future,
+          label: Text(loc.yearFutureList),
+          icon: const Icon(Icons.next_plan),
+        ),
+      ],
+      selectedValue: timeMomentView,
+      onChanged: (newValue) {
+        setState(() => timeMomentView = newValue);
         widget.onChanged?.call(newValue);
       },
     );

--- a/lib/widgets/statistics_type_selector.dart
+++ b/lib/widgets/statistics_type_selector.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:trainlog_app/platform/adaptive_segmented_button.dart';
 
 enum StatisticsType { bar, pie, table }
 
@@ -23,18 +24,16 @@ class _StatisticsTypeSelectorState extends State<StatisticsTypeSelector> {
 
   @override
   Widget build(BuildContext context) {
-    return SegmentedButton<StatisticsType>(
-      segments: [
-          ButtonSegment(value: StatisticsType.bar, icon: Icon(Icons.bar_chart)),
-          ButtonSegment(value: StatisticsType.pie, icon: Icon(Icons.pie_chart)),
-          ButtonSegment(value: StatisticsType.table, icon: Icon(Icons.table_chart)),
-        ],
-      selected: <StatisticsType>{statisticsType},
-      onSelectionChanged: (Set<StatisticsType> newSelection) {
-        final newValue = newSelection.first;
-        setState(() {
-          statisticsType = newValue;
-        });
+    return AdaptiveSegmentedButton.build<StatisticsType>(
+      context: context,
+      segments: const [
+        AdaptiveSegmentedButtonSegment(value: StatisticsType.bar, icon: Icon(Icons.bar_chart)),
+        AdaptiveSegmentedButtonSegment(value: StatisticsType.pie, icon: Icon(Icons.pie_chart)),
+        AdaptiveSegmentedButtonSegment(value: StatisticsType.table, icon: Icon(Icons.table_chart)),
+      ],
+      selectedValue: statisticsType,
+      onChanged: (newValue) {
+        setState(() => statisticsType = newValue);
         widget.onChanged?.call(newValue);
       },
     );

--- a/lib/widgets/trip_visibility_selector.dart
+++ b/lib/widgets/trip_visibility_selector.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:trainlog_app/l10n/app_localizations.dart';
+import 'package:trainlog_app/platform/adaptive_segmented_button.dart';
 import 'package:trainlog_app/utils/platform_utils.dart';
 
 enum TripVisibility {
@@ -62,28 +63,27 @@ class TripVisibilitySelector extends StatelessWidget {
   Widget build(BuildContext context) {
     final loc = AppLocalizations.of(context)!;
 
-    return SegmentedButton<TripVisibility>(
+    return AdaptiveSegmentedButton.build<TripVisibility>(
+      context: context,
       segments: [
-        ButtonSegment(
+        AdaptiveSegmentedButtonSegment(
           value: TripVisibility.public,
           label: Text(loc.visibilityPublic),
-          icon: const Icon(Icons.public),
+          icon: Icon(TripVisibility.public.icon()),
         ),
-        ButtonSegment(
+        AdaptiveSegmentedButtonSegment(
           value: TripVisibility.friends,
           label: Text(loc.visibilityFriends),
-          icon: const Icon(Icons.people),
+          icon: Icon(TripVisibility.friends.icon()),
         ),
-        ButtonSegment(
+        AdaptiveSegmentedButtonSegment(
           value: TripVisibility.private,
           label: Text(loc.visibilityPrivate),
-          icon: const Icon(Icons.lock),
+          icon: Icon(TripVisibility.private.icon()),
         ),
       ],
-      selected: {value},
-      onSelectionChanged: (newSelection) {
-        onChanged(newSelection.first);
-      },
+      selectedValue: value,
+      onChanged: onChanged,
       showSelectedIcon: false,
       style: const ButtonStyle(
         visualDensity: VisualDensity(horizontal: -2, vertical: -2),

--- a/lib/widgets/vehicle_energy_selector.dart
+++ b/lib/widgets/vehicle_energy_selector.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:trainlog_app/l10n/app_localizations.dart';
+import 'package:trainlog_app/platform/adaptive_segmented_button.dart';
 
 enum EnergyType { auto, electric, thermic }
 
@@ -17,28 +18,27 @@ class VehicleEnergySelector extends StatelessWidget {
   Widget build(BuildContext context) {
     final loc = AppLocalizations.of(context)!;
 
-    return SegmentedButton<EnergyType>(
+    return AdaptiveSegmentedButton.build<EnergyType>(
+      context: context,
       segments: [
-        ButtonSegment(
+        AdaptiveSegmentedButtonSegment(
           value: EnergyType.auto,
           label: Text(loc.auto),
           icon: const Icon(Icons.auto_awesome),
         ),
-        ButtonSegment(
+        AdaptiveSegmentedButtonSegment(
           value: EnergyType.electric,
           label: Text(loc.energyElectricShort),
           icon: const Icon(Icons.bolt),
         ),
-        ButtonSegment(
+        AdaptiveSegmentedButtonSegment(
           value: EnergyType.thermic,
           label: Text(loc.energyThermicShort),
           icon: const Icon(Icons.local_fire_department),
         ),
       ],
-      selected: {value},
-      onSelectionChanged: (newSelection) {
-        onChanged(newSelection.first);
-      },
+      selectedValue: value,
+      onChanged: onChanged,
       showSelectedIcon: false,
       style: const ButtonStyle(
         visualDensity: VisualDensity(horizontal: -2, vertical: -2),


### PR DESCRIPTION
Introduces AdaptiveSegmentedButton in the platform folder that renders Material's SegmentedButton on Android and CupertinoSlidingSegmentedControl on iOS. Updates PastFutureSelector, StatisticsTypeSelector, VehicleEnergySelector, and TripVisibilitySelector to use it, leaving Android behaviour unchanged.

https://claude.ai/code/session_01CekKwqfHxfW9qV7Y4rFAzZ