### PR TITLE
Fix iOS statistics filter crash in bar chart touch handling

### DIFF
--- a/lib/widgets/logo_bar_chart.dart
+++ b/lib/widgets/logo_bar_chart.dart
@@ -174,7 +174,9 @@ class _LogoBarChartState extends State<LogoBarChart> {
           width: 20,
           rodStackItems: [
             BarChartRodStackItem(0, past, color),
-            if (future > 0) BarChartRodStackItem(past, total, _lighten(color)),
+            // Keep a second stack item even when `future == 0` to avoid
+            // fl_chart touch index mismatches while data is being filtered.
+            BarChartRodStackItem(past, total, _lighten(color)),
           ],
         ),
       ],


### PR DESCRIPTION
### Motivation
- Filtering the statistics chart in iOS/Cupertino mode could trigger a `RangeError` from `fl_chart` because some bar groups had one stack item while others had two, which led to an out-of-range stack index during pointer/touch updates.

### Description
- In `lib/widgets/logo_bar_chart.dart` the `_makeGroup` function now always includes a second `BarChartRodStackItem` (previously conditional on `future > 0`) and adds a brief comment explaining this avoids `fl_chart` touch-index mismatches when data is filtered.

### Testing
- Attempted to run `dart format lib/widgets/logo_bar_chart.dart` and `flutter analyze lib/widgets/logo_bar_chart.dart` but Dart/Flutter tooling was not available in this environment, so automated checks were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f44b3e130c8322aa81ccf8b25ac445)