### PR TITLE
Claude/fix back button behavior g78 ku

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -537,5 +537,7 @@
   "onboardingPage3Title": "Share your travels",
   "onboardingPage3Subtitle": "Create shareable links about your trips to share your travel plans with anyone.",
   "onboardingPage4Title": "Leaderboards",
-  "onboardingPage4Subtitle": "Are you a frequent traveller? See how your travels stack up against other members worldwide."
+  "onboardingPage4Subtitle": "Are you a frequent traveller? See how your travels stack up against other members worldwide.",
+
+  "tapAgainToExit": "Tap again to exit"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -349,5 +349,7 @@
   "onboardingPage3Title": "Partagez vos voyages",
   "onboardingPage3Subtitle": "Créez des liens partageables pour vos trajets et communiquez vos projets de voyage à qui vous voulez.",
   "onboardingPage4Title": "Classements",
-  "onboardingPage4Subtitle": "Êtes-vous un grand voyageur ? Comparez vos voyages avec ceux des autres membres du monde entier."
+  "onboardingPage4Subtitle": "Êtes-vous un grand voyageur ? Comparez vos voyages avec ceux des autres membres du monde entier.",
+
+  "tapAgainToExit": "Appuyez à nouveau pour quitter"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -351,5 +351,7 @@
   "onboardingPage3Title": "旅をシェア",
   "onboardingPage3Subtitle": "旅のリンクを作成して、移動の計画を誰とでも共有できます。",
   "onboardingPage4Title": "リーダーボード",
-  "onboardingPage4Subtitle": "よく旅をするあなたへ。世界中のメンバーと旅の記録を比べてみましょう。"
+  "onboardingPage4Subtitle": "よく旅をするあなたへ。世界中のメンバーと旅の記録を比べてみましょう。",
+
+  "tapAgainToExit": "もう一度タップすると終了します"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2093,6 +2093,10 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Are you a frequent traveller? See how your travels stack up against other members worldwide.'**
   String get onboardingPage4Subtitle;
+
+  /// In en, this message translates to:
+  /// **'Tap again to exit'**
+  String get tapAgainToExit;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2094,6 +2094,8 @@ abstract class AppLocalizations {
   /// **'Are you a frequent traveller? See how your travels stack up against other members worldwide.'**
   String get onboardingPage4Subtitle;
 
+  /// No description provided for @tapAgainToExit.
+  ///
   /// In en, this message translates to:
   /// **'Tap again to exit'**
   String get tapAgainToExit;

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1201,4 +1201,7 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get onboardingPage4Subtitle =>
       'Are you a frequent traveller? See how your travels stack up against other members worldwide.';
+
+  @override
+  String get tapAgainToExit => 'Tap again to exit';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1209,4 +1209,7 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get onboardingPage4Subtitle =>
       'Êtes-vous un grand voyageur ? Comparez vos voyages avec ceux des autres membres du monde entier.';
+
+  @override
+  String get tapAgainToExit => 'Appuyez à nouveau pour quitter';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1183,4 +1183,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get onboardingPage4Subtitle => 'よく旅をするあなたへ。世界中のメンバーと旅の記録を比べてみましょう。';
+
+  @override
+  String get tapAgainToExit => 'もう一度タップすると終了します';
 }

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -1185,4 +1185,7 @@ class AppLocalizationsTl extends AppLocalizations {
   @override
   String get onboardingPage4Subtitle =>
       'Ikaw ba ay madalas maglakbay? Tingnan kung paano ang iyong mga paglalakbay kumpara sa ibang mga miyembro sa buong mundo.';
+
+  @override
+  String get tapAgainToExit => 'I-tap muli para lumabas';
 }

--- a/lib/l10n/app_tl.arb
+++ b/lib/l10n/app_tl.arb
@@ -516,5 +516,7 @@
   "onboardingPage3Title": "Ibahagi ang iyong mga paglalakbay",
   "onboardingPage3Subtitle": "Gumawa ng mga link na maaaring ibahagi para sa iyong mga biyahe upang ibahagi ang iyong mga plano sa paglalakbay sa sinuman.",
   "onboardingPage4Title": "Mga Leaderboard",
-  "onboardingPage4Subtitle": "Ikaw ba ay madalas maglakbay? Tingnan kung paano ang iyong mga paglalakbay kumpara sa ibang mga miyembro sa buong mundo."
+  "onboardingPage4Subtitle": "Ikaw ba ay madalas maglakbay? Tingnan kung paano ang iyong mga paglalakbay kumpara sa ibang mga miyembro sa buong mundo.",
+
+  "tapAgainToExit": "I-tap muli para lumabas"
 }

--- a/lib/navigation/material_shell.dart
+++ b/lib/navigation/material_shell.dart
@@ -104,6 +104,8 @@ class MaterialShell extends StatefulWidget {
 }
 
 class _MaterialShellState extends State<MaterialShell> {
+  final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
+
   late final PageController _pageController;
 
   int _selectedIndex = 0;
@@ -253,8 +255,22 @@ class _MaterialShellState extends State<MaterialShell> {
   Widget build(BuildContext context) {
     final currentPage = _pages[_selectedIndex];
 
-    return SafeArea(
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, _) {
+        if (didPop) return;
+        if (_scaffoldKey.currentState?.isDrawerOpen == true) {
+          _scaffoldKey.currentState!.closeDrawer();
+          return;
+        }
+        if (_isDrawerPage) {
+          _goBackToBottomNavPage();
+        }
+        // On bottom-tab pages: absorb the back press so the app stays open.
+      },
+      child: SafeArea(
       child: Scaffold(
+        key: _scaffoldKey,
         appBar: _isDrawerPage
             ? AdaptiveAppBar(
                 title: currentPage.titleBuilder(context),
@@ -354,6 +370,7 @@ class _MaterialShellState extends State<MaterialShell> {
                     ),
                 ],
               ),
+      ),
       ),
     );
   }

--- a/lib/navigation/material_shell.dart
+++ b/lib/navigation/material_shell.dart
@@ -1,5 +1,6 @@
 // material_shell.dart
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:trainlog_app/l10n/app_localizations.dart';
 import 'package:trainlog_app/navigation/nav_models.dart';
 import 'package:trainlog_app/features/settings/settings_material_page.dart';
@@ -110,6 +111,8 @@ class _MaterialShellState extends State<MaterialShell> {
 
   int _selectedIndex = 0;
   int _previousBottomIndex = 0;
+
+  DateTime? _lastBackPress;
 
   late final List<AppPage> _pages;
 
@@ -265,8 +268,21 @@ class _MaterialShellState extends State<MaterialShell> {
         }
         if (_isDrawerPage) {
           _goBackToBottomNavPage();
+          return;
         }
-        // On bottom-tab pages: absorb the back press so the app stays open.
+        // Bottom-tab page: require a second back press within 2 s to exit.
+        final now = DateTime.now();
+        if (_lastBackPress != null && now.difference(_lastBackPress!) < const Duration(seconds: 2)) {
+          SystemNavigator.pop();
+          return;
+        }
+        _lastBackPress = now;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(AppLocalizations.of(context)!.tapAgainToExit),
+            duration: const Duration(seconds: 2),
+          ),
+        );
       },
       child: SafeArea(
       child: Scaffold(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: trainlog_app
 description: "Your online travel diary"
 publish_to: 'none'
-version: 0.1.1+6
+version: 0.1.2+7
 
 environment:
   sdk: ^3.8.0


### PR DESCRIPTION
Fix Android back button closing the app instead of navigating back
Wrap MaterialShell's Scaffold in a PopScope so the hardware back button:
- closes the drawer when it's open
- returns to the previous bottom-tab page when on a drawer page

On main (bottom-tab) pages, the first back press now shows a localised
"Tap again to exit" snackbar. A second press within 2 seconds exits the app
via SystemNavigator.pop(). Translations added for EN, FR, JA, and TL.