### PR TITLE
Implement background sync with local-first data loading

### DIFF
--- a/lib/app/app_root.dart
+++ b/lib/app/app_root.dart
@@ -1,5 +1,7 @@
 import 'package:country_picker/country_picker.dart';
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
@@ -9,6 +11,22 @@ import 'package:trainlog_app/app/home_gate.dart';
 import 'package:trainlog_app/l10n/app_localizations.dart';
 import 'package:trainlog_app/providers/settings_provider.dart';
 import 'package:trainlog_app/utils/platform_utils.dart';
+
+class CrashlyticsNavigationObserver extends NavigatorObserver {
+  @override
+  void didPush(Route route, Route? previousRoute) {
+    FirebaseCrashlytics.instance.log(
+      'Navigated to ${route.settings.name}',
+    );
+  }
+
+  @override
+  void didPop(Route route, Route? previousRoute) {
+    FirebaseCrashlytics.instance.log(
+      'Popped ${route.settings.name}',
+    );
+  }
+}
 
 class AppRoot extends StatelessWidget {
   final WidgetBuilder signedInBuilder;
@@ -34,6 +52,9 @@ class AppRoot extends StatelessWidget {
     return MaterialApp(
       scaffoldMessengerKey: rootScaffoldMessengerKey,
       navigatorKey: rootNavigatorKey,
+      navigatorObservers: kDebugMode ? [] : [
+        CrashlyticsNavigationObserver(),
+      ],
       locale: settings.locale,
       localizationsDelegates: [
         ...AppLocalizations.localizationsDelegates,

--- a/lib/navigation/platform_shell.dart
+++ b/lib/navigation/platform_shell.dart
@@ -1,6 +1,8 @@
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:trainlog_app/navigation/cupertino_shell.dart';
 import 'package:trainlog_app/navigation/material_shell.dart';
+import 'package:trainlog_app/providers/trips_provider.dart';
 import 'package:trainlog_app/utils/platform_utils.dart';
 
 class PlatformShell extends StatelessWidget {
@@ -8,6 +10,37 @@ class PlatformShell extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return AppPlatform.isApple ? const CupertinoShell() : const MaterialShell();
+    return Stack(
+      children: [
+        AppPlatform.isApple ? const CupertinoShell() : const MaterialShell(),
+        const _SyncProgressOverlay(),
+      ],
+    );
+  }
+}
+
+/// A thin indeterminate [LinearProgressIndicator] pinned just below the
+/// status bar.  It is only visible while [TripsProvider.isSyncing] is true,
+/// i.e. when a background incremental sync is running after the local DB
+/// data has already been presented to the user.
+class _SyncProgressOverlay extends StatelessWidget {
+  const _SyncProgressOverlay();
+
+  @override
+  Widget build(BuildContext context) {
+    final isSyncing = context.select<TripsProvider, bool>((t) => t.isSyncing);
+    if (!isSyncing) return const SizedBox.shrink();
+
+    final topPadding = MediaQuery.of(context).padding.top; // status-bar height
+    return Positioned(
+      top: topPadding,
+      left: 0,
+      right: 0,
+      child: LinearProgressIndicator(
+        minHeight: 2,
+        backgroundColor: Colors.transparent,
+        color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.8),
+      ),
+    );
   }
 }

--- a/lib/navigation/platform_shell.dart
+++ b/lib/navigation/platform_shell.dart
@@ -37,7 +37,7 @@ class _SyncProgressOverlay extends StatelessWidget {
       left: 0,
       right: 0,
       child: LinearProgressIndicator(
-        minHeight: 2,
+        minHeight: 4,
         backgroundColor: Colors.transparent,
         color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.8),
       ),

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -501,6 +501,14 @@ class SettingsProvider with ChangeNotifier {
     setLastFetchingTrips(DateTime.now().toUtc());
   }
 
+  Future<void> clearLastFetchingTrips() async {
+    if (_SP_lastFetchingTrips == null) return;
+    _SP_lastFetchingTrips = null;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove('last_fetching_trips');
+    notifyListeners();
+  }
+
   // ------------------------------------------------------------------------------
   
   void _loadLastUsedInstanceUrl() async {

--- a/lib/providers/statistics_provider.dart
+++ b/lib/providers/statistics_provider.dart
@@ -396,10 +396,11 @@ class StatisticsProvider extends ChangeNotifier {
       case GraphType.operator:
         return List.generate(
           data.length,
-          (i) => withOperatorLogoBg(
-            context,
-            _trainlog.getOperatorImage(data[i], maxWidth: 48, maxHeight: 48),
-          ),
+          (i) => _trainlog.getOperatorImage(data[i], maxWidth: 48, maxHeight: 48),
+          // (i) => withOperatorLogoBg(
+          //   context,
+          //   _trainlog.getOperatorImage(data[i], maxWidth: 48, maxHeight: 48),
+          // ),
         );
 
       case GraphType.country:
@@ -456,10 +457,11 @@ class StatisticsProvider extends ChangeNotifier {
             );
           }
           // Otherwise display operator logo
-          return withOperatorLogoBg(
-            context,
-            _trainlog.getOperatorImage(name, maxWidth: 48, maxHeight: 48),
-          );
+          return _trainlog.getOperatorImage(name, maxWidth: 48, maxHeight: 48);
+          // return withOperatorLogoBg(
+          //   context,
+          //   _trainlog.getOperatorImage(name, maxWidth: 48, maxHeight: 48),
+          // );
         });
         case GraphType.country:
           return List.generate(

--- a/lib/providers/trainlog_provider.dart
+++ b/lib/providers/trainlog_provider.dart
@@ -86,6 +86,7 @@ class TrainlogProvider extends ChangeNotifier {
     try {
       await _service.clearSession();
       settings.clearUsername();
+      settings.clearLastFetchingTrips();
       settings.setShouldReloadPolylines(true);
       await trips.clearAll();
       await AppCacheFilePath.deleteFile(AppCacheFilePath.polylines);

--- a/lib/providers/trips_provider.dart
+++ b/lib/providers/trips_provider.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:country_picker/country_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:trainlog_app/data/models/trips.dart';
@@ -17,6 +19,11 @@ class TripsProvider extends ChangeNotifier {
 
   bool _loading = true;
   bool get isLoading => _loading;
+
+  /// True while an incremental background sync with the server is running,
+  /// after the local DB has already been presented to the UI.
+  bool _isSyncing = false;
+  bool get isSyncing => _isSyncing;
   TripsRepository? get repository => _repository;
 
   List<VehicleType> _vehicleTypes = const [VehicleType.unknown];
@@ -99,13 +106,59 @@ class TripsProvider extends ChangeNotifier {
 
     _hasLoadedForUser = true;
 
-    debugPrint("🚀 TripsProvider auto-loading trips for $_username");
+    final lastFetch = _settings!.lastFetchingTrips;
+    final isFirstLoad = lastFetch == null || lastFetch == forceRefreshDate.toUtc();
 
-    // await loadTrips(
-    //   locale: _locale,
-    //   loadFromApi: true,
-    // );
-    await loadNecessaryTripsData(locale: _locale, hardRefresh: true);
+    if (isFirstLoad) {
+      // No prior data: fetch everything from the server (full hard refresh).
+      debugPrint("🚀 TripsProvider: first load for $_username → hard refresh");
+      await loadNecessaryTripsData(locale: _locale, hardRefresh: true);
+    } else {
+      // Returning user: show local DB data immediately, then sync in background.
+      debugPrint("🚀 TripsProvider: returning user $_username → local DB + background sync");
+      await _loadFromLocalDb();
+      unawaited(_backgroundSync());
+    }
+  }
+
+  /// Loads the repository directly from the local SQLite DB and refreshes all
+  /// derived lists.  Fast — no network access.
+  Future<void> _loadFromLocalDb() async {
+    _loading = true;
+    notifyListeners();
+    try {
+      _repository = await TripsRepository.loadFromDatabase();
+      await _refreshDerivedLists();
+      _revision++;
+      _polylineRevision++;
+      final count = await _repository!.count();
+      debugPrint("✅ Loaded $count trips from local DB");
+    } catch (e, stack) {
+      debugPrint("🛑 _loadFromLocalDb failed: $e");
+      debugPrintStack(stackTrace: stack);
+      _vehicleTypes = const [VehicleType.unknown];
+      _years = const [];
+      _operators = const [];
+      _countryCodes = const [];
+      _mapCountryCodes = const {};
+    } finally {
+      _loading = false;
+      notifyListeners();
+    }
+  }
+
+  /// Runs an incremental network sync without touching the loading state
+  /// (the UI is already showing local data).  Sets [isSyncing] = true for
+  /// the duration so the progress bar overlay can react.
+  Future<void> _backgroundSync() async {
+    _isSyncing = true;
+    notifyListeners();
+    try {
+      await loadNecessaryTripsData(locale: _locale, hardRefresh: false, silentSync: true);
+    } finally {
+      _isSyncing = false;
+      notifyListeners();
+    }
   }
 
   // ------------------------
@@ -155,9 +208,19 @@ class TripsProvider extends ChangeNotifier {
   //   }
   // }
 
-  Future<void> loadNecessaryTripsData({Locale? locale, bool hardRefresh = false}) async {
-    _loading = true;
-    notifyListeners();
+  /// Loads (or refreshes) trips data.
+  ///
+  /// [hardRefresh] — if true, re-downloads everything from the server;
+  ///   otherwise only fetches trips modified since [SettingsProvider.lastFetchingTrips].
+  ///
+  /// [silentSync] — if true, the [isLoading] flag is NOT toggled.  Use this
+  ///   when calling from a background context where the UI is already showing
+  ///   data from the local DB (e.g. [_backgroundSync]).
+  Future<void> loadNecessaryTripsData({Locale? locale, bool hardRefresh = false, bool silentSync = false}) async {
+    if (!silentSync) {
+      _loading = true;
+      notifyListeners();
+    }
     if (locale != null) _locale = locale;
 
     DateTime? lastRefresh = hardRefresh ? null : _settings!.lastFetchingTrips;
@@ -185,9 +248,7 @@ class TripsProvider extends ChangeNotifier {
         final trips = await _service!.fetchLastUpdatedTripsData(_username??"", lastRefresh);
         if (trips.isEmpty) {
           debugPrint("✅ Nothing to update.");
-          _loading = false;
-          notifyListeners();
-          return;
+          return; // finally block handles notifyListeners
         }
         _repository = await TripsRepository.loadFromTripsList(trips);
         _modificatedTrips = [...?_modificatedTrips, ...trips];
@@ -215,8 +276,8 @@ class TripsProvider extends ChangeNotifier {
       _countryCodes = const [];
       _mapCountryCodes = const {};
     } finally {
-      _loading = false;
-      notifyListeners(); // single notify after all data ready
+      if (!silentSync) _loading = false;
+      notifyListeners();
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: trainlog_app
 description: "Your online travel diary"
 publish_to: 'none'
-version: 0.1.4+10
+version: 0.1.7+13
 
 environment:
   sdk: ^3.8.0


### PR DESCRIPTION
## Summary
This PR implements a background sync mechanism that improves the user experience by showing locally cached data immediately while syncing updates from the server in the background. It also adds crash reporting integration and cleans up some UI code.

## Key Changes

### TripsProvider - Local-First Data Loading
- Added `_isSyncing` flag to track background sync state separately from initial loading
- Refactored `autoLoadTripsForUser()` to distinguish between first-time loads and returning users:
  - **First load**: Performs a hard refresh from the server (existing behavior)
  - **Returning users**: Loads local DB immediately, then syncs in background
- Extracted `_loadFromLocalDb()` method to quickly load cached data from SQLite without network access
- Added `_backgroundSync()` method to perform incremental syncs without blocking the UI
- Updated `loadNecessaryTripsData()` with `silentSync` parameter to prevent loading state changes during background operations
- Properly handles the loading state to avoid flickering when showing local data first

### UI - Sync Progress Indicator
- Modified `PlatformShell` to display a thin `LinearProgressIndicator` below the status bar when `isSyncing` is true
- Uses `context.select()` for efficient rebuilds only when sync state changes
- Provides visual feedback to users that data is being updated in the background

### Crash Reporting
- Added `CrashlyticsNavigationObserver` to `AppRoot` to log navigation events to Firebase Crashlytics
- Observer is only active in release mode (`!kDebugMode`)
- Logs route pushes and pops for better crash context

### Settings Provider
- Added `clearLastFetchingTrips()` method to reset the last sync timestamp
- Called during logout to ensure a fresh sync on next login

### Cleanup
- Commented out `withOperatorLogoBg()` wrapper calls in `StatisticsProvider` (appears to be temporary debugging)
- Updated version to 0.1.7+13

## Implementation Details
- Uses `unawaited()` for background sync to avoid blocking the UI thread
- Maintains separate `_loading` (initial load) and `_isSyncing` (background sync) flags for proper state management
- The `silentSync` parameter ensures the finally block still notifies listeners even when loading state isn't toggled
- Local DB loading is fast and provides immediate feedback while network operations happen asynchronously

https://claude.ai/code/session_01MhyvUWhg4ELAc9aLPBtS7E