### PR TITLE
Add light background band to logo axis in dark mode

### DIFF
--- a/lib/features/statistics/statistics_page.dart
+++ b/lib/features/statistics/statistics_page.dart
@@ -170,6 +170,7 @@ class _StatisticsPageState extends State<StatisticsPage> {
                                   baseUnit: baseUnit,
                                   unitsByFactor: unitMap, // null for duration
                                   color: barColor,
+                                  showAxisBackground: statsProv.graph == GraphType.operator,
                                   // Only show tooltip for scalable units (distance/trips/CO2)
                                   unitHelpTooltip: (isDurationOrTrips)
                                       ? null

--- a/lib/providers/statistics_provider.dart
+++ b/lib/providers/statistics_provider.dart
@@ -450,10 +450,9 @@ class StatisticsProvider extends ChangeNotifier {
           return List.generate(keys.length, (i) {
           final name = keys[i];
           if (name == AppLocalizations.of(context)!.statisticsOtherLabel) {
-            // Just display text for "Other"
             return Text(
               name,
-              //style: const TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
+              style: const TextStyle(color: Colors.black),
             );
           }
           // Otherwise display operator logo

--- a/lib/widgets/logo_bar_chart.dart
+++ b/lib/widgets/logo_bar_chart.dart
@@ -299,8 +299,11 @@ class _LogoBarChartState extends State<LogoBarChart> {
     );
 
     const double axisReservedSize = 50;
+    // rightTitles: reservedSize(30) + axisNameSize(20) = 50px on the right/bottom edge
+    const double rightAxisSize = 50;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final showBand = widget.showAxisBackground && isDark;
+    final rotated = widget.rotationQuarterTurns % 2 == 1;
 
     final chart = BarChart(
       key: chartDataKey,
@@ -353,7 +356,14 @@ class _LogoBarChartState extends State<LogoBarChart> {
               getTitlesWidget: (value, meta) {
                 final i = value.toInt();
                 if (i < 0 || i >= _images.length) return const SizedBox.shrink();
-                return SideTitleWidget(meta: meta, child: _images[i]);
+                Widget child = _images[i];
+                if (widget.showAxisBackground && rotated) {
+                  child = Padding(
+                    padding: const EdgeInsets.only(left: 8),
+                    child: child,
+                  );
+                }
+                return SideTitleWidget(meta: meta, child: child);
               },
             ),
           ),
@@ -386,15 +396,15 @@ class _LogoBarChartState extends State<LogoBarChart> {
     if (!showBand) return chart;
 
     // In dark mode, draw a light band behind the logo axis area.
-    // rotationQuarterTurns==1 means the chart is rotated so the "bottom" axis
-    // appears on the left side visually.
-    final rotated = widget.rotationQuarterTurns % 2 == 1;
+    // rotationQuarterTurns==1 means the "bottom" axis appears on the left visually.
     return Stack(
       children: [
         Positioned(
-          left: rotated ? 0 : null,
-          right: rotated ? null : 0,
-          bottom: 0,
+          // non-rotated: full-width band at the bottom, stopping before the right numeric axis
+          // rotated: full-height band on the left, stopping before the bottom numeric axis
+          left: 0,
+          right: rotated ? null : rightAxisSize,
+          bottom: rotated ? rightAxisSize : 0,
           top: rotated ? 0 : null,
           width: rotated ? axisReservedSize : null,
           height: rotated ? null : axisReservedSize,

--- a/lib/widgets/logo_bar_chart.dart
+++ b/lib/widgets/logo_bar_chart.dart
@@ -1,6 +1,7 @@
 import 'dart:math' as math;
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
+import 'package:trainlog_app/app/app_globals.dart';
 import 'package:trainlog_app/l10n/app_localizations.dart';
 import 'package:trainlog_app/utils/number_formatter.dart';
 
@@ -36,6 +37,9 @@ class LogoBarChart extends StatefulWidget {
   final int rotationQuarterTurns;
   final InlineSpan? unitHelpTooltip;
 
+  /// When true, a light background band is drawn behind the logo axis in dark mode.
+  final bool showAxisBackground;
+
     /// Optional: raw (unscaled) values for tooltips, matching the stat order.
   /// If provided with [tooltipValueFormatter], the tooltip will display these
   /// pretty-printed values instead of the scaled ones.
@@ -57,6 +61,7 @@ class LogoBarChart extends StatefulWidget {
     this.color,
     this.rotationQuarterTurns = 0,
     this.unitHelpTooltip,
+    this.showAxisBackground = false,
     this.tooltipRawPast,
     this.tooltipRawFuture,
     this.tooltipValueFormatter,
@@ -293,7 +298,11 @@ class _LogoBarChartState extends State<LogoBarChart> {
       '${_pastScaled.join(',')}|${_futureScaled.join(',')}',
     );
 
-    return BarChart(
+    const double axisReservedSize = 50;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final showBand = widget.showAxisBackground && isDark;
+
+    final chart = BarChart(
       key: chartDataKey,
       BarChartData(
         rotationQuarterTurns: widget.rotationQuarterTurns,
@@ -372,6 +381,29 @@ class _LogoBarChartState extends State<LogoBarChart> {
           ),
         ),
       ),
+    );
+
+    if (!showBand) return chart;
+
+    // In dark mode, draw a light band behind the logo axis area.
+    // rotationQuarterTurns==1 means the chart is rotated so the "bottom" axis
+    // appears on the left side visually.
+    final rotated = widget.rotationQuarterTurns % 2 == 1;
+    return Stack(
+      children: [
+        chart,
+        Positioned(
+          left: rotated ? 0 : null,
+          right: rotated ? null : 0,
+          bottom: 0,
+          top: rotated ? 0 : null,
+          width: rotated ? axisReservedSize : null,
+          height: rotated ? null : axisReservedSize,
+          child: IgnorePointer(
+            child: Container(color: kLightThemeSurface),
+          ),
+        ),
+      ],
     );
   }
 

--- a/lib/widgets/logo_bar_chart.dart
+++ b/lib/widgets/logo_bar_chart.dart
@@ -362,6 +362,11 @@ class _LogoBarChartState extends State<LogoBarChart> {
                     padding: const EdgeInsets.only(left: 8),
                     child: child,
                   );
+                } else if (widget.showAxisBackground && !rotated) {
+                  child = RotatedBox(
+                    quarterTurns: 3,
+                    child: SizedBox(width: 32, height: 32, child: child),
+                  );
                 }
                 return SideTitleWidget(meta: meta, child: child);
               },

--- a/lib/widgets/logo_bar_chart.dart
+++ b/lib/widgets/logo_bar_chart.dart
@@ -391,7 +391,6 @@ class _LogoBarChartState extends State<LogoBarChart> {
     final rotated = widget.rotationQuarterTurns % 2 == 1;
     return Stack(
       children: [
-        chart,
         Positioned(
           left: rotated ? 0 : null,
           right: rotated ? null : 0,
@@ -399,10 +398,9 @@ class _LogoBarChartState extends State<LogoBarChart> {
           top: rotated ? 0 : null,
           width: rotated ? axisReservedSize : null,
           height: rotated ? null : axisReservedSize,
-          child: IgnorePointer(
-            child: Container(color: kLightThemeSurface),
-          ),
+          child: Container(color: kLightThemeSurface),
         ),
+        chart,
       ],
     );
   }


### PR DESCRIPTION
## Summary
This PR enhances the visual presentation of bar charts in dark mode by adding an optional light background band behind the logo axis area, improving contrast and readability.

## Key Changes
- **LogoBarChart widget**: Added `showAxisBackground` parameter (defaults to `false`) to control whether a light background band is displayed behind the logo axis in dark mode
- **Visual styling**: 
  - Light background band uses `kLightThemeSurface` color and is positioned behind the logo axis
  - Band dimensions adapt based on chart rotation: full-width at bottom for normal orientation, full-height on left for rotated orientation
  - Band respects the reserved axis space (50px) to avoid overlapping with numeric axis labels
- **Logo positioning**: Added padding/rotation adjustments to logo images when background band is enabled to ensure proper alignment
- **Statistics page**: Enabled the background band feature specifically for operator graph type (`showAxisBackground: statsProv.graph == GraphType.operator`)
- **Minor fix**: Updated "Other" label styling in statistics provider to use explicit black color

## Implementation Details
- The background band is rendered using a `Stack` with `Positioned` widget for precise placement
- Chart rotation is detected via `rotationQuarterTurns % 2 == 1` to determine band orientation
- Logo images receive conditional styling (padding for rotated, rotation+sizing for non-rotated) when background is enabled
- Dark mode detection uses `Theme.of(context).brightness == Brightness.dark`

https://claude.ai/code/session_01Fv9v43rYqztJLZXPF66aDq