### PR TITLE
Claude/fix map interactions io e8z

### DIFF
--- a/lib/features/map/map_page.dart
+++ b/lib/features/map/map_page.dart
@@ -244,6 +244,7 @@ class _MapPageState extends State<MapPage> with WidgetsBindingObserver, Automati
             keepAlive: true,
             interactionOptions: const InteractionOptions(
               rotationThreshold: 20.0,
+              enableMultiFingerGestureRace: true,
             ),
             onPositionChanged: (pos, hasGesture) {
               _center = pos.center;

--- a/lib/features/map/map_page.dart
+++ b/lib/features/map/map_page.dart
@@ -242,6 +242,9 @@ class _MapPageState extends State<MapPage> with WidgetsBindingObserver, Automati
             initialCenter: _center,
             initialZoom: _zoom,
             keepAlive: true,
+            interactionOptions: const InteractionOptions(
+              rotationThreshold: 20.0,
+            ),
             onPositionChanged: (pos, hasGesture) {
               _center = pos.center;
               _zoom = pos.zoom;

--- a/lib/widgets/rendered_polyline_layer.dart
+++ b/lib/widgets/rendered_polyline_layer.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:provider/provider.dart';
@@ -18,9 +20,11 @@ class RenderedPolylineLayer extends StatefulWidget {
 
 class _RenderedPolylineLayerState extends State<RenderedPolylineLayer> {
   final LayerHitNotifier<int> _hitNotifier = ValueNotifier(null);
+  Timer? _singleTapTimer;
 
   @override
   void dispose() {
+    _singleTapTimer?.cancel();
     _hitNotifier.dispose();
     super.dispose();
   }
@@ -35,15 +39,18 @@ class _RenderedPolylineLayerState extends State<RenderedPolylineLayer> {
       shouldRebuild: (prev, next) => prev.revision != next.revision,
       builder: (context, data, child) {
         return GestureDetector(
-          onTapUp: (_) async {
+          onTapUp: (_) {
             final result = _hitNotifier.value;
             if (result == null) return;
+            final hit = result.hitValues.firstOrNull;
+            if (hit == null) return;
 
-            for (final hit in result.hitValues) {
+            _singleTapTimer?.cancel();
+            _singleTapTimer = Timer(const Duration(milliseconds: 300), () async {
               await widget.onTripTap(hit);
-              break;
-            }
+            });
           },
+          onDoubleTap: () => _singleTapTimer?.cancel(),
           child: PolylineLayer<int>(
             hitNotifier: _hitNotifier,
             polylines: data.polylines,

--- a/lib/widgets/rendered_polyline_layer.dart
+++ b/lib/widgets/rendered_polyline_layer.dart
@@ -46,7 +46,7 @@ class _RenderedPolylineLayerState extends State<RenderedPolylineLayer> {
             if (hit == null) return;
 
             _singleTapTimer?.cancel();
-            _singleTapTimer = Timer(const Duration(milliseconds: 300), () async {
+            _singleTapTimer = Timer(const Duration(milliseconds: 150), () async {
               await widget.onTripTap(hit);
             });
           },


### PR DESCRIPTION
fix: add rotation deadzone and prevent double-tap from opening trip sheet
- Add rotationThreshold: 20.0 to InteractionOptions to require intentional rotation gesture before the map rotates, avoiding accidental rotation during pinch-zoom
- Debounce polyline tap with 150 ms timer so double-tap zoom cancels the pending single-tap action and the trip bottom sheet only opens on deliberate single taps