### PR TITLE
Use device language for default locale when no preference saved

### DIFF
--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -3,6 +3,7 @@ import 'package:geodesy/geodesy.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:trainlog_app/data/models/polyline_filter_state.dart';
 import 'package:trainlog_app/data/models/trips.dart';
+import 'package:trainlog_app/l10n/app_localizations.dart';
 import 'package:trainlog_app/providers/trainlog_provider.dart';
 import 'package:trainlog_app/providers/trips_provider.dart';
 import 'package:trainlog_app/utils/map_color_palette.dart';
@@ -149,7 +150,9 @@ class SettingsProvider with ChangeNotifier {
     } else {
       // No saved preference: use the phone's language if the app supports it,
       // otherwise fall back to English.
-      const supportedLanguageCodes = ['en', 'fr', 'ja', 'tl'];
+      final supportedLanguageCodes = AppLocalizations.supportedLocales
+          .map((locale) => locale.languageCode)
+          .toSet();
       final deviceLanguageCode =
           WidgetsBinding.instance.platformDispatcher.locale.languageCode;
       if (supportedLanguageCodes.contains(deviceLanguageCode)) {

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -147,7 +147,16 @@ class SettingsProvider with ChangeNotifier {
     if (languageCode != null) {
       _locale = Locale(languageCode);
     } else {
-      _locale = const Locale('en', 'GB'); // Default locale
+      // No saved preference: use the phone's language if the app supports it,
+      // otherwise fall back to English.
+      const supportedLanguageCodes = ['en', 'fr', 'ja', 'tl'];
+      final deviceLanguageCode =
+          WidgetsBinding.instance.platformDispatcher.locale.languageCode;
+      if (supportedLanguageCodes.contains(deviceLanguageCode)) {
+        _locale = Locale(deviceLanguageCode);
+      } else {
+        _locale = const Locale('en');
+      }
     }
     notifyListeners();
   }

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -158,7 +158,7 @@ class SettingsProvider with ChangeNotifier {
       if (supportedLanguageCodes.contains(deviceLanguageCode)) {
         _locale = Locale(deviceLanguageCode);
       } else {
-        _locale = const Locale('en');
+        _locale = const Locale('en', 'GB');
       }
     }
     notifyListeners();


### PR DESCRIPTION
## Summary
Updated the settings provider to respect the device's language preference when no locale has been explicitly saved, while maintaining English (GB) as a fallback for unsupported languages.

## Key Changes
- Added import for `AppLocalizations` to access supported locales
- Modified the default locale initialization logic in `SettingsProvider` to:
  - Detect the device's language code from the platform dispatcher
  - Check if the device language is in the app's list of supported languages
  - Use the device language if supported, otherwise fall back to English (GB)
  - Added explanatory comments for clarity

## Implementation Details
The change extracts supported language codes from `AppLocalizations.supportedLocales` and compares them against the device's language code. This provides a better user experience by automatically using the user's preferred language when available, while gracefully falling back to English for unsupported languages.

https://claude.ai/code/session_01DhvZod3bR28fcATYpAzVhP