### PR TITLE
Suppress OSM tile network errors from Crashlytics

### DIFF
--- a/lib/features/map/map_page.dart
+++ b/lib/features/map/map_page.dart
@@ -256,6 +256,7 @@ class _MapPageState extends State<MapPage> with WidgetsBindingObserver, Automati
             TileLayer(
               urlTemplate: "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
               userAgentPackageName: 'me.trainlog.app',
+              errorTileCallback: (tile, error, stackTrace) {},
             ),
             RenderedPolylineLayer(
               onTripTap: (tripId) async {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,6 +14,12 @@ import 'package:trainlog_app/utils/cached_data_utils.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'firebase_options.dart';
 
+bool _isOsmTileNetworkError(Object error) {
+  final msg = error.toString();
+  return msg.contains('tile.openstreetmap.org') &&
+      (msg.contains('SocketException') || msg.contains('ClientException'));
+}
+
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
@@ -24,10 +30,12 @@ Future<void> main() async {
 
   // Pass all uncaught "fatal" errors from the framework to Crashlytics
   FlutterError.onError = (errorDetails) {
+    if (_isOsmTileNetworkError(errorDetails.exception)) return;
     FirebaseCrashlytics.instance.recordFlutterFatalError(errorDetails);
   };
   // Pass all uncaught asynchronous errors that aren't handled by the Flutter framework to Crashlytics
   PlatformDispatcher.instance.onError = (error, stack) {
+    if (_isOsmTileNetworkError(error)) return true;
     FirebaseCrashlytics.instance.recordError(error, stack, fatal: true);
     return true;
   };

--- a/lib/widgets/mini_map_box.dart
+++ b/lib/widgets/mini_map_box.dart
@@ -176,6 +176,7 @@ class _MiniMapBoxState extends State<MiniMapBox> {
         TileLayer(
           urlTemplate: "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
           userAgentPackageName: 'me.trainlog.app',
+          errorTileCallback: (tile, error, stackTrace) {},
         ),
 
         // Normal pin only when not movable
@@ -287,6 +288,7 @@ class _FullscreenMapOverlayState extends State<FullscreenMapOverlay> {
                 urlTemplate:
                     "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
                 userAgentPackageName: 'me.trainlog.app',
+                errorTileCallback: (tile, error, stackTrace) {},
               ),
 
               if (!widget.isCoordinateMovable)


### PR DESCRIPTION
## Summary
This PR suppresses OpenStreetMap tile network errors from being reported to Firebase Crashlytics, as these are expected transient failures that don't represent actual application errors.

## Key Changes
- Added `_isOsmTileNetworkError()` helper function to detect OSM tile network failures (SocketException and ClientException from tile.openstreetmap.org)
- Updated Crashlytics error handlers to skip reporting OSM tile network errors:
  - `FlutterError.onError` handler in main.dart
  - `PlatformDispatcher.instance.onError` handler in main.dart
- Added empty `errorTileCallback` handlers to all TileLayer instances to prevent unhandled errors:
  - MiniMapBox widget (2 instances)
  - FullscreenMapOverlay widget
  - MapPage widget

## Implementation Details
The solution uses two complementary approaches:
1. **Error filtering at the framework level**: Prevents OSM tile errors from reaching Crashlytics by checking the error message for OSM tile URLs and network-related exceptions
2. **Error suppression at the tile layer level**: Provides empty error callbacks to TileLayer widgets to gracefully handle tile loading failures without propagating them as unhandled errors

This reduces noise in Crashlytics while maintaining proper error reporting for actual application issues.

https://claude.ai/code/session_01FeB2RuHzdrv51WXYLVuhjm