### PR TITLE
Add polyline integrity check to detect and recover missing entries

### DIFF
--- a/lib/data/trips_repository.dart
+++ b/lib/data/trips_repository.dart
@@ -245,6 +245,50 @@ class TripsRepository {
     return maps.map((m) => m['path'] as String).toList();
   }
 
+  /// Returns all trip UIDs that have a non-empty path stored in the DB.
+  /// Used to verify that the loaded polyline list is complete.
+  Future<List<String>> getTripIdsWithPath() async {
+    final maps = await _db.query(
+      TripsTable.tableName,
+      columns: ['uid'],
+      where: 'path IS NOT NULL AND path != ""',
+    );
+    return maps.map((m) => m['uid'] as String).toList();
+  }
+
+  /// Returns path-related data only for the trips identified by [ids].
+  /// Used to recover polylines that were missing from a previous load.
+  Future<List<Map<String, dynamic>>> getPathExtendedDataForIds(List<String> ids) async {
+    if (ids.isEmpty) return [];
+
+    final placeholders = List.filled(ids.length, '?').join(',');
+    final maps = await _db.query(
+      TripsTable.tableName,
+      columns: [
+        'uid',
+        'path',
+        'type',
+        'origin_station',
+        'destination_station',
+        'start_datetime',
+        'end_datetime',
+        'utc_start_datetime',
+        'utc_end_datetime',
+        'created',
+      ],
+      where: 'uid IN ($placeholders) AND path IS NOT NULL AND path != ""',
+      whereArgs: ids,
+    );
+
+    return maps.map((e) {
+      final typeEnum = VehicleType.fromString(e['type']?.toString());
+      return {
+        ...e,
+        'type': typeEnum,
+      };
+    }).toList();
+  }
+
   Future<List<Map<String, dynamic>>> getPathExtendedData([
     PathDisplayOrder order = PathDisplayOrder.creationDate,
   ]) async {

--- a/lib/providers/polyline_provider.dart
+++ b/lib/providers/polyline_provider.dart
@@ -383,6 +383,10 @@ class PolylineProvider extends ChangeNotifier {
           _isLoading = false;
           _scheduleNextFlip();
           notifyListeners();
+
+          // Run integrity check asynchronously: the cache may be stale or
+          // incomplete if a trip was added/updated without flushing the cache.
+          unawaited(_checkAndFixMissingPolylines(myToken));
           return;
         } catch (e) {
           debugPrint('Polyline cache read failed: $e');
@@ -435,12 +439,115 @@ class PolylineProvider extends ChangeNotifier {
       if (styled.isNotEmpty) {
         unawaited(_writeCache(styled));
       }
+
+      // Even after a DB load, some entries may have been silently dropped due
+      // to decode errors.  Verify completeness and patch any gaps.
+      unawaited(_checkAndFixMissingPolylines(myToken));
     } catch (e) {
       if (myToken != _loadToken) return;
 
       _isLoading = false;
       _error = e;
       notifyListeners();
+    }
+  }
+
+  // ============================================================================
+  // Polyline integrity check
+  // ============================================================================
+  //
+  // In rare cases a trip with a path in the DB may not have a corresponding
+  // PolylineEntry in [_polylines] — e.g. after loading from a stale file cache,
+  // after a silent decode error, or when an incremental trip refresh only
+  // updated a subset of trips.
+  //
+  // This method compares the set of trip IDs that have a path in the DB with
+  // the set of IDs currently loaded in [_polylines].  Any mismatch is repaired
+  // by fetching and decoding only the missing entries.
+  //
+  // The [loadToken] argument prevents stale results from being applied if a
+  // newer reload starts while this check is still in progress.
+  // ============================================================================
+
+  Future<void> _checkAndFixMissingPolylines(int loadToken) async {
+    final trips = _trips;
+    final settings = _settings;
+    if (trips == null || settings == null) return;
+
+    final repo = trips.repository;
+    if (repo == null) return;
+
+    try {
+      // Fetch all trip IDs that have a non-empty path in the DB.
+      final dbIds = (await repo.getTripIdsWithPath())
+          .map((id) => int.tryParse(id))
+          .whereType<int>()
+          .toSet();
+
+      // Bail out if another reload has started in the meantime.
+      if (_loadToken != loadToken) return;
+
+      final loadedIds = _polylines.map((e) => e.tripId).toSet();
+      final missingIds = dbIds.difference(loadedIds);
+
+      if (missingIds.isEmpty) return;
+
+      debugPrint(
+        '⚠️ Polyline integrity: ${missingIds.length} trip(s) have a path in the DB '
+        'but no polyline loaded — recovering...',
+      );
+
+      // Fetch path data only for the missing trips.
+      final pathData = await repo.getPathExtendedDataForIds(
+        missingIds.map((id) => id.toString()).toList(),
+      );
+
+      if (pathData.isEmpty) return;
+      if (_loadToken != loadToken) return; // Check again after the async gap.
+
+      // Build isolate-friendly structures.
+      final palette = MapColorPaletteHelper.getPalette(settings.mapColorPalette);
+      final colors = <String, int>{};
+      for (final type in VehicleType.values) {
+        colors[type.name] = (palette[type] ?? Colors.black).toARGB32();
+      }
+
+      final entries = pathData.map<Map<String, dynamic>>((raw) {
+        final m = Map<String, dynamic>.from(raw);
+        final typeVal = m['type'];
+        m['type'] = typeVal is VehicleType ? typeVal.name : (typeVal?.toString() ?? '');
+        return m;
+      }).toList();
+
+      final decoded = await compute(
+        PolylineTools.decodePolylinesBatchIsolateFriendly,
+        {'entries': entries, 'colors': colors},
+      );
+
+      if (_loadToken != loadToken) return; // Check after the heavy compute step.
+
+      final styled = _restyleAll(decoded, palette);
+
+      for (final entry in styled) {
+        final index = _polylines.indexWhere((e) => e.tripId == entry.tripId);
+        if (index >= 0) {
+          _polylines[index] = entry;
+        } else {
+          _polylines.add(entry);
+        }
+      }
+
+      debugPrint('✅ Polyline integrity: recovered ${styled.length} missing polyline(s)');
+
+      _reconcileFiltersWithTrips();
+      _rebuildRenderedPolylines(notify: true);
+
+      // Flush the now-complete polyline list to the cache.
+      if (_polylines.isNotEmpty) {
+        unawaited(_writeCache(_polylines));
+      }
+    } catch (e) {
+      debugPrint('⚠️ Polyline integrity check failed: $e');
     }
   }
 
@@ -850,6 +957,11 @@ class PolylineProvider extends ChangeNotifier {
 
     upsertPolylinesFromTrips(partialUpdate);
     _lastTripsPolylineRevision = trips.polylineRevision;
+
+    // An incremental refresh only updates modified trips, so a polyline that
+    // was missing before the refresh will still be absent.  Run the integrity
+    // check to catch and recover any such gaps.
+    unawaited(_checkAndFixMissingPolylines(_loadToken));
   }
 
   void _onSettingsChanged() {


### PR DESCRIPTION
## Summary
This PR adds a polyline integrity verification system to detect and recover missing polyline entries that may occur due to stale cache files, silent decode errors, or incomplete incremental trip updates.

## Key Changes
- **New integrity check method** (`_checkAndFixMissingPolylines`): Compares trip IDs with paths in the database against currently loaded polylines, identifies gaps, and recovers missing entries by fetching and decoding only the missing data
- **Automatic integrity checks** triggered at three points:
  - After loading polylines from cache (to handle stale/incomplete cache files)
  - After loading polylines from the database (to catch silent decode errors)
  - After incremental trip updates (to recover polylines from newly added/modified trips)
- **New repository methods**:
  - `getTripIdsWithPath()`: Queries all trip UIDs that have a non-empty path in the database
  - `getPathExtendedDataForIds()`: Fetches path-related data only for specified trip IDs
- **Load token validation**: Uses existing `_loadToken` mechanism to prevent stale results from being applied if a newer reload starts during the integrity check

## Notable Implementation Details
- The integrity check runs asynchronously without blocking the UI (using `unawaited()`)
- Includes multiple load token checks at async boundaries to prevent race conditions
- Reuses existing polyline decoding infrastructure (`PolylineTools.decodePolylinesBatchIsolateFriendly`) and styling logic (`_restyleAll`)
- Updates the cache with recovered polylines to prevent repeated recovery attempts
- Includes debug logging to track recovery operations and diagnose issues

https://claude.ai/code/session_01Bn7Kxeo81mQxdbasynjQaQ