### PR TITLE
Claude/adaptive button trip page fqul5

### DIFF
--- a/lib/features/trips/add_trip_page.dart
+++ b/lib/features/trips/add_trip_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:trainlog_app/platform/adaptive_button.dart';
 import 'package:step_progress/step_progress.dart';
 import 'package:lottie/lottie.dart';
 import 'package:trainlog_app/data/controllers/trainlog_web_controller.dart';
@@ -261,94 +262,68 @@ class _AddTripPageState extends State<AddTripPage> {
     return newModel;
   }
 
-  Widget _bottomButtonHelper(bool isLastStep)
-  {
+  Widget _bottomButtonHelper(bool isLastStep) {
     final loc = AppLocalizations.of(context)!;
 
-    if(isLastStep)
-    {
+    if (isLastStep) {
       return Column(
         children: [
           SizedBox(
             width: double.infinity,
-            child: ElevatedButton.icon(
-              icon: Icon(Icons.check, size: 24,),
+            child: AdaptiveButton.build(
+              context: context,
+              icon: Icons.check,
               label: Text(
                 loc.validateButton,
                 style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
               ),
               onPressed: (_isRouterLoading || _hasRoutingError) ? null : _validateTrip,
-              style: ElevatedButton.styleFrom(
-                backgroundColor: Theme.of(context).colorScheme.primary,
-                foregroundColor: Theme.of(context).colorScheme.onPrimary,
-                padding: const EdgeInsets.symmetric(vertical: 18),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(28),
-                ),
-                elevation: 3,
-              ),
+              type: AdaptiveButtonType.primary,
+              padding: const EdgeInsets.symmetric(vertical: 18),
+              borderRadius: BorderRadius.circular(28),
+              elevation: 3,
             ),
           ),
-          SizedBox(height: 8,),
+          const SizedBox(height: 8),
           SizedBox(
             width: double.infinity,
-            child: ElevatedButton(
+            child: AdaptiveButton.build(
+              context: context,
+              icon: Icons.subdirectory_arrow_right,
+              label: Text(
+                loc.continueTripButton,
+                textAlign: TextAlign.center,
+                softWrap: true,
+                maxLines: 2,
+                overflow: TextOverflow.visible,
+                style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+              ),
               onPressed: (_isRouterLoading || _hasRoutingError)
-                ? null
-                : () => _validateTrip(continueTrip: true),
-              style: ElevatedButton.styleFrom(
-                backgroundColor: Theme.of(context).colorScheme.secondary,
-                foregroundColor: Theme.of(context).colorScheme.onSecondary,
-                padding: const EdgeInsets.symmetric(vertical: 18, horizontal: 16),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(28),
-                ),
-                elevation: 3,
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  const Icon(Icons.subdirectory_arrow_right, size: 24),
-                  const SizedBox(width: 8),
-                  Flexible(
-                    child: Text(
-                      loc.continueTripButton,
-                      textAlign: TextAlign.center,
-                      softWrap: true,
-                      maxLines: 2,
-                      overflow: TextOverflow.visible,
-                      style: const TextStyle(
-                        fontSize: 16,
-                        fontWeight: FontWeight.w600,
-                      ),
-                    ),
-                  ),
-                ],
-              ),
+                  ? null
+                  : () => _validateTrip(continueTrip: true),
+              type: AdaptiveButtonType.secondary,
+              padding: const EdgeInsets.symmetric(vertical: 18, horizontal: 16),
+              borderRadius: BorderRadius.circular(28),
+              elevation: 3,
             ),
-          )
+          ),
         ],
       );
-    }
-    else{
-      return ElevatedButton.icon(
-        icon: Icon(Icons.arrow_forward, size: 24,),
+    } else {
+      return AdaptiveButton.build(
+        context: context,
+        icon: Icons.arrow_forward,
         label: Text(
           loc.nextButton,
           style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
         ),
         onPressed: _nextStep,
-        style: ElevatedButton.styleFrom(
-          backgroundColor: Theme.of(context).colorScheme.secondaryContainer,
-          foregroundColor: Theme.of(context).colorScheme.onSecondaryContainer,
-          padding: const EdgeInsets.symmetric(vertical: 18),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(28),
-          ),
-          elevation: 3,
-        ),
+        type: AdaptiveButtonType.secondaryContainer,
+        padding: const EdgeInsets.symmetric(vertical: 18),
+        borderRadius: BorderRadius.circular(28),
+        elevation: 3,
       );
-    }    
+    }
   }
 
   Future<bool?> _showExitConfirmationDialog(BuildContext context) {

--- a/lib/features/trips/add_trip_page.dart
+++ b/lib/features/trips/add_trip_page.dart
@@ -15,6 +15,7 @@ import 'package:trainlog_app/features/trips/trip_form_path.dart';
 import 'package:trainlog_app/providers/trips_provider.dart';
 import 'package:trainlog_app/utils/date_utils.dart';
 import 'package:trainlog_app/data/models/trips.dart';
+import 'package:trainlog_app/utils/platform_utils.dart';
 
 class AddTripPage extends StatefulWidget {
   final List<int>? preRecorderIdsToDelete;
@@ -280,7 +281,7 @@ class _AddTripPageState extends State<AddTripPage> {
               onPressed: (_isRouterLoading || _hasRoutingError) ? null : _validateTrip,
               type: AdaptiveButtonType.primary,
               padding: const EdgeInsets.symmetric(vertical: 18),
-              borderRadius: BorderRadius.circular(28),
+              borderRadius: AppPlatform.isApple ? null : BorderRadius.circular(28),
               elevation: 3,
             ),
           ),
@@ -303,7 +304,7 @@ class _AddTripPageState extends State<AddTripPage> {
                   : () => _validateTrip(continueTrip: true),
               type: AdaptiveButtonType.secondary,
               padding: const EdgeInsets.symmetric(vertical: 18, horizontal: 16),
-              borderRadius: BorderRadius.circular(28),
+              borderRadius: AppPlatform.isApple ? null : BorderRadius.circular(28),
               elevation: 3,
             ),
           ),
@@ -320,7 +321,7 @@ class _AddTripPageState extends State<AddTripPage> {
         onPressed: _nextStep,
         type: AdaptiveButtonType.secondaryContainer,
         padding: const EdgeInsets.symmetric(vertical: 18),
-        borderRadius: BorderRadius.circular(28),
+        borderRadius: AppPlatform.isApple ? null : BorderRadius.circular(28),
         elevation: 3,
       );
     }

--- a/lib/platform/adaptive_button.dart
+++ b/lib/platform/adaptive_button.dart
@@ -46,9 +46,9 @@ class AdaptiveButton {
       padding: padding,
       minimumSize: minimumSize,
       elevation: elevation ?? (type == AdaptiveButtonType.destructive ? 1 : null),
-      // shape: RoundedRectangleBorder(
-      //   borderRadius: borderRadius ?? BorderRadius.circular(8),
-      // ),
+      shape: borderRadius != null
+          ? RoundedRectangleBorder(borderRadius: borderRadius)
+          : null,
     );
 
     final Widget? effectiveIcon = iconWidget ?? (icon != null ? Icon(icon) : null);


### PR DESCRIPTION
Replace ElevatedButton/ElevatedButton.icon calls in _bottomButtonHelper with AdaptiveButton.build so iOS renders CupertinoButton.filled while Material keeps the existing elevated style with rounded corners.

Also enable the borderRadius shape in AdaptiveButton._materialButton so the rounded corners are preserved when a borderRadius is passed.