### PR TITLE
Refactor navigation to use floating bottom nav bar

### DIFF
--- a/lib/app/app_nav_bar_theme.dart
+++ b/lib/app/app_nav_bar_theme.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+
+/// ThemeExtension that supplies colours for the floating bottom nav bar.
+/// Consumed by AdaptiveBottomNavBar via Theme.of(context).extension<AppNavBarColors>().
+class AppNavBarColors extends ThemeExtension<AppNavBarColors> {
+  final Color background;
+  final Color active;
+  final Color inactive;
+  final Color shadow;
+
+  const AppNavBarColors({
+    required this.background,
+    required this.active,
+    required this.inactive,
+    required this.shadow,
+  });
+
+  @override
+  AppNavBarColors copyWith({
+    Color? background,
+    Color? active,
+    Color? inactive,
+    Color? shadow,
+  }) =>
+      AppNavBarColors(
+        background: background ?? this.background,
+        active: active ?? this.active,
+        inactive: inactive ?? this.inactive,
+        shadow: shadow ?? this.shadow,
+      );
+
+  @override
+  AppNavBarColors lerp(ThemeExtension<AppNavBarColors>? other, double t) {
+    if (other is! AppNavBarColors) return this;
+    return AppNavBarColors(
+      background: Color.lerp(background, other.background, t)!,
+      active: Color.lerp(active, other.active, t)!,
+      inactive: Color.lerp(inactive, other.inactive, t)!,
+      shadow: Color.lerp(shadow, other.shadow, t)!,
+    );
+  }
+}

--- a/lib/app/app_root.dart
+++ b/lib/app/app_root.dart
@@ -104,9 +104,14 @@ class AppRoot extends StatelessWidget {
       ),
 
       builder: (_, child) {
-        return ScaffoldMessenger(
-          key: rootScaffoldMessengerKey,
-          child: child!,
+        final themeData =
+            brightness == Brightness.dark ? AppTheme.dark : AppTheme.light;
+        return Theme(
+          data: themeData,
+          child: ScaffoldMessenger(
+            key: rootScaffoldMessengerKey,
+            child: child!,
+          ),
         );
       },
 

--- a/lib/app/app_theme.dart
+++ b/lib/app/app_theme.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:trainlog_app/app/app_colors.dart';
+import 'package:trainlog_app/app/app_nav_bar_theme.dart';
 
 /// Trainlog design-system themes and typography.
 abstract final class AppTheme {
@@ -97,6 +98,14 @@ abstract final class AppTheme {
           borderSide: const BorderSide(color: AppColors.blue, width: 2),
         ),
       ),
+      extensions: const [
+        AppNavBarColors(
+          background: AppColors.lightBg,
+          active: AppColors.amber,
+          inactive: AppColors.lightText3,
+          shadow: Color(0x1F14213D), // navy @ 12 %
+        ),
+      ],
     );
   }
 
@@ -182,6 +191,14 @@ abstract final class AppTheme {
           borderSide: const BorderSide(color: AppColors.sky, width: 2),
         ),
       ),
+      extensions: const [
+        AppNavBarColors(
+          background: AppColors.darkElevated,
+          active: AppColors.amber,
+          inactive: AppColors.darkText3,
+          shadow: Color(0x66000000), // black @ 40 %
+        ),
+      ],
     );
   }
 

--- a/lib/features/map/map_page.dart
+++ b/lib/features/map/map_page.dart
@@ -407,7 +407,7 @@ class _MapPageState extends State<MapPage> with WidgetsBindingObserver, Automati
     final forg = Theme.of(context).colorScheme.onTertiaryContainer;
     return Positioned(
       right: 16,
-      bottom: 16 + 56 + 12,
+      bottom: 16 + MediaQuery.of(context).padding.bottom,
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [

--- a/lib/features/map/map_page.dart
+++ b/lib/features/map/map_page.dart
@@ -407,7 +407,7 @@ class _MapPageState extends State<MapPage> with WidgetsBindingObserver, Automati
     final forg = Theme.of(context).colorScheme.onTertiaryContainer;
     return Positioned(
       right: 16,
-      bottom: 16 + MediaQuery.of(context).padding.bottom,
+      bottom: 16 + MediaQuery.of(context).padding.bottom + 56 + 12, // above nav bar + some spacing
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [

--- a/lib/features/ranking/ranking_page.dart
+++ b/lib/features/ranking/ranking_page.dart
@@ -19,6 +19,7 @@ class _RankingPageState extends State<RankingPage>
   Widget build(BuildContext context) {
     final loc = AppLocalizations.of(context)!;
 
+    final navClearance = MediaQuery.of(context).padding.bottom;
     return Column(
       children: [
         DismissibleErrorBannerBlock(
@@ -38,6 +39,7 @@ class _RankingPageState extends State<RankingPage>
             publicPage: true,
           ),
         ),
+        SizedBox(height: navClearance),
       ],
     );
   }

--- a/lib/features/statistics/statistics_page.dart
+++ b/lib/features/statistics/statistics_page.dart
@@ -75,9 +75,8 @@ class _StatisticsPageState extends State<StatisticsPage> {
         final barColor   = palette[statsProv.vehicle] ?? Colors.blue;
         final hasData    = statsProv.currentStats.isNotEmpty && !statsProv.isLoading;
 
-        final navClearance = MediaQuery.of(context).padding.bottom;
         return Padding(
-          padding: EdgeInsets.only(left: 20, top: 20, right: 20, bottom: 20 + navClearance),
+          padding: const EdgeInsets.all(20),
           child: Column(
             children: [
               // Top right: chart type switcher (bar/pie/table)
@@ -106,6 +105,7 @@ class _StatisticsPageState extends State<StatisticsPage> {
               Expanded(
                 child: MinHeightScrollable(
                   minHeight: 350,
+                  padding: EdgeInsets.only(bottom: MediaQuery.of(context).padding.bottom),
                   child: Builder(
                     builder: (_) {
                       if (statsProv.isLoading) {

--- a/lib/features/statistics/statistics_page.dart
+++ b/lib/features/statistics/statistics_page.dart
@@ -75,8 +75,9 @@ class _StatisticsPageState extends State<StatisticsPage> {
         final barColor   = palette[statsProv.vehicle] ?? Colors.blue;
         final hasData    = statsProv.currentStats.isNotEmpty && !statsProv.isLoading;
 
+        final navClearance = MediaQuery.of(context).padding.bottom;
         return Padding(
-          padding: const EdgeInsets.all(20),
+          padding: EdgeInsets.only(left: 20, top: 20, right: 20, bottom: 20 + navClearance),
           child: Column(
             children: [
               // Top right: chart type switcher (bar/pie/table)

--- a/lib/features/trips/trips_page.dart
+++ b/lib/features/trips/trips_page.dart
@@ -97,7 +97,9 @@ class _TripsPageState extends State<TripsPage> {
     _dataSource!.setVisibleColumns(visibleColumns);
     final locale = Localizations.localeOf(context);
 
-    return RefreshIndicator(
+    return SafeArea(
+      top: false,
+      child: RefreshIndicator(
       key: _refreshKey,
       onRefresh: () async {
         //final settings = context.read<SettingsProvider>();        
@@ -127,14 +129,13 @@ class _TripsPageState extends State<TripsPage> {
           final double availableHeight = constraints.maxHeight;
           const double headingHeight = 56.0;
           const double rowHeight = 48.0;
-          final double footerHeight = btmPad + 50;
+          final double footerHeight = AppPlatform.isApple ? btmPad + 50 : 180.0; // On Material, keep space for the FAB
 
           // Estimate how many rows fit in the remaining height
           final rowsPerPage = ((availableHeight - headingHeight - footerHeight) ~/ rowHeight).clamp(5, 50);
 
           return SingleChildScrollView(
             physics: const AlwaysScrollableScrollPhysics(),
-            padding: EdgeInsets.only(bottom: btmPad),
             child: ConstrainedBox(
               constraints: BoxConstraints(minHeight: constraints.maxHeight),
               child: DataTableTheme(
@@ -175,6 +176,7 @@ class _TripsPageState extends State<TripsPage> {
           );
         },
       ),
+    ),
     );
   }
 

--- a/lib/features/trips/trips_page.dart
+++ b/lib/features/trips/trips_page.dart
@@ -127,13 +127,14 @@ class _TripsPageState extends State<TripsPage> {
           final double availableHeight = constraints.maxHeight;
           const double headingHeight = 56.0;
           const double rowHeight = 48.0;
-          final double footerHeight = AppPlatform.isApple ? btmPad + 50 : 180.0; // On Material, keep space for the FAB
-      
+          final double footerHeight = btmPad + 50;
+
           // Estimate how many rows fit in the remaining height
           final rowsPerPage = ((availableHeight - headingHeight - footerHeight) ~/ rowHeight).clamp(5, 50);
-      
+
           return SingleChildScrollView(
             physics: const AlwaysScrollableScrollPhysics(),
+            padding: EdgeInsets.only(bottom: btmPad),
             child: ConstrainedBox(
               constraints: BoxConstraints(minHeight: constraints.maxHeight),
               child: DataTableTheme(

--- a/lib/navigation/cupertino_shell.dart
+++ b/lib/navigation/cupertino_shell.dart
@@ -3,21 +3,14 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart' show Icon;
 import 'package:trainlog_app/l10n/app_localizations.dart';
 import 'package:trainlog_app/navigation/nav_models.dart';
-import 'package:trainlog_app/features/settings/settings_cupertino_page.dart';
+import 'package:trainlog_app/platform/adaptive_bottom_navbar.dart';
 import 'package:trainlog_app/platform/cupertino_fab.dart';
 import 'package:trainlog_app/utils/platform_utils.dart';
 
-import 'package:trainlog_app/features/about/about_page.dart';
-import 'package:trainlog_app/features/user/dashboard_page.dart';
-import 'package:trainlog_app/features/friends/friends_page.dart';
 import 'package:trainlog_app/features/map/map_page.dart';
 import 'package:trainlog_app/features/ranking/ranking_page.dart';
-import 'package:trainlog_app/features/spr/smart_prerecorder_page.dart';
 import 'package:trainlog_app/features/statistics/statistics_page.dart';
-import 'package:trainlog_app/features/tags/tags_page.dart';
-import 'package:trainlog_app/features/tickets/tickets_page.dart';
 import 'package:trainlog_app/features/trips/trips_page.dart';
-import 'package:trainlog_app/widgets/menu_header.dart';
 
 typedef SetPrimaryActions = void Function(List<AppPrimaryAction> actions);
 
@@ -29,71 +22,115 @@ class CupertinoShell extends StatefulWidget {
 }
 
 class _CupertinoShellState extends State<CupertinoShell> {
-  late final CupertinoTabController _controller;
-  static const double _tabBarHeight = 50.0; // keep consistent with CupertinoTabBar default
+  int _currentIndex = 0;
 
-  @override
-  void initState() {
-    super.initState();
-    _controller = CupertinoTabController();
-  }
+  final List<GlobalKey<NavigatorState>> _navigatorKeys = [
+    GlobalKey<NavigatorState>(),
+    GlobalKey<NavigatorState>(),
+    GlobalKey<NavigatorState>(),
+    GlobalKey<NavigatorState>(),
+  ];
 
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
+  void _onTabTapped(int index) {
+    if (index == _currentIndex) {
+      // Pop to root when tapping the active tab
+      _navigatorKeys[index].currentState?.popUntil((r) => r.isFirst);
+    } else {
+      setState(() => _currentIndex = index);
+    }
   }
 
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
 
-    return CupertinoTabScaffold(
-      controller: _controller,
-      tabBar: CupertinoTabBar(
-        items: [
-          BottomNavigationBarItem(icon: Icon(AdaptiveIcons.map), label: l10n.menuMapTitle),
-          BottomNavigationBarItem(icon: Icon(AdaptiveIcons.trips), label: l10n.menuTripsTitle),
-          BottomNavigationBarItem(icon: Icon(AdaptiveIcons.ranking), label: l10n.menuRankingTitle),
-          BottomNavigationBarItem(icon: Icon(AdaptiveIcons.statistics), label: l10n.menuStatisticsTitle),
-          BottomNavigationBarItem(icon: Icon(AdaptiveIcons.other), label: l10n.menuIosMore),
-        ],
-      ),
-      tabBuilder: (context, index) {
-        return CupertinoTabView(
-          builder: (_) {
-            switch (index) {
-              case 0:
-                return _CupertinoRootPage(
+    final navItems = [
+      BottomNavigationBarItem(icon: Icon(AdaptiveIcons.map), label: l10n.menuMapTitle),
+      BottomNavigationBarItem(icon: Icon(AdaptiveIcons.trips), label: l10n.menuTripsTitle),
+      BottomNavigationBarItem(icon: Icon(AdaptiveIcons.ranking), label: l10n.menuRankingTitle),
+      BottomNavigationBarItem(icon: Icon(AdaptiveIcons.statistics), label: l10n.menuStatisticsTitle),
+    ];
+
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, _) {
+        if (!didPop) {
+          _navigatorKeys[_currentIndex].currentState?.maybePop();
+        }
+      },
+      child: Stack(
+        children: [
+          // Tab content — only the active tab's navigator is visible
+          IndexedStack(
+            index: _currentIndex,
+            children: [
+              _TabNavigator(
+                navigatorKey: _navigatorKeys[0],
+                builder: (ctx) => _CupertinoRootPage(
                   key: ValueKey(AppPageId.map.name),
                   title: l10n.menuMapTitle,
                   hasNavBar: false,
-                  builder: (ctx, setActions) => MapPage(onPrimaryActionsReady: setActions),
-                );
-              case 1:
-                return _CupertinoRootPage(
+                  builder: (c, setActions) => MapPage(onPrimaryActionsReady: setActions),
+                ),
+              ),
+              _TabNavigator(
+                navigatorKey: _navigatorKeys[1],
+                builder: (ctx) => _CupertinoRootPage(
                   key: ValueKey(AppPageId.trips.name),
                   title: l10n.menuTripsTitle,
-                  builder: (ctx, setActions) => TripsPage(onPrimaryActionsReady: setActions),
-                );
-              case 2:
-                return _CupertinoRootPage(
+                  builder: (c, setActions) => TripsPage(onPrimaryActionsReady: setActions),
+                ),
+              ),
+              _TabNavigator(
+                navigatorKey: _navigatorKeys[2],
+                builder: (ctx) => _CupertinoRootPage(
                   key: ValueKey(AppPageId.ranking.name),
                   title: l10n.menuRankingTitle,
                   builder: (_, __) => const RankingPage(),
-                );
-              case 3:
-                return _CupertinoRootPage(
+                ),
+              ),
+              _TabNavigator(
+                navigatorKey: _navigatorKeys[3],
+                builder: (ctx) => _CupertinoRootPage(
                   key: ValueKey(AppPageId.statistics.name),
                   title: l10n.menuStatisticsTitle,
                   builder: (_, __) => const StatisticsPage(),
-                );
-              default:
-                return _MorePage();
-            }
-          },
-        );
-      },
+                ),
+              ),
+            ],
+          ),
+
+          // Floating nav bar at bottom
+          Positioned(
+            left: 0,
+            right: 0,
+            bottom: 0,
+            child: AdaptiveBottomNavBar(
+              currentIndex: _currentIndex,
+              items: navItems,
+              onTap: _onTabTapped,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TabNavigator extends StatelessWidget {
+  final GlobalKey<NavigatorState> navigatorKey;
+  final WidgetBuilder builder;
+
+  const _TabNavigator({required this.navigatorKey, required this.builder});
+
+  @override
+  Widget build(BuildContext context) {
+    return Navigator(
+      key: navigatorKey,
+      onGenerateRoute: (settings) => CupertinoPageRoute(
+        settings: settings,
+        builder: builder,
+      ),
     );
   }
 }
@@ -107,7 +144,6 @@ class CupertinoPrimaryActionsRow extends StatelessWidget {
   Widget build(BuildContext context) {
     if (actions.isEmpty) return const SizedBox.shrink();
 
-    // Multiple actions: show in a row with FIRST action on the right.
     final reversed = actions.reversed.toList();
 
     return Row(
@@ -118,15 +154,15 @@ class CupertinoPrimaryActionsRow extends StatelessWidget {
             padding: EdgeInsets.zero,
             onPressed: reversed[i].onPressed,
             foregroundColor: reversed[i].isDestructive ? CupertinoColors.systemRed.resolveFrom(context) : null,
-            child: reversed[i].label == null 
-              ? Icon(reversed[i].icon) 
-              : Row(
-                children: [
-                  Icon(reversed[i].icon),
-                  const SizedBox(width: 4,),
-                  Text(reversed[i].label!)
-                ],
-              ),
+            child: reversed[i].label == null
+                ? Icon(reversed[i].icon)
+                : Row(
+                    children: [
+                      Icon(reversed[i].icon),
+                      const SizedBox(width: 4),
+                      Text(reversed[i].label!),
+                    ],
+                  ),
           ),
           if (i != reversed.length - 1) const SizedBox(width: 6),
         ],
@@ -163,8 +199,6 @@ class _CupertinoRootPageState extends State<_CupertinoRootPage> {
   @override
   Widget build(BuildContext context) {
     final mq = MediaQuery.of(context);
-
-    // Reserve: tab bar height + home indicator safe area
     final bottomPadding = mq.padding.bottom;
     final navBg = CupertinoTheme.of(context).scaffoldBackgroundColor;
 
@@ -193,15 +227,12 @@ class _CupertinoRootPageState extends State<_CupertinoRootPage> {
   Widget _childWithoutNavBar(MediaQueryData mq) {
     return Stack(
       children: [
-        // Map content
         Positioned.fill(
           child: Padding(
             padding: EdgeInsets.only(bottom: mq.padding.bottom),
             child: widget.builder(context, (actions) => _actions.value = actions),
           ),
         ),
-
-        // Top-right floating primary actions (replaces nav bar trailing)
         Positioned(
           top: mq.padding.top + 8,
           right: 12,
@@ -209,10 +240,7 @@ class _CupertinoRootPageState extends State<_CupertinoRootPage> {
             valueListenable: _actions,
             builder: (_, actions, __) {
               if (actions.isEmpty) return const SizedBox.shrink();
-
-              // Multiple: row with FIRST action on the right.
               final reversed = actions.reversed.toList();
-
               return Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
@@ -230,211 +258,3 @@ class _CupertinoRootPageState extends State<_CupertinoRootPage> {
   }
 }
 
-class _MorePage extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
-    final mq = MediaQuery.of(context);
-    final bottomPadding = mq.padding.bottom;
-
-    //final navBg = CupertinoTheme.of(context).scaffoldBackgroundColor;
-
-    return CupertinoPageScaffold(
-      // navigationBar: CupertinoNavigationBar(
-      //   backgroundColor: navBg,
-      //   middle: Text(l10n.menuIosMore),
-      // ),
-      child: Padding(
-        padding: EdgeInsets.only(bottom: bottomPadding),
-        child: Column(
-          children: [
-            ConstrainedBox(
-              constraints: BoxConstraints(
-                maxHeight: 170,
-              ),
-              child: Container(
-                decoration: const BoxDecoration(
-                  border: Border.symmetric(
-                    horizontal: BorderSide(color: Color(0xFF3772FF), width: 20),
-                  ),
-                ),
-                child: Container(
-                  margin: EdgeInsets.all(0),
-                  padding: EdgeInsets.all(8),
-                  decoration: BoxDecoration(color: Color(0xFF14213D)),
-                  child: MenuHeader(),
-                ),
-              ),
-            ),
-            Expanded(
-              child: ListView(
-                children: [
-                  //_sectionHeader('Pages'),
-                  _moreTile(
-                    context,
-                    icon: AdaptiveIcons.dashboard,
-                    title: l10n.menuDashboardTitle,
-                    push: () => _pushSimple(context, l10n.menuDashboardTitle, const DashboardPage()),
-                  ),
-                  _moreTile(
-                    context,
-                    icon: AdaptiveIcons.tags,
-                    title: l10n.menuTagsTitle,
-                    push: () => _pushWithActions(
-                      context,
-                      l10n.menuTagsTitle,
-                      (setActions) => TagsPage(onPrimaryActionsReady: setActions),
-                    ),
-                  ),
-                  _moreTile(
-                    context,
-                    icon: AdaptiveIcons.tickets,
-                    title: l10n.menuTicketsTitle,
-                    push: () => _pushWithActions(
-                      context,
-                      l10n.menuTicketsTitle,
-                      (setActions) => TicketsPage(onPrimaryActionsReady: setActions),
-                    ),
-                  ),
-                  // _moreTile(
-                  //   context,
-                  //   icon: AdaptiveIcons.friends,
-                  //   title: l10n.menuFriendsTitle,
-                  //   push: () => _pushSimple(context, l10n.menuFriendsTitle, const FriendsPage()),
-                  // ),
-                  _moreTile(
-                    context,
-                    icon: AdaptiveIcons.smartPrerecorder,
-                    title: l10n.menuSmartPrerecorderTitle,
-                    push: () => _pushWithActions(
-                      context,
-                      l10n.menuSmartPrerecorderTitle,
-                      (setActions) => SmartPrerecorderPage(onPrimaryActionsReady: setActions),
-                    ),
-                  ),
-                  _sectionHeader(''),
-                  _moreTile(
-                    context,
-                    icon: AdaptiveIcons.settings,
-                    title: l10n.menuSettingsTitle,
-                    push: () => _pushSimple(context, l10n.menuSettingsTitle, const SettingsCupertinoPage()),
-                  ),
-                  _moreTile(
-                    context,
-                    icon: AdaptiveIcons.info,
-                    title: l10n.menuAboutTitle,
-                    push: () => _pushSimple(context, l10n.menuAboutTitle, const AboutPage()),
-                  ),
-                ],
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget _sectionHeader(String text) {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
-      child: Text(
-        text,
-        style: const TextStyle(
-          fontSize: 13,
-          color: CupertinoColors.systemGrey,
-        ),
-      ),
-    );
-  }
-
-  Widget _moreTile(
-    BuildContext context, {
-    required IconData icon,
-    required String title,
-    required VoidCallback push,
-  }) {
-    return CupertinoListTile(
-      leading: Icon(icon),
-      title: Text(title),
-      trailing: const CupertinoListTileChevron(),
-      onTap: push,
-    );
-  }
-
-  void _pushSimple(BuildContext context, String title, Widget page) {
-    final navBg = CupertinoTheme.of(context).scaffoldBackgroundColor;
-
-    Navigator.of(context).push(
-      CupertinoPageRoute(
-        builder: (_) => CupertinoPageScaffold(
-          navigationBar: CupertinoNavigationBar(
-            backgroundColor: navBg,
-            middle: Text(title),
-          ),
-          child: page,
-        ),
-      ),
-    );
-  }
-
-  void _pushWithActions(
-    BuildContext context,
-    String title,
-    Widget Function(SetPrimaryActions setActions) builder,
-  ) {
-    Navigator.of(context).push(
-      CupertinoPageRoute(
-        builder: (_) => _CupertinoRoutedPage(
-          title: title,
-          builder: builder,
-        ),
-      ),
-    );
-  }
-}
-
-class _CupertinoRoutedPage extends StatefulWidget {
-  final String title;
-  final Widget Function(SetPrimaryActions setActions) builder;
-
-  const _CupertinoRoutedPage({
-    required this.title,
-    required this.builder,
-  });
-
-  @override
-  State<_CupertinoRoutedPage> createState() => _CupertinoRoutedPageState();
-}
-
-class _CupertinoRoutedPageState extends State<_CupertinoRoutedPage> {
-  final ValueNotifier<List<AppPrimaryAction>> _actions = ValueNotifier(const []);
-
-  @override
-  void dispose() {
-    _actions.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final mq = MediaQuery.of(context);
-    final bottomPadding = mq.padding.bottom;
-
-    final navBg = CupertinoTheme.of(context).scaffoldBackgroundColor;
-
-    return CupertinoPageScaffold(
-      navigationBar: CupertinoNavigationBar(
-        backgroundColor: navBg,
-        middle: Text(widget.title),
-        trailing: ValueListenableBuilder<List<AppPrimaryAction>>(
-          valueListenable: _actions,
-          builder: (_, actions, __) => CupertinoPrimaryActionsRow(actions: actions),
-        ),
-      ),
-      child: Padding(
-        padding: EdgeInsets.only(bottom: bottomPadding),
-        child: widget.builder((actions) => _actions.value = actions),
-      ),
-    );
-  }
-}

--- a/lib/navigation/cupertino_shell.dart
+++ b/lib/navigation/cupertino_shell.dart
@@ -3,7 +3,8 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart' show Icon;
 import 'package:trainlog_app/l10n/app_localizations.dart';
 import 'package:trainlog_app/navigation/nav_models.dart';
-import 'package:trainlog_app/platform/adaptive_bottom_navbar.dart';
+import 'package:trainlog_app/platform/adaptive_bottom_navbar.dart'
+    show AdaptiveBottomNavBar, kNavBarClearance;
 import 'package:trainlog_app/platform/cupertino_fab.dart';
 import 'package:trainlog_app/utils/platform_utils.dart';
 
@@ -217,10 +218,17 @@ class _CupertinoRootPageState extends State<_CupertinoRootPage> {
     );
   }
 
-  Widget _childWithNavBar(double bottomPadding) {
-    return Padding(
-      padding: EdgeInsets.only(bottom: bottomPadding),
-      child: widget.builder(context, (actions) => _actions.value = actions),
+  Widget _childWithNavBar(double systemBottomPadding) {
+    // Physical padding handles the system safe area (home indicator etc.).
+    // The MediaQuery override exposes kNavBarClearance as padding.bottom so
+    // scrollable pages can add the right bottom clearance without platform checks.
+    final mq = MediaQuery.of(context);
+    return MediaQuery(
+      data: mq.copyWith(padding: mq.padding.copyWith(bottom: kNavBarClearance)),
+      child: Padding(
+        padding: EdgeInsets.only(bottom: systemBottomPadding),
+        child: widget.builder(context, (actions) => _actions.value = actions),
+      ),
     );
   }
 

--- a/lib/navigation/material_shell.dart
+++ b/lib/navigation/material_shell.dart
@@ -290,6 +290,7 @@ class _MaterialShellState extends State<MaterialShell> {
             : Colors.white,
         child: SafeArea(
         child: Scaffold(
+        extendBody: true,
         key: _scaffoldKey,
         appBar: _isDrawerPage
             ? AdaptiveAppBar(

--- a/lib/platform/adaptive_bottom_navbar.dart
+++ b/lib/platform/adaptive_bottom_navbar.dart
@@ -1,6 +1,5 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:trainlog_app/utils/platform_utils.dart';
+import 'package:trainlog_app/app/app_nav_bar_theme.dart';
 
 class AdaptiveBottomNavBar extends StatelessWidget {
   final int currentIndex;
@@ -16,60 +15,25 @@ class AdaptiveBottomNavBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return _FloatingNavBar(
-      currentIndex: currentIndex,
-      items: items,
-      onTap: onTap,
-    );
-  }
-}
-
-class _FloatingNavBar extends StatelessWidget {
-  final int currentIndex;
-  final List<BottomNavigationBarItem> items;
-  final ValueChanged<int> onTap;
-
-  const _FloatingNavBar({
-    required this.currentIndex,
-    required this.items,
-    required this.onTap,
-  });
-
-  @override
-  Widget build(BuildContext context) {
+    final navColors = Theme.of(context).extension<AppNavBarColors>()!;
     final mq = MediaQuery.of(context);
-    final bottomPadding = mq.padding.bottom;
-
-    final isDark = AppPlatform.isApple
-        ? CupertinoTheme.of(context).brightness == Brightness.dark
-        : Theme.of(context).brightness == Brightness.dark;
-
-    final activeColor = AppPlatform.isApple
-        ? CupertinoTheme.of(context).primaryColor
-        : Theme.of(context).colorScheme.primary;
-
-    const inactiveColor = Color(0xFF8E8E93);
-
-    final bgColor = isDark
-        ? (AppPlatform.isApple ? const Color(0xFF1C1C1E) : const Color(0xFF1E1E2E))
-        : Colors.white;
 
     return Container(
       color: Colors.transparent,
       padding: EdgeInsets.only(
         left: 16,
         right: 16,
-        bottom: bottomPadding + 8,
+        bottom: mq.padding.bottom + 8,
         top: 8,
       ),
       child: Container(
         height: 64,
         decoration: BoxDecoration(
-          color: bgColor,
+          color: navColors.background,
           borderRadius: BorderRadius.circular(24),
           boxShadow: [
             BoxShadow(
-              color: Colors.black.withOpacity(isDark ? 0.4 : 0.12),
+              color: navColors.shadow,
               blurRadius: 20,
               offset: const Offset(0, 4),
             ),
@@ -82,8 +46,8 @@ class _FloatingNavBar extends StatelessWidget {
                 child: _NavBarItem(
                   item: items[i],
                   isSelected: i == currentIndex,
-                  activeColor: activeColor,
-                  inactiveColor: inactiveColor,
+                  activeColor: navColors.active,
+                  inactiveColor: navColors.inactive,
                   onTap: () => onTap(i),
                 ),
               ),

--- a/lib/platform/adaptive_bottom_navbar.dart
+++ b/lib/platform/adaptive_bottom_navbar.dart
@@ -1,6 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:trainlog_app/app/app_nav_bar_theme.dart';
 
+/// Height of the nav bar pill + its top/bottom padding, excluding the system
+/// safe area. Both shells expose this value as MediaQuery.padding.bottom so
+/// scrollable pages can add the right clearance without knowing about the nav.
+const double kNavBarClearance = 80.0;
+
 class AdaptiveBottomNavBar extends StatelessWidget {
   final int currentIndex;
   final List<BottomNavigationBarItem> items;

--- a/lib/platform/adaptive_bottom_navbar.dart
+++ b/lib/platform/adaptive_bottom_navbar.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:trainlog_app/utils/platform_utils.dart';
 
 class AdaptiveBottomNavBar extends StatelessWidget {
-  final int currentIndex; // 0..(items.length-1)
+  final int currentIndex;
   final List<BottomNavigationBarItem> items;
   final ValueChanged<int> onTap;
 
@@ -16,28 +16,126 @@ class AdaptiveBottomNavBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (AppPlatform.isApple) {
-      return CupertinoTabBar(
-        currentIndex: currentIndex,
-        onTap: onTap,
-        items: items,
-        activeColor: CupertinoTheme.of(context).primaryColor,
-        inactiveColor: CupertinoColors.systemGrey,
-      );
-    }
+    return _FloatingNavBar(
+      currentIndex: currentIndex,
+      items: items,
+      onTap: onTap,
+    );
+  }
+}
 
-    // Material 3
-    return NavigationBar(
-      selectedIndex: currentIndex,
-      onDestinationSelected: onTap,
-      destinations: [
-        for (final item in items)
-          NavigationDestination(
-            icon: item.icon,
-            selectedIcon: item.activeIcon,
-            label: item.label ?? '',
+class _FloatingNavBar extends StatelessWidget {
+  final int currentIndex;
+  final List<BottomNavigationBarItem> items;
+  final ValueChanged<int> onTap;
+
+  const _FloatingNavBar({
+    required this.currentIndex,
+    required this.items,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final mq = MediaQuery.of(context);
+    final bottomPadding = mq.padding.bottom;
+
+    final isDark = AppPlatform.isApple
+        ? CupertinoTheme.of(context).brightness == Brightness.dark
+        : Theme.of(context).brightness == Brightness.dark;
+
+    final activeColor = AppPlatform.isApple
+        ? CupertinoTheme.of(context).primaryColor
+        : Theme.of(context).colorScheme.primary;
+
+    const inactiveColor = Color(0xFF8E8E93);
+
+    final bgColor = isDark
+        ? (AppPlatform.isApple ? const Color(0xFF1C1C1E) : const Color(0xFF1E1E2E))
+        : Colors.white;
+
+    return Container(
+      color: Colors.transparent,
+      padding: EdgeInsets.only(
+        left: 16,
+        right: 16,
+        bottom: bottomPadding + 8,
+        top: 8,
+      ),
+      child: Container(
+        height: 64,
+        decoration: BoxDecoration(
+          color: bgColor,
+          borderRadius: BorderRadius.circular(24),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withOpacity(isDark ? 0.4 : 0.12),
+              blurRadius: 20,
+              offset: const Offset(0, 4),
+            ),
+          ],
+        ),
+        child: Row(
+          children: [
+            for (int i = 0; i < items.length; i++)
+              Expanded(
+                child: _NavBarItem(
+                  item: items[i],
+                  isSelected: i == currentIndex,
+                  activeColor: activeColor,
+                  inactiveColor: inactiveColor,
+                  onTap: () => onTap(i),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _NavBarItem extends StatelessWidget {
+  final BottomNavigationBarItem item;
+  final bool isSelected;
+  final Color activeColor;
+  final Color inactiveColor;
+  final VoidCallback onTap;
+
+  const _NavBarItem({
+    required this.item,
+    required this.isSelected,
+    required this.activeColor,
+    required this.inactiveColor,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final color = isSelected ? activeColor : inactiveColor;
+
+    return GestureDetector(
+      onTap: onTap,
+      behavior: HitTestBehavior.opaque,
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          IconTheme(
+            data: IconThemeData(color: color, size: 24),
+            child: isSelected && item.activeIcon != item.icon
+                ? item.activeIcon
+                : item.icon,
           ),
-      ],
+          const SizedBox(height: 3),
+          Text(
+            item.label ?? '',
+            style: TextStyle(
+              color: color,
+              fontSize: 11,
+              fontWeight: isSelected ? FontWeight.w600 : FontWeight.w400,
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/widgets/min_height_scrollable.dart
+++ b/lib/widgets/min_height_scrollable.dart
@@ -6,16 +6,19 @@ class MinHeightScrollable extends StatelessWidget {
     super.key,
     required this.minHeight,
     required this.child,
+    this.padding,
   });
 
   final double minHeight;
   final Widget child;
+  final EdgeInsetsGeometry? padding;
 
   @override
   Widget build(BuildContext context) {
     return LayoutBuilder(
       builder: (context, constraints) {
         return SingleChildScrollView(
+          padding: padding,
           // optional: AlwaysScrollable helps on tall screens
           physics: const AlwaysScrollableScrollPhysics(),
           child: ConstrainedBox(


### PR DESCRIPTION
## Summary
Refactored the Cupertino shell navigation to replace the native `CupertinoTabBar` with a custom floating bottom navigation bar design. This change unifies the navigation experience across platforms and enables a more modern, pill-shaped nav bar UI.

## Key Changes

- **Replaced `CupertinoTabScaffold` with custom navigation architecture**: 
  - Removed `CupertinoTabController` and tab-based navigation
  - Implemented manual tab state management with `_currentIndex` and `GlobalKey<NavigatorState>` per tab
  - Added `_TabNavigator` widget to manage independent navigation stacks for each tab

- **Introduced floating bottom nav bar**:
  - Created new `AdaptiveBottomNavBar` widget with custom Material Design styling (pill-shaped container with rounded corners and shadow)
  - Removed the "More" tab and its associated `_MorePage` class (dashboard, tags, tickets, settings, about pages are no longer accessible from main nav)
  - Nav bar now uses `IndexedStack` to show only the active tab's content

- **Added theme support for nav bar colors**:
  - Created `AppNavBarColors` theme extension to supply colors (background, active, inactive, shadow)
  - Integrated into both light and dark themes in `app_theme.dart`
  - Nav bar colors use amber for active state and custom grays for inactive

- **Improved bottom padding handling**:
  - Introduced `kNavBarClearance` constant (80.0) to standardize nav bar clearance across pages
  - Modified `_CupertinoRootPageState._childWithNavBar()` to expose nav clearance via `MediaQuery.padding.bottom` override
  - Updated scrollable pages (trips, ranking, statistics) to respect this padding

- **Enhanced back button handling**:
  - Wrapped shell in `PopScope` to handle system back button
  - Tapping active tab now pops to root of that tab's navigation stack
  - Proper navigation state management per tab

- **Code cleanup**:
  - Removed unused imports (settings, about, dashboard, friends, tags, tickets, SPR pages)
  - Removed `_MorePage` and `_CupertinoRoutedPage` classes
  - Reformatted code for consistency

## Notable Implementation Details

- The floating nav bar is positioned absolutely at the bottom using `Stack` and `Positioned`
- Each tab maintains its own `Navigator` with independent route history
- The nav bar height (64) plus padding (8 top/bottom + system safe area) totals the `kNavBarClearance` constant
- Pages can now use `MediaQuery.of(context).padding.bottom` to add proper scroll clearance without platform-specific checks

https://claude.ai/code/session_017iU1pzj7VWfffDYSc1qksi