### PR TITLE
Refactor timeline layout to use IntrinsicHeight and improve responsiveness

### DIFF
--- a/lib/features/trips/trips_page.dart
+++ b/lib/features/trips/trips_page.dart
@@ -179,10 +179,12 @@ class _TripsPageState extends State<TripsPage> {
 
   Widget _tableGeneralHeaderBuilder(TripsProvider tripsProvider) {
     final locale = Localizations.localeOf(context);
-    return SingleChildScrollView(
+    return Align(
+      alignment: Alignment.centerRight,
+      child: SingleChildScrollView(
       scrollDirection: Axis.horizontal,
       child: Row(
-        mainAxisAlignment: MainAxisAlignment.end,
+        mainAxisSize: MainAxisSize.min,
         children: [
         PastFutureSelector(
           initialValue: _dataSource!.timeMoment,
@@ -242,6 +244,7 @@ class _TripsPageState extends State<TripsPage> {
           tooltip: AppLocalizations.of(context)!.filterButton,
         ),
       ],
+      ),
     ),
     );
   }

--- a/lib/features/trips/trips_page.dart
+++ b/lib/features/trips/trips_page.dart
@@ -179,9 +179,11 @@ class _TripsPageState extends State<TripsPage> {
 
   Widget _tableGeneralHeaderBuilder(TripsProvider tripsProvider) {
     final locale = Localizations.localeOf(context);
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.end,
-      children: [
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.end,
+        children: [
         PastFutureSelector(
           initialValue: _dataSource!.timeMoment,
           onChanged: (newMoment) {
@@ -240,6 +242,7 @@ class _TripsPageState extends State<TripsPage> {
           tooltip: AppLocalizations.of(context)!.filterButton,
         ),
       ],
+    ),
     );
   }
 

--- a/lib/widgets/trip_time_line.dart
+++ b/lib/widgets/trip_time_line.dart
@@ -40,7 +40,7 @@ class TripTimeline extends StatelessWidget {
         children: [
           // LEFT: departure and arrival time
           SizedBox(
-            width: 65,
+            width: 72,
             child: Column(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               crossAxisAlignment: CrossAxisAlignment.end,
@@ -55,6 +55,8 @@ class TripTimeline extends StatelessWidget {
                         decoration: trip.hasDepartureDelay ? TextDecoration.lineThrough : null,
                       ),
                       textAlign: TextAlign.right,
+                      softWrap: false,
+                      overflow: TextOverflow.visible,
                     ),
                     if (departureDelay != null) ...[
                       const SizedBox(height: 4),
@@ -79,6 +81,8 @@ class TripTimeline extends StatelessWidget {
                         decoration: trip.hasArrivalDelay ? TextDecoration.lineThrough : null,
                       ),
                       textAlign: TextAlign.right,
+                      softWrap: false,
+                      overflow: TextOverflow.visible,
                     ),
                     if (arrivalDelay != null) ...[
                       const SizedBox(height: 4),
@@ -121,6 +125,7 @@ class TripTimeline extends StatelessWidget {
                   softWrap: true,
                   overflow: TextOverflow.ellipsis,
                 ),
+                const SizedBox(height: 8),
 
                 // Middle: line info
                 Flexible(
@@ -140,7 +145,7 @@ class TripTimeline extends StatelessWidget {
                           ..removeLast(),
                       ),
                     ),
-                    const SizedBox(width: 8),
+                    const SizedBox(height: 8),
                     //Expanded(
                       /*child:*/ Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
@@ -160,6 +165,7 @@ class TripTimeline extends StatelessWidget {
                   ],
                 ),
                 ),
+                const SizedBox(height: 8),
 
                 // Bottom: destination station
                 Text(

--- a/lib/widgets/trip_time_line.dart
+++ b/lib/widgets/trip_time_line.dart
@@ -34,75 +34,64 @@ class TripTimeline extends StatelessWidget {
     final color = palette[trip.type] ?? Colors.black;
     final trainlog = Provider.of<TrainlogProvider>(context, listen: false);
 
-    const double timelineHeight = 250;
-
-    return SizedBox(
-      height: timelineHeight,
+    return IntrinsicHeight(
       child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           // LEFT: departure and arrival time
           SizedBox(
             width: 65,
-            child: Stack(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              crossAxisAlignment: CrossAxisAlignment.end,
               children: [
-                Positioned(
-                  top: 0,
-                  child: Column(
-                    children: [
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    Text(
+                      departureTime,
+                      style: TextStyle(
+                        fontSize: 12,
+                        decoration: trip.hasDepartureDelay ? TextDecoration.lineThrough : null,
+                      ),
+                      textAlign: TextAlign.right,
+                    ),
+                    if (departureDelay != null) ...[
+                      const SizedBox(height: 4),
                       Text(
-                        departureTime,
+                        departureDelay,
                         style: TextStyle(
                           fontSize: 12,
-                          decoration: trip.hasDepartureDelay ? TextDecoration.lineThrough : null,
-                          //color: trip.hasDepartureDelay ? Theme.of(context).colorScheme.error : null 
+                          color: trip.departureDelay! > 0 ? Colors.red : Colors.green,
                         ),
                         textAlign: TextAlign.right,
                       ),
-                      if (departureDelay != null) ...[
-                        const SizedBox(height: 4),
-                        Text(
-                          departureDelay,
-                          style: TextStyle(
-                            fontSize: 12, 
-                            color: trip.departureDelay! > 0
-                              ? Colors.red
-                              : Colors.green,
-                          ),
-                          textAlign: TextAlign.right,
-                        ),
-                      ],
                     ],
-                  ),
+                  ],
                 ),
-                Positioned(
-                  bottom: 0,
-                  child: Column(
-                    children: [
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    Text(
+                      arrivalTime,
+                      style: TextStyle(
+                        fontSize: 12,
+                        decoration: trip.hasArrivalDelay ? TextDecoration.lineThrough : null,
+                      ),
+                      textAlign: TextAlign.right,
+                    ),
+                    if (arrivalDelay != null) ...[
+                      const SizedBox(height: 4),
                       Text(
-                        arrivalTime,
+                        arrivalDelay,
                         style: TextStyle(
                           fontSize: 12,
-                          decoration: trip.hasArrivalDelay ? TextDecoration.lineThrough : null,
-                          //color: trip.hasArrivalDelay ? Theme.of(context).colorScheme.error :
+                          color: trip.arrivalDelay! > 0 ? Colors.red : Colors.green,
                         ),
                         textAlign: TextAlign.right,
                       ),
-                      if (arrivalDelay != null) ...[
-                        const SizedBox(height: 4),
-                        Text(
-                          arrivalDelay,
-                          style: TextStyle(
-                            fontSize: 12, 
-                            color: trip.arrivalDelay! > 0
-                              ? Colors.red
-                              : Colors.green,
-                          ),
-                          textAlign: TextAlign.right,
-                        ),
-                      ],
                     ],
-                  ),                  
+                  ],
                 ),
               ],
             ),
@@ -187,8 +176,6 @@ class TripTimeline extends StatelessWidget {
     );
   }
 
-
-
   Widget _buildDot(BuildContext context, Icon icon, Color color) => Container(
       width: 40,
       height: 40,
@@ -211,7 +198,6 @@ class TripTimeline extends StatelessWidget {
 
   Widget _buildLine(Color color) => Container(
         width: 10,
-        height: 150,
         color: color,
   );
 

--- a/lib/widgets/trip_time_line.dart
+++ b/lib/widgets/trip_time_line.dart
@@ -125,7 +125,7 @@ class TripTimeline extends StatelessWidget {
                   softWrap: true,
                   overflow: TextOverflow.ellipsis,
                 ),
-                const SizedBox(height: 8),
+                const SizedBox(height: 24),
 
                 // Middle: line info
                 Flexible(
@@ -165,7 +165,7 @@ class TripTimeline extends StatelessWidget {
                   ],
                 ),
                 ),
-                const SizedBox(height: 8),
+                const SizedBox(height: 24),
 
                 // Bottom: destination station
                 Text(

--- a/lib/widgets/trip_time_line.dart
+++ b/lib/widgets/trip_time_line.dart
@@ -130,11 +130,12 @@ class TripTimeline extends StatelessWidget {
                   trip.originStation,
                   style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w500),
                   softWrap: true,
-                  overflow: TextOverflow.visible,
+                  overflow: TextOverflow.ellipsis,
                 ),
 
                 // Middle: line info
-                Column(
+                Flexible(
+                  child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     operatorName.isEmpty
@@ -169,13 +170,14 @@ class TripTimeline extends StatelessWidget {
                     //),
                   ],
                 ),
+                ),
 
                 // Bottom: destination station
                 Text(
                   trip.destinationStation,
                   style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w500),
                   softWrap: true,
-                  overflow: TextOverflow.visible,
+                  overflow: TextOverflow.ellipsis,
                 ),
               ],
             ),


### PR DESCRIPTION
## Summary
Refactored the trip timeline widget to use `IntrinsicHeight` instead of a fixed height constraint, improving layout flexibility and responsiveness. Also enhanced the trips page header layout for better horizontal scrolling support.

## Key Changes

**TripTimeline Widget:**
- Replaced fixed `SizedBox` height (250px) with `IntrinsicHeight` for dynamic sizing based on content
- Converted left panel from `Stack` with `Positioned` widgets to a `Column` with `mainAxisAlignment.spaceBetween` for cleaner layout
- Changed `crossAxisAlignment` from `start` to `stretch` to properly fill available space
- Increased left panel width from 65 to 72 pixels
- Wrapped middle section (line info) in `Flexible` widget to handle overflow gracefully
- Changed station name overflow from `visible` to `ellipsis` for better text handling
- Added explicit spacing (`SizedBox` height: 24) between departure/arrival times and station names
- Removed hardcoded height (150px) from `_buildLine()` method to allow dynamic sizing
- Fixed spacing widget type from `SizedBox(width: 8)` to `SizedBox(height: 8)` in column context
- Cleaned up commented-out code and extra blank lines

**TripsPage Header:**
- Wrapped header row in `Align` widget with `centerRight` alignment
- Added `SingleChildScrollView` with horizontal scroll direction for better mobile responsiveness
- Changed `Row` from `mainAxisAlignment.end` to `mainAxisSize.min` for proper sizing with scroll container

## Implementation Details
The timeline now dynamically adjusts its height based on content rather than forcing a fixed 250px height, making it more flexible for varying content lengths. The layout shift from `Stack`/`Positioned` to `Column` with proper alignment is more maintainable and follows Flutter best practices for responsive layouts.

https://claude.ai/code/session_018q6bmC71MhMmUtBrWNRFta