### PR TITLE
Refactor station data structure to separate display and base names

### DIFF
--- a/lib/data/models/trip_form_model.dart
+++ b/lib/data/models/trip_form_model.dart
@@ -15,6 +15,7 @@ class TripFormModel extends ChangeNotifier {
   VehicleType? vehicleType = VehicleType.train;
 
   String? departureStationName;
+  String? departureStationBaseName;
   double? departureLat;
   double? departureLong;
   String? departureAddress;
@@ -22,6 +23,7 @@ class TripFormModel extends ChangeNotifier {
   bool highlightDepartureErrors = false;
 
   String? arrivalStationName;
+  String? arrivalStationBaseName;
   double? arrivalLat;
   double? arrivalLong;
   String? arrivalAddress;
@@ -236,12 +238,14 @@ class TripFormModel extends ChangeNotifier {
   
   void setDeparture({
     String? name,
+    String? baseName,
     double? lat,
     double? long,
     String? address,
     bool? geoMode,
   }) {
     departureStationName = name;
+    departureStationBaseName = baseName;
     departureLat = lat;
     departureLong = long;
     departureAddress = address;
@@ -259,12 +263,14 @@ class TripFormModel extends ChangeNotifier {
 
   void setArrival({
     String? name,
+    String? baseName,
     double? lat,
     double? long,
     String? address,
     bool? geoMode,
   }) {
     arrivalStationName = name;
+    arrivalStationBaseName = baseName;
     arrivalLat = lat;
     arrivalLong = long;
     arrivalAddress = address;
@@ -285,6 +291,10 @@ class TripFormModel extends ChangeNotifier {
     final tmpName = departureStationName;
     departureStationName = arrivalStationName;
     arrivalStationName = tmpName;
+
+    final tmpBaseName = departureStationBaseName;
+    departureStationBaseName = arrivalStationBaseName;
+    arrivalStationBaseName = tmpBaseName;
 
     // --- swap coordinates ---
     final tmpLat = departureLat;
@@ -486,7 +496,7 @@ class TripFormModel extends ChangeNotifier {
     }
     map['originStation'] = [
       [departureLat, departureLong],
-      departureStationName,
+      departureStationBaseName ?? departureStationName,
     ];
 
     // ---- destination ----
@@ -497,7 +507,7 @@ class TripFormModel extends ChangeNotifier {
     }
     map['destinationStation'] = [
       [arrivalLat, arrivalLong],
-      arrivalStationName,
+      arrivalStationBaseName ?? arrivalStationName,
     ];
 
     final departureDate = _when(dateType == DateType.precise, () => _isoDate(departureDateLocal));

--- a/lib/features/trips/trip_form_basics.dart
+++ b/lib/features/trips/trip_form_basics.dart
@@ -233,6 +233,7 @@ class TripFormBasics extends StatelessWidget {
         if (isDeparture) {
           model.setDeparture(
             name: values['name'],
+            baseName: values['baseName'],
             lat: lat,
             long: lng,
             geoMode: values['mode'] == 'geo',
@@ -242,6 +243,7 @@ class TripFormBasics extends StatelessWidget {
         } else {
           model.setArrival(
             name: values['name'],
+            baseName: values['baseName'],
             lat: lat,
             long: lng,
             geoMode: values['mode'] == 'geo',

--- a/lib/providers/trainlog_provider.dart
+++ b/lib/providers/trainlog_provider.dart
@@ -12,7 +12,8 @@ import 'package:latlong2/latlong.dart';
 import "package:unorm_dart/unorm_dart.dart" as unorm;
 
 typedef StationInfo = (
-  String label,
+  String name,
+  String displayName,
   LatLng coords,
   String address,
   bool isManual
@@ -380,8 +381,8 @@ class TrainlogProvider extends ChangeNotifier {
     return visits[label] ?? 0;
   }
 
-  String cleanLabel(String label) {
-    return removeFlagPrefix(label).toLowerCase();
+  String cleanLabel(String displayName) {
+    return removeFlagPrefix(displayName).toLowerCase();
   }
 
   Future<List<StationInfo>> fetchStations(
@@ -404,34 +405,14 @@ class TrainlogProvider extends ChangeNotifier {
     final normalizedQuery = _normalize(query);
 
     // ---- Manual stations (filtered by query) ----
-    final manualList = manualMap.entries
-        .map((e) => (
-              e.key,         // label with flag
-              e.value.$1,    // LatLng
-              e.value.$2,    // address
-              true,          // isManual
-            ))
-        .where((entry) {
-          final label   = _normalize(entry.$1);
-          //final address = _normalize(entry.$3);
-          return label.contains(normalizedQuery)/* ||
-                address.contains(normalizedQuery)*/;
-        })
-        .toList();
-
-    // ---- OSM stations (already filtered by query in API) ----
-    final osmList = osmMap.entries
-        .map((e) => (
-              e.key,
-              e.value.$1,
-              e.value.$2,
-              false,
-            ))
+    final manualList = manualMap
+        .where((s) => _normalize(s.displayName).contains(normalizedQuery))
         .toList();
 
     // ---- Combine + attach visit counts ----
-    // (label, coords, address, isManual, visits)
+    // (name, displayName, coords, address, isManual, visits)
     final combined = <(
+      String,
       String,
       LatLng,
       String,
@@ -439,27 +420,27 @@ class TrainlogProvider extends ChangeNotifier {
       int
     )>[];
 
-    int visitCount(String label) => visits[label] ?? 0;
-    String cleanLabel(String label) =>
-        removeFlagPrefix(label).toLowerCase();
+    int visitCount(String displayName) => visits[displayName] ?? 0;
+    String cleanLabel(String displayName) =>
+        removeFlagPrefix(displayName).toLowerCase();
 
     for (final m in manualList) {
-      combined.add((m.$1, m.$2, m.$3, m.$4, visitCount(m.$1)));
+      combined.add((m.name, m.displayName, m.coords, m.address, m.isManual, visitCount(m.displayName)));
     }
-    for (final o in osmList) {
-      combined.add((o.$1, o.$2, o.$3, o.$4, visitCount(o.$1)));
+    for (final o in osmMap) {
+      combined.add((o.name, o.displayName, o.coords, o.address, o.isManual, visitCount(o.displayName)));
     }
 
     // ---- Sort: 1) visits DESC, 2) alphabetical ignoring flag ----
     combined.sort((a, b) {
-      final visitsDiff = b.$5.compareTo(a.$5); // most visited first
+      final visitsDiff = b.$6.compareTo(a.$6); // most visited first
       if (visitsDiff != 0) return visitsDiff;
 
-      return cleanLabel(a.$1).compareTo(cleanLabel(b.$1));
+      return cleanLabel(a.$2).compareTo(cleanLabel(b.$2));
     });
 
-    // ---- Back to StationInfo (label, coords, address, isManual) ----
-    return combined.map((e) => (e.$1, e.$2, e.$3, e.$4)).toList();
+    // ---- Back to StationInfo (name, displayName, coords, address, isManual) ----
+    return combined.map((e) => (e.$1, e.$2, e.$3, e.$4, e.$5)).toList();
   }
 
   List<StationInfo> _mergeStationLists(
@@ -471,11 +452,11 @@ class TrainlogProvider extends ChangeNotifier {
 
     for (final osmItem in osm) {
       final osmKey =
-          removeFlagPrefix(osmItem.$1).toLowerCase(); // key without emoji
+          removeFlagPrefix(osmItem.$2).toLowerCase(); // displayName without emoji
 
       while (i < manual.length) {
         final manualKey =
-            removeFlagPrefix(manual[i].$1).toLowerCase(); // key without emoji
+            removeFlagPrefix(manual[i].$2).toLowerCase(); // displayName without emoji
 
         if (manualKey.compareTo(osmKey) < 0) {
           merged.add(manual[i]);

--- a/lib/services/trainlog_service.dart
+++ b/lib/services/trainlog_service.dart
@@ -11,6 +11,14 @@ import 'package:trainlog_app/data/models/news_model.dart';
 import 'package:trainlog_app/data/models/trips.dart';
 import 'package:trainlog_app/utils/text_utils.dart';
 
+typedef StationResult = ({
+  String name,
+  String displayName,
+  LatLng coords,
+  String address,
+  bool isManual,
+});
+
 class TrainlogLoginResult {
   final bool success;
   final List<Cookie> cookies;
@@ -446,12 +454,13 @@ class TrainlogService {
     throw Exception("Invalid coordinate type: $v");
   }
 
-  Future<Map<String, (LatLng, String)>> fetchAllManualStationsSuffixed(
+  Future<List<StationResult>> fetchAllManualStationsSuffixed(
     String username,
     VehicleType type,
   ) async {
     final manual = await _fetchRawManualStations(username, type);
-    final result = <String, (LatLng, String)>{};
+    final seen = <String>{};
+    final result = <StationResult>[];
 
     for (final entry in manual.entries) {
       final baseName = entry.key;
@@ -462,29 +471,36 @@ class TrainlogService {
         _toDouble(coords[1]),
       );
 
-      var name = baseName;
+      var displayName = baseName;
 
       // Handle suffixing
-      if (result.containsKey(name)) {
+      if (seen.contains(displayName)) {
         int suffixIndex = 0;
         while (true) {
           final candidate =
               "$baseName (${String.fromCharCode(97 + suffixIndex)})";
-          if (!result.containsKey(candidate)) {
-            name = candidate;
+          if (!seen.contains(candidate)) {
+            displayName = candidate;
             break;
           }
           suffixIndex++;
         }
       }
 
-      result[name] = (latLng, "@manual@");
+      seen.add(displayName);
+      result.add((
+        name: baseName,
+        displayName: displayName,
+        coords: latLng,
+        address: "@manual@",
+        isManual: true,
+      ));
     }
 
     return result;
   }
 
-  Future<Map<String, (LatLng, String)>> fetchStations(
+  Future<List<StationResult>> fetchStations(
     String query,
     VehicleType type,
   ) async {
@@ -532,27 +548,27 @@ class TrainlogService {
 
         final data = res.data;
         if (data == null) {
-          return {};
+          return [];
         }
 
         return _airportListGenerator(data);
       }
-    
+
       final res = await _safeGet<Map<String, dynamic>>(path);
 
       final data = res.data;
       if (data == null) {
-        return {};
+        return [];
       }
 
       return _stationListGenerator(data);
     } on Exception catch (_) {
-      return {};
+      return [];
     }
   }
 
-  Map<String, (LatLng, String)> _airportListGenerator(List<dynamic> airports) {
-    final result = <String, (LatLng, String)>{};
+  List<StationResult> _airportListGenerator(List<dynamic> airports) {
+    final result = <StationResult>[];
 
     for (final raw in airports) {
       final entry = raw as Map<String, dynamic>;
@@ -566,20 +582,25 @@ class TrainlogService {
 
       if (lat == null || lng == null) continue;
 
-      final key = "${countryCodeToEmoji(country)} $name ($iata)";
-      final value = (LatLng(lat.toDouble(), lng.toDouble()), city);
+      final displayName = "${countryCodeToEmoji(country)} $name ($iata)";
 
-      result[key] = value;
+      result.add((
+        name: displayName,
+        displayName: displayName,
+        coords: LatLng(lat.toDouble(), lng.toDouble()),
+        address: city,
+        isManual: false,
+      ));
     }
 
     return result;
   }
 
-  Map<String, (LatLng, String)> _stationListGenerator(
+  List<StationResult> _stationListGenerator(
     Map<String, dynamic> data,
   ) {
     final features = data["features"] as List<dynamic>? ?? [];
-    final result = <String, (LatLng, String)>{};
+    final result = <StationResult>[];
 
     for (final f in features) {
       final feature = f as Map<String, dynamic>;
@@ -595,7 +616,7 @@ class TrainlogService {
       final props = feature["properties"] as Map<String, dynamic>;
 
       final countryCode = props["countrycode"] as String? ?? "";
-      final name = props["name"] as String? ?? "";
+      final stationName = props["name"] as String? ?? "";
       final homonymy = props["homonymy_order"] as String? ?? "";
 
       final street = props["street"] as String? ?? "";
@@ -603,9 +624,9 @@ class TrainlogService {
       final district = props["district"] as String? ?? "";
       final city = props["city"] as String? ?? "";
 
-      // --- Key: "🇯🇵 Tokyo - Kita-Senju (a)" ---
       final emoji = countryCodeToEmoji(countryCode);
-      final key = "$emoji $name$homonymy";
+      final name = "$emoji $stationName";
+      final displayName = "$emoji $stationName$homonymy";
 
       // --- Address string ---
       final parts = [
@@ -617,7 +638,13 @@ class TrainlogService {
 
       final address = parts.join(", ");
 
-      result[key] = (latLng, address);
+      result.add((
+        name: name,
+        displayName: displayName,
+        coords: latLng,
+        address: address,
+        isManual: false,
+      ));
     }
 
     return result;

--- a/lib/widgets/station_fields_switcher.dart
+++ b/lib/widgets/station_fields_switcher.dart
@@ -60,6 +60,7 @@ class _StationFieldsSwitcherState extends State<StationFieldsSwitcher>
   late bool _geoMode = widget.initialGeoMode;
   double? _savedLat;
   double? _savedLng;
+  String? _savedBaseName;
 
   static const double _extraFieldHeight = 48;
   int _direction = -1;
@@ -128,6 +129,7 @@ class _StationFieldsSwitcherState extends State<StationFieldsSwitcher>
       _nameCtl.text = "";
       _savedLat = null;
       _savedLng = null;
+      _savedBaseName = null;
     }
     else {
       _nameCtl.text = widget.initialStationName ?? '';
@@ -136,6 +138,7 @@ class _StationFieldsSwitcherState extends State<StationFieldsSwitcher>
       _longCtl.text = "0.0";
       _savedLat = widget.initialLat;
       _savedLng = widget.initialLng;
+      _savedBaseName = null;
     }
 
     _currentAddress = widget.initialAddress ?? '';
@@ -159,6 +162,7 @@ class _StationFieldsSwitcherState extends State<StationFieldsSwitcher>
     widget.onChanged?.call({
       'mode': _geoMode ? "geo" : "name",
       'name': _geoMode ? _manualNameCtl.text : _nameCtl.text,
+      'baseName': _geoMode ? _manualNameCtl.text : (_savedBaseName ?? _nameCtl.text),
       'lat': _geoMode ? _latCtl.text : _savedLat?.toString() ?? "",
       'long': _geoMode ? _longCtl.text : _savedLng?.toString() ?? "",
       'address': _geoMode ? '' : _currentAddress,
@@ -204,10 +208,10 @@ class _StationFieldsSwitcherState extends State<StationFieldsSwitcher>
           },
 
           itemBuilder: (context, station) {
-            final (label, coords, address, isManual) = station;
+            final (name, displayName, coords, address, isManual) = station;
             return ListTile(
               tileColor: isManual ? Colors.red.withValues(alpha: 0.1) : null,
-              title: Text(label),
+              title: Text(displayName),
               trailing: isManual
                   ? Text(loc.manual, style: const TextStyle(color: Colors.red))
                   : null,
@@ -281,9 +285,10 @@ class _StationFieldsSwitcherState extends State<StationFieldsSwitcher>
   // Select station
   // ------------------------------
   void _selectStation(StationInfo station) {
-    final (label, coords, address, isManual) = station;
+    final (name, displayName, coords, address, isManual) = station;
 
-    _nameCtl.text = label;
+    _nameCtl.text = displayName;
+    _savedBaseName = name;
     _savedLat = coords.latitude;
     _savedLng = coords.longitude;
 


### PR DESCRIPTION
## Summary
This PR refactors the station data structure throughout the application to distinguish between a station's display name (with emoji flags and homonymy suffixes) and its base name (the actual station identifier). This enables proper handling of manual stations and improves data consistency when submitting trip information.

## Key Changes

- **New `StationResult` typedef** in `trainlog_service.dart`: Replaces tuple-based station representation with a named record containing `name`, `displayName`, `coords`, `address`, and `isManual` fields
  
- **Updated `StationInfo` typedef** in `trainlog_provider.dart`: Changed from `(label, coords, address, isManual)` to `(name, displayName, coords, address, isManual)` to match the new structure

- **Refactored station fetching methods**: 
  - `fetchAllManualStationsSuffixed()` now returns `List<StationResult>` instead of `Map<String, (LatLng, String)>`
  - `fetchStations()` returns `List<StationResult>` for consistency
  - `_airportListGenerator()` and `_stationListGenerator()` updated to build `StationResult` records

- **Enhanced `TripFormModel`**: Added `departureStationBaseName` and `arrivalStationBaseName` fields to store the base station names separately from display names, ensuring correct data is sent to the API

- **Updated UI components**:
  - `station_fields_switcher.dart`: Now tracks `_savedBaseName` and passes it through the `onChanged` callback
  - `trip_form_basics.dart`: Passes both `name` and `baseName` when setting departure/arrival stations

- **Improved station list handling**: Changed from map-based to list-based storage in `fetchStations()` to better support the new data structure

## Implementation Details

The refactoring maintains backward compatibility in the UI while improving data integrity. Manual stations now properly preserve their base names (without suffixes) separately from their display names (with suffixes like "(a)", "(b)"), allowing the API to receive the correct station identifier when submitting trips.

https://claude.ai/code/session_01SJenM4LB1PNSTdQ7cYGSNG