### PR TITLE
Fix fl_chart touch index mismatches by always stacking and keying chart data

### DIFF
--- a/lib/widgets/logo_bar_chart.dart
+++ b/lib/widgets/logo_bar_chart.dart
@@ -174,7 +174,9 @@ class _LogoBarChartState extends State<LogoBarChart> {
           width: 20,
           rodStackItems: [
             BarChartRodStackItem(0, past, color),
-            if (future > 0) BarChartRodStackItem(past, total, _lighten(color)),
+            // Keep a second stack item even when `future == 0` to avoid
+            // fl_chart touch index mismatches while data is being filtered.
+            BarChartRodStackItem(past, total, _lighten(color)),
           ],
         ),
       ],
@@ -286,7 +288,13 @@ class _LogoBarChartState extends State<LogoBarChart> {
     final colors = widget.colors ??
         List.generate(n, (i) => widget.color ?? Colors.blue);
 
+    final chartDataKey = ValueKey<String>(
+      '${widget.rotationQuarterTurns}|${_titles.join('¦')}|'
+      '${_pastScaled.join(',')}|${_futureScaled.join(',')}',
+    );
+
     return BarChart(
+      key: chartDataKey,
       BarChartData(
         rotationQuarterTurns: widget.rotationQuarterTurns,
         minY: 0,


### PR DESCRIPTION
### Motivation
- Prevent touch index mismatches in `fl_chart` when filtering or updating series where a bar stack item can disappear.  
- Ensure the `BarChart` widget rebuilds deterministically when rotation, titles, or scaled data change so touch/tooltip state stays consistent.  

### Description
- Always emit a second `BarChartRodStackItem` in `_makeGroup` (even when `future == 0`) to avoid occasional touch-index mismatches while data is being filtered.  
- Add a `ValueKey` (`chartDataKey`) to the `BarChart` that is derived from `rotationQuarterTurns`, `_titles`, `_pastScaled`, and `_futureScaled` so the chart is replaced when its underlying layout/data changes.  
- Add a clarifying comment explaining why the second stack item is kept even for zero `future` values.  

### Testing
- Ran `flutter analyze` locally and fixed no new analyzer issues.  
- Ran `flutter test` (project test suite) and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f44b3e130c8322aa81ccf8b25ac445)