### PR TITLE
Claude/add trip button labels dyw ae

### DIFF
--- a/lib/features/trips/trips_page.dart
+++ b/lib/features/trips/trips_page.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -212,37 +213,30 @@ class _TripsPageState extends State<TripsPage> {
             ),
           ),
         const SizedBox(width: 8),
-        Material(
-          elevation: 4,
-          shape: const CircleBorder(),
-          color: Theme.of(context).colorScheme.primaryContainer,
-          child: IconButton(
-            onPressed: () async {
-              final operators = tripsProvider.operators;
-              final countries = await tripsProvider.getMapCountryCodesSafe(locale: locale);//mapCountryCodes;
-              final types = tripsProvider.vehicleTypes;
+        _AdaptiveFilterButton(
+          onPressed: () async {
+            final operators = tripsProvider.operators;
+            final countries = await tripsProvider.getMapCountryCodesSafe(locale: locale);
+            final types = tripsProvider.vehicleTypes;
 
-              if(!context.mounted) return;
-              final result = await showAdaptiveTripsFilterDialog(
-                context,
-                operatorOptions: operators,
-                countryOptions: countries,
-                typeOptions: types,
-                initialFilter: _activeFilter,
-              );
+            if (!context.mounted) return;
+            final result = await showAdaptiveTripsFilterDialog(
+              context,
+              operatorOptions: operators,
+              countryOptions: countries,
+              typeOptions: types,
+              initialFilter: _activeFilter,
+            );
 
-              if (result != null) {
-                setState(() {
-                  _activeFilter = result;
-                  _dataSource!.setFilter(result);
-                  _tableKey = UniqueKey();
-                });
-              }
-            },
-            icon: const Icon(Icons.filter_alt),
-            color: Theme.of(context).colorScheme.onPrimaryContainer,
-            tooltip: AppLocalizations.of(context)!.filterButton,
-          ),
+            if (result != null) {
+              setState(() {
+                _activeFilter = result;
+                _dataSource!.setFilter(result);
+                _tableKey = UniqueKey();
+              });
+            }
+          },
+          tooltip: AppLocalizations.of(context)!.filterButton,
         ),
       ],
     );
@@ -301,6 +295,7 @@ class _TripsPageState extends State<TripsPage> {
   }
 
   AppPrimaryAction _buildPrimaryAction(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
     return AppPrimaryAction(
       onPressed: () async {
         final didSave = await Navigator.of(context).push<bool>(
@@ -337,6 +332,7 @@ class _TripsPageState extends State<TripsPage> {
         }
       },
       icon: AdaptiveIcons.add,
+      label: loc.tripsAddButton,
     );
   }
 }
@@ -693,6 +689,39 @@ class _Badge extends StatelessWidget {
           fontSize: 11,
           fontWeight: FontWeight.bold,
         ),
+      ),
+    );
+  }
+}
+
+class _AdaptiveFilterButton extends StatelessWidget {
+  final VoidCallback onPressed;
+  final String tooltip;
+
+  const _AdaptiveFilterButton({
+    required this.onPressed,
+    required this.tooltip,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (AppPlatform.isApple) {
+      return CupertinoButton(
+        padding: EdgeInsets.zero,
+        onPressed: onPressed,
+        child: Icon(AdaptiveIcons.filter),
+      );
+    }
+
+    return Material(
+      elevation: 4,
+      shape: const CircleBorder(),
+      color: Theme.of(context).colorScheme.primaryContainer,
+      child: IconButton(
+        onPressed: onPressed,
+        icon: const Icon(Icons.filter_alt),
+        color: Theme.of(context).colorScheme.onPrimaryContainer,
+        tooltip: tooltip,
       ),
     );
   }

--- a/lib/features/trips/trips_page.dart
+++ b/lib/features/trips/trips_page.dart
@@ -709,7 +709,15 @@ class _AdaptiveFilterButton extends StatelessWidget {
       return CupertinoButton(
         padding: EdgeInsets.zero,
         onPressed: onPressed,
-        child: Icon(AdaptiveIcons.filter),
+        child: Container(
+          width: 36,
+          height: 36,
+          decoration: BoxDecoration(
+            color: CupertinoColors.systemFill.resolveFrom(context),
+            shape: BoxShape.circle,
+          ),
+          child: Icon(AdaptiveIcons.filter, size: 20),
+        ),
       );
     }
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -242,6 +242,7 @@
   "tripsFilterOperator": "Operator",
   "tripsFilterType": "Vehicle Type",
   "filterClearButton": "Clear filter",
+  "tripsAddButton": "New trip",
 
   "graphTypeOperator": "Operator",
   "graphTypeCountry": "Country",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -202,6 +202,7 @@
   "tripsFilterOperator": "Opérateur",
   "tripsFilterType": "Types de véhicule",
   "filterClearButton": "Supprimer les filtres",
+  "tripsAddButton": "Nouv. trajet",
 
   "graphTypeOperator": "Opérateur",
   "graphTypeCountry": "Pays",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -202,6 +202,7 @@
   "tripsFilterOperator": "事業者",
   "tripsFilterType": "乗り物のタイプ",
   "filterClearButton": "フィルターを消す",
+  "tripsAddButton": "旅行を追加",
 
   "graphTypeOperator": "事業者",
   "graphTypeCountry": "国",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1278,6 +1278,12 @@ abstract class AppLocalizations {
   /// **'Clear filter'**
   String get filterClearButton;
 
+  /// No description provided for @tripsAddButton.
+  ///
+  /// In en, this message translates to:
+  /// **'New trip'**
+  String get tripsAddButton;
+
   /// No description provided for @graphTypeOperator.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -626,6 +626,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get filterClearButton => 'Clear filter';
 
   @override
+  String get tripsAddButton => 'New trip';
+
+  @override
   String get graphTypeOperator => 'Operator';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -633,6 +633,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get filterClearButton => 'Supprimer les filtres';
 
   @override
+  String get tripsAddButton => 'Nouv. trajet';
+
+  @override
   String get graphTypeOperator => 'Opérateur';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -616,6 +616,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get filterClearButton => 'フィルターを消す';
 
   @override
+  String get tripsAddButton => '旅行を追加';
+
+  @override
   String get graphTypeOperator => '事業者';
 
   @override

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -626,6 +626,9 @@ class AppLocalizationsTl extends AppLocalizations {
   String get filterClearButton => 'Ibura ang filter';
 
   @override
+  String get tripsAddButton => 'Bag. biyahe';
+
+  @override
   String get graphTypeOperator => 'Operator';
 
   @override

--- a/lib/l10n/app_tl.arb
+++ b/lib/l10n/app_tl.arb
@@ -225,6 +225,7 @@
   "tripsFilterOperator": "Operator",
   "tripsFilterType": "Uri ng sasakyan",
   "filterClearButton": "Ibura ang filter",
+  "tripsAddButton": "Bag. biyahe",
   "graphTypeOperator": "Operator",
   "graphTypeCountry": "Bansa",
   "graphTypeYears": "Taon",


### PR DESCRIPTION
Add label to trips add button and make filter button iOS-adaptive
- Add tripsAddButton l10n key (EN: "New trip", FR: "Nouv. trajet", JA: "旅行を追加", TL: "Bag. biyahe")
- Pass label to AppPrimaryAction so the button renders as extended FAB on Material and as icon+text on Cupertino nav bar
- Extract filter button into _AdaptiveFilterButton: CupertinoButton on iOS, Material elevated circle on Android