### PR TITLE
Replace legacy drawer with full-screen menu on Android

### DIFF
--- a/lib/app/app_colors.dart
+++ b/lib/app/app_colors.dart
@@ -118,4 +118,15 @@ abstract final class AppColors {
 
   /// Walk
   static const Color modeWalk = Color(0xFF9E9E9E);
+
+  // ── Extra accent colours ─────────────────────────────────────────────────
+
+  /// Violet · accent  #7C3AED
+  static const Color violet = Color(0xFF7C3AED);
+
+  /// Violet tint  #EDE9FE
+  static const Color violetSoft = Color(0xFFEDE9FE);
+
+  /// Early / success (shared alias for green)
+  static const Color early = successLight;
 }

--- a/lib/app/app_theme.dart
+++ b/lib/app/app_theme.dart
@@ -33,13 +33,15 @@ abstract final class AppTheme {
       onTertiary: Colors.white,
       error: AppColors.errorLight,
       onError: Colors.white,
-      surface: AppColors.lightSurface,
+      // surface = card / sheet / elevated element (white)
+      surface: AppColors.lightBg,
       onSurface: AppColors.lightText,
       onSurfaceVariant: AppColors.lightText2,
       outline: AppColors.lightLine,
       outlineVariant: AppColors.lightLine,
       shadow: AppColors.navy,
-      inverseSurface: AppColors.darkBg,
+      // inverseSurface = the always-dark branded summary card background
+      inverseSurface: AppColors.navy,
       onInverseSurface: AppColors.darkText,
       inversePrimary: AppColors.amberDk,
     );
@@ -52,12 +54,13 @@ abstract final class AppTheme {
     return ThemeData(
       useMaterial3: true,
       colorScheme: colorScheme,
-      scaffoldBackgroundColor: AppColors.lightBg,
-      cardColor: AppColors.lightSurface,
+      // scaffoldBackgroundColor = page canvas (beige)
+      scaffoldBackgroundColor: AppColors.lightSurface,
+      cardColor: AppColors.lightBg,
       dividerColor: AppColors.lightLine,
       textTheme: textTheme,
       appBarTheme: AppBarTheme(
-        backgroundColor: AppColors.lightBg,
+        backgroundColor: AppColors.lightSurface,
         foregroundColor: AppColors.lightText,
         elevation: 0,
         titleTextStyle: GoogleFonts.spaceGrotesk(
@@ -132,7 +135,8 @@ abstract final class AppTheme {
       outline: AppColors.darkLine,
       outlineVariant: AppColors.darkLine,
       shadow: Colors.black,
-      inverseSurface: AppColors.lightSurface,
+      // inverseSurface = the always-light branded summary card background
+      inverseSurface: AppColors.lightBg,
       onInverseSurface: AppColors.lightText,
       inversePrimary: AppColors.amberDk,
     );

--- a/lib/features/menu/full_screen_menu_page.dart
+++ b/lib/features/menu/full_screen_menu_page.dart
@@ -216,7 +216,7 @@ class _ExploreGrid extends StatelessWidget {
       physics: const NeverScrollableScrollPhysics(),
       crossAxisSpacing: 12,
       mainAxisSpacing: 12,
-      childAspectRatio: 1.35,
+      childAspectRatio: 1.15,
       children: items
           .map((d) => ExploreCard(data: d, onTap: () => onPageTap(d.id)))
           .toList(),

--- a/lib/features/menu/full_screen_menu_page.dart
+++ b/lib/features/menu/full_screen_menu_page.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:trainlog_app/app/app_colors.dart';
 import 'package:trainlog_app/features/menu/menu_explore_card.dart';
 import 'package:trainlog_app/features/menu/menu_summary_card.dart';
+import 'package:trainlog_app/app/app_colors.dart';
 import 'package:trainlog_app/l10n/app_localizations.dart';
 import 'package:trainlog_app/navigation/nav_models.dart';
 import 'package:trainlog_app/providers/settings_provider.dart';
@@ -11,7 +11,7 @@ import 'package:trainlog_app/providers/trips_provider.dart';
 import 'package:trainlog_app/utils/platform_utils.dart';
 
 /// Full-screen menu replacing the legacy Drawer on Android.
-/// Provides a clean entry point for iOS too (wire up from the iOS shell when ready).
+/// Provides a clean entry point for iOS (wire up from the iOS shell when ready).
 class FullScreenMenuPage extends StatelessWidget {
   final VoidCallback onClose;
   final VoidCallback onSettingsTap;
@@ -31,24 +31,15 @@ class FullScreenMenuPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final loc = AppLocalizations.of(context)!;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
-
-    // Reversed from usual: the page background is the "surface" tone (beige in
-    // light, deep dark in dark) so that white/elevated cards pop above it.
-    final scaffoldBg = isDark ? AppColors.darkBg : AppColors.lightSurface;
 
     return Scaffold(
-      backgroundColor: scaffoldBg,
+      // Uses the theme's scaffoldBackgroundColor directly (beige in light,
+      // deep dark in dark — set correctly in AppTheme).
       body: SafeArea(
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            _TopBar(
-              onClose: onClose,
-              onSettings: onSettingsTap,
-              loc: loc,
-              isDark: isDark,
-            ),
+            _TopBar(onClose: onClose, onSettings: onSettingsTap, loc: loc),
             Expanded(
               child: SingleChildScrollView(
                 padding: const EdgeInsets.symmetric(horizontal: 16),
@@ -58,15 +49,14 @@ class FullScreenMenuPage extends StatelessWidget {
                     const SizedBox(height: 8),
                     const MenuSummaryCard(),
                     const SizedBox(height: 24),
-                    _SectionHeader(label: loc.menuExploreSectionTitle, isDark: isDark),
+                    _SectionHeader(label: loc.menuExploreSectionTitle),
                     const SizedBox(height: 12),
                     _ExploreGrid(onPageTap: onPageTap, loc: loc),
                     const SizedBox(height: 24),
-                    _SectionHeader(label: loc.menuMenuSectionTitle, isDark: isDark),
+                    _SectionHeader(label: loc.menuMenuSectionTitle),
                     const SizedBox(height: 8),
                     _MenuBlock(
                       loc: loc,
-                      isDark: isDark,
                       onInboxTap: onInboxTap,
                       onTrainlogStatusTap: onTrainlogStatusTap,
                       onAboutTap: () => onPageTap(AppPageId.about),
@@ -99,21 +89,17 @@ class _TopBar extends StatelessWidget {
   final VoidCallback onClose;
   final VoidCallback onSettings;
   final AppLocalizations loc;
-  final bool isDark;
 
   const _TopBar({
     required this.onClose,
     required this.onSettings,
     required this.loc,
-    required this.isDark,
   });
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final btnBg = isDark ? AppColors.darkSurface : AppColors.lightBg;
-    final btnFg = isDark ? AppColors.darkText : AppColors.lightText;
-    final borderColor = isDark ? AppColors.darkLine : AppColors.lightLine;
+    final cs = theme.colorScheme;
 
     Widget squareBtn({required IconData icon, required VoidCallback onTap, String? tooltip}) {
       return Tooltip(
@@ -125,11 +111,11 @@ class _TopBar extends StatelessWidget {
             width: 38,
             height: 38,
             decoration: BoxDecoration(
-              color: btnBg,
+              color: cs.surface,
               borderRadius: BorderRadius.circular(10),
-              border: Border.all(color: borderColor, width: 1),
+              border: Border.all(color: cs.outlineVariant, width: 1),
             ),
-            child: Icon(icon, color: btnFg, size: 20),
+            child: Icon(icon, color: cs.onSurface, size: 20),
           ),
         ),
       );
@@ -166,9 +152,8 @@ class _TopBar extends StatelessWidget {
 
 class _SectionHeader extends StatelessWidget {
   final String label;
-  final bool isDark;
 
-  const _SectionHeader({required this.label, required this.isDark});
+  const _SectionHeader({required this.label});
 
   @override
   Widget build(BuildContext context) {
@@ -178,7 +163,7 @@ class _SectionHeader extends StatelessWidget {
         fontSize: 11,
         fontWeight: FontWeight.w700,
         letterSpacing: 1.2,
-        color: isDark ? AppColors.darkText3 : AppColors.lightText3,
+        color: Theme.of(context).colorScheme.onSurfaceVariant,
       ),
     );
   }
@@ -243,7 +228,6 @@ class _ExploreGrid extends StatelessWidget {
 
 class _MenuBlock extends StatelessWidget {
   final AppLocalizations loc;
-  final bool isDark;
   final VoidCallback onInboxTap;
   final VoidCallback onTrainlogStatusTap;
   final VoidCallback onAboutTap;
@@ -251,7 +235,6 @@ class _MenuBlock extends StatelessWidget {
 
   const _MenuBlock({
     required this.loc,
-    required this.isDark,
     required this.onInboxTap,
     required this.onTrainlogStatusTap,
     required this.onAboutTap,
@@ -260,11 +243,7 @@ class _MenuBlock extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final blockBg = isDark ? AppColors.darkSurface : AppColors.lightBg;
-    final borderColor = isDark ? AppColors.darkLine : AppColors.lightLine;
-    final chevronColor = isDark ? AppColors.darkText3 : AppColors.lightText3;
-    final textColor = isDark ? AppColors.darkText : AppColors.lightText;
-    final errorColor = isDark ? AppColors.errorDark : AppColors.errorLight;
+    final cs = Theme.of(context).colorScheme;
 
     final items = <_MenuItemData>[
       _MenuItemData(
@@ -287,9 +266,9 @@ class _MenuBlock extends StatelessWidget {
       ),
       _MenuItemData(
         icon: AdaptiveIcons.logout,
-        iconBg: errorColor,
+        iconBg: cs.error,
         label: loc.logoutButton,
-        labelColor: errorColor,
+        labelColor: cs.error,
         onTap: onLogout,
         isDestructive: true,
       ),
@@ -297,18 +276,15 @@ class _MenuBlock extends StatelessWidget {
 
     return Container(
       decoration: BoxDecoration(
-        color: blockBg,
+        color: cs.surface,
         borderRadius: BorderRadius.circular(14),
-        border: Border.all(color: borderColor, width: 1),
+        border: Border.all(color: cs.outlineVariant, width: 1),
       ),
       child: Column(
         children: [
           for (int i = 0; i < items.length; i++) ...[
             _MenuTile(
               data: items[i],
-              isDark: isDark,
-              textColor: textColor,
-              chevronColor: chevronColor,
               isFirst: i == 0,
               isLast: i == items.length - 1,
             ),
@@ -316,9 +292,9 @@ class _MenuBlock extends StatelessWidget {
               Divider(
                 height: 1,
                 thickness: 1,
-                indent: 16 + 36 + 12, // align with label start
+                indent: 16 + 28 + 12, // align with label start
                 endIndent: 0,
-                color: borderColor,
+                color: cs.outlineVariant,
               ),
           ],
         ],
@@ -347,24 +323,19 @@ class _MenuItemData {
 
 class _MenuTile extends StatelessWidget {
   final _MenuItemData data;
-  final bool isDark;
-  final Color textColor;
-  final Color chevronColor;
   final bool isFirst;
   final bool isLast;
 
   const _MenuTile({
     required this.data,
-    required this.isDark,
-    required this.textColor,
-    required this.chevronColor,
     required this.isFirst,
     required this.isLast,
   });
 
   @override
   Widget build(BuildContext context) {
-    final resolvedTextColor = data.labelColor ?? textColor;
+    final cs = Theme.of(context).colorScheme;
+    final resolvedTextColor = data.labelColor ?? cs.onSurface;
 
     return InkWell(
       onTap: data.onTap,
@@ -376,8 +347,6 @@ class _MenuTile extends StatelessWidget {
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
         child: Row(
           children: [
-            // Coloured square icon background — deliberately smaller than
-            // the Explore grid icons to match the list-item visual weight.
             Container(
               width: 28,
               height: 28,
@@ -399,7 +368,7 @@ class _MenuTile extends StatelessWidget {
               ),
             ),
             if (!data.isDestructive)
-              Icon(Icons.chevron_right, size: 20, color: chevronColor),
+              Icon(Icons.chevron_right, size: 20, color: cs.onSurfaceVariant),
           ],
         ),
       ),

--- a/lib/features/menu/full_screen_menu_page.dart
+++ b/lib/features/menu/full_screen_menu_page.dart
@@ -57,46 +57,7 @@ class FullScreenMenuPage extends StatelessWidget {
                     const SizedBox(height: 24),
                     _SectionHeader(label: loc.menuMenuSectionTitle),
                     const SizedBox(height: 8),
-                    Builder(builder: (context) {
-                      final cs = Theme.of(context).colorScheme;
-                      return MenuBlock(items: [
-                        MenuItemData(
-                          icon: AdaptiveIcons.inbox,
-                          iconBg: AppColors.amber,
-                          label: loc.menuInboxTitle,
-                          onTap: onInboxTap,
-                        ),
-                        MenuItemData(
-                          icon: AdaptiveIcons.ok,
-                          iconBg: AppColors.blue,
-                          label: loc.trainglogStatusPageTitle,
-                          onTap: onTrainlogStatusTap,
-                        ),
-                        MenuItemData(
-                          icon: AdaptiveIcons.info,
-                          iconBg: AppColors.navy,
-                          label: loc.menuAboutTitle,
-                          onTap: () => onPageTap(AppPageId.about),
-                        ),
-                        MenuItemData(
-                          icon: AdaptiveIcons.logout,
-                          iconBg: cs.error,
-                          label: loc.logoutButton,
-                          labelColor: cs.error,
-                          isDestructive: true,
-                          onTap: () async {
-                            final settings = context.read<SettingsProvider>();
-                            final trips = context.read<TripsProvider>();
-                            final scaffMsg = ScaffoldMessenger.of(context);
-                            onClose();
-                            await context.read<TrainlogProvider>().logout(settings, trips);
-                            scaffMsg.showSnackBar(
-                              SnackBar(content: Text(loc.loggedOut)),
-                            );
-                          },
-                        ),
-                      ]);
-                    }),
+                    _menuBlockBuilder(loc),
                     const SizedBox(height: 32),
                   ],
                 ),
@@ -106,6 +67,49 @@ class FullScreenMenuPage extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  Builder _menuBlockBuilder(AppLocalizations loc) {
+    return Builder(builder: (context) {
+      final cs = Theme.of(context).colorScheme;
+      return MenuBlock(items: [
+        MenuItemData(
+          icon: AdaptiveIcons.inbox,
+          iconBg: AppColors.amber,
+          label: loc.menuInboxTitle,
+          onTap: onInboxTap,
+        ),
+        MenuItemData(
+          icon: AdaptiveIcons.ok,
+          iconBg: AppColors.blue,
+          label: loc.trainglogStatusPageTitle,
+          onTap: onTrainlogStatusTap,
+        ),
+        MenuItemData(
+          icon: AdaptiveIcons.info,
+          iconBg: AppColors.navy,
+          label: loc.menuAboutTitle,
+          onTap: () => onPageTap(AppPageId.about),
+        ),
+        MenuItemData(
+          icon: AdaptiveIcons.logout,
+          iconBg: cs.error,
+          label: loc.logoutButton,
+          labelColor: cs.error,
+          isDestructive: true,
+          onTap: () async {
+            final settings = context.read<SettingsProvider>();
+            final trips = context.read<TripsProvider>();
+            final scaffMsg = ScaffoldMessenger.of(context);
+            onClose();
+            await context.read<TrainlogProvider>().logout(settings, trips);
+            scaffMsg.showSnackBar(
+              SnackBar(content: Text(loc.loggedOut)),
+            );
+          },
+        ),
+      ]);
+    });
   }
 }
 

--- a/lib/features/menu/full_screen_menu_page.dart
+++ b/lib/features/menu/full_screen_menu_page.dart
@@ -376,15 +376,16 @@ class _MenuTile extends StatelessWidget {
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
         child: Row(
           children: [
-            // Coloured square icon background
+            // Coloured square icon background — deliberately smaller than
+            // the Explore grid icons to match the list-item visual weight.
             Container(
-              width: 36,
-              height: 36,
+              width: 28,
+              height: 28,
               decoration: BoxDecoration(
                 color: data.iconBg,
-                borderRadius: BorderRadius.circular(8),
+                borderRadius: BorderRadius.circular(6),
               ),
-              child: Icon(data.icon, color: Colors.white, size: 18),
+              child: Icon(data.icon, color: Colors.white, size: 15),
             ),
             const SizedBox(width: 12),
             Expanded(

--- a/lib/features/menu/full_screen_menu_page.dart
+++ b/lib/features/menu/full_screen_menu_page.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart';
-import 'package:google_fonts/google_fonts.dart';
 import 'package:provider/provider.dart';
 import 'package:trainlog_app/app/app_colors.dart';
+import 'package:trainlog_app/features/menu/menu_explore_card.dart';
+import 'package:trainlog_app/features/menu/menu_summary_card.dart';
 import 'package:trainlog_app/l10n/app_localizations.dart';
 import 'package:trainlog_app/navigation/nav_models.dart';
 import 'package:trainlog_app/providers/settings_provider.dart';
@@ -10,9 +10,9 @@ import 'package:trainlog_app/providers/trainlog_provider.dart';
 import 'package:trainlog_app/providers/trips_provider.dart';
 import 'package:trainlog_app/utils/platform_utils.dart';
 
-/// A full-screen menu that replaces the legacy Drawer on Android and provides
-/// a future entry point for iOS.
-class FullScreenMenuPage extends StatefulWidget {
+/// Full-screen menu replacing the legacy Drawer on Android.
+/// Provides a clean entry point for iOS too (wire up from the iOS shell when ready).
+class FullScreenMenuPage extends StatelessWidget {
   final VoidCallback onClose;
   final VoidCallback onSettingsTap;
   final void Function(AppPageId id) onPageTap;
@@ -29,27 +29,25 @@ class FullScreenMenuPage extends StatefulWidget {
   });
 
   @override
-  State<FullScreenMenuPage> createState() => _FullScreenMenuPageState();
-}
-
-class _FullScreenMenuPageState extends State<FullScreenMenuPage> {
-  @override
   Widget build(BuildContext context) {
     final loc = AppLocalizations.of(context)!;
-    final theme = Theme.of(context);
-    final isDark = theme.brightness == Brightness.dark;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
+    // Reversed from usual: the page background is the "surface" tone (beige in
+    // light, deep dark in dark) so that white/elevated cards pop above it.
+    final scaffoldBg = isDark ? AppColors.darkBg : AppColors.lightSurface;
 
     return Scaffold(
-      backgroundColor: isDark ? AppColors.darkBg : AppColors.lightBg,
+      backgroundColor: scaffoldBg,
       body: SafeArea(
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             _TopBar(
-              onClose: widget.onClose,
-              onSettings: widget.onSettingsTap,
+              onClose: onClose,
+              onSettings: onSettingsTap,
               loc: loc,
-              theme: theme,
+              isDark: isDark,
             ),
             Expanded(
               child: SingleChildScrollView(
@@ -58,32 +56,32 @@ class _FullScreenMenuPageState extends State<FullScreenMenuPage> {
                   crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
                     const SizedBox(height: 8),
-                    _SummaryCard(isDark: isDark, theme: theme),
+                    const MenuSummaryCard(),
                     const SizedBox(height: 24),
-                    _SectionHeader(label: loc.menuExploreSectionTitle, theme: theme),
+                    _SectionHeader(label: loc.menuExploreSectionTitle, isDark: isDark),
                     const SizedBox(height: 12),
-                    _ExploreGrid(onPageTap: widget.onPageTap, loc: loc),
+                    _ExploreGrid(onPageTap: onPageTap, loc: loc),
                     const SizedBox(height: 24),
-                    _SectionHeader(label: loc.menuMenuSectionTitle, theme: theme),
-                    const SizedBox(height: 4),
-                    _MenuList(
+                    _SectionHeader(label: loc.menuMenuSectionTitle, isDark: isDark),
+                    const SizedBox(height: 8),
+                    _MenuBlock(
                       loc: loc,
-                      theme: theme,
-                      onInboxTap: widget.onInboxTap,
-                      onTrainlogStatusTap: widget.onTrainlogStatusTap,
-                      onAboutTap: () => widget.onPageTap(AppPageId.about),
+                      isDark: isDark,
+                      onInboxTap: onInboxTap,
+                      onTrainlogStatusTap: onTrainlogStatusTap,
+                      onAboutTap: () => onPageTap(AppPageId.about),
                       onLogout: () async {
                         final settings = context.read<SettingsProvider>();
                         final trips = context.read<TripsProvider>();
                         final scaffMsg = ScaffoldMessenger.of(context);
-                        widget.onClose();
+                        onClose();
                         await context.read<TrainlogProvider>().logout(settings, trips);
                         scaffMsg.showSnackBar(
                           SnackBar(content: Text(loc.loggedOut)),
                         );
                       },
                     ),
-                    const SizedBox(height: 24),
+                    const SizedBox(height: 32),
                   ],
                 ),
               ),
@@ -95,197 +93,71 @@ class _FullScreenMenuPageState extends State<FullScreenMenuPage> {
   }
 }
 
-// ── Top bar ──────────────────────────────────────────────────────────────────
+// ── Top bar ───────────────────────────────────────────────────────────────────
 
 class _TopBar extends StatelessWidget {
   final VoidCallback onClose;
   final VoidCallback onSettings;
   final AppLocalizations loc;
-  final ThemeData theme;
+  final bool isDark;
 
   const _TopBar({
     required this.onClose,
     required this.onSettings,
     required this.loc,
-    required this.theme,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-      child: Row(
-        children: [
-          IconButton(
-            icon: const Icon(Icons.arrow_back),
-            tooltip: MaterialLocalizations.of(context).backButtonTooltip,
-            onPressed: onClose,
-          ),
-          Expanded(
-            child: Text(
-              loc.menuYouTitle,
-              textAlign: TextAlign.center,
-              style: theme.textTheme.titleLarge?.copyWith(
-                fontWeight: FontWeight.w600,
-              ),
-            ),
-          ),
-          IconButton(
-            icon: const Icon(Icons.settings_outlined),
-            tooltip: loc.menuSettingsTitle,
-            onPressed: onSettings,
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-// ── Summary card ─────────────────────────────────────────────────────────────
-
-class _SummaryCard extends StatelessWidget {
-  final bool isDark;
-  final ThemeData theme;
-
-  const _SummaryCard({required this.isDark, required this.theme});
-
-  @override
-  Widget build(BuildContext context) {
-    final auth = context.watch<TrainlogProvider>();
-    final trips = context.watch<TripsProvider>();
-
-    final cardBg = isDark ? AppColors.darkSurface : AppColors.lightSurface;
-
-    return Container(
-      decoration: BoxDecoration(
-        color: cardBg,
-        borderRadius: BorderRadius.circular(16),
-      ),
-      padding: const EdgeInsets.all(16),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          _AppIcon(),
-          const SizedBox(width: 16),
-          Expanded(
-            child: _SummaryText(
-              username: auth.username ?? '',
-              instanceUrl: auth.instanceUrl,
-              trips: trips,
-              theme: theme,
-              isDark: isDark,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _AppIcon extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      width: 56,
-      height: 56,
-      decoration: const BoxDecoration(
-        color: AppColors.navy,
-        shape: BoxShape.circle,
-      ),
-      padding: const EdgeInsets.all(4),
-      child: Container(
-        decoration: BoxDecoration(
-          color: AppColors.amber,
-          shape: BoxShape.circle,
-        ),
-        padding: const EdgeInsets.all(6),
-        child: SvgPicture.asset(
-          'assets/icon/trainlog_icon_foreground_only.svg',
-          colorFilter: const ColorFilter.mode(AppColors.navy, BlendMode.srcIn),
-        ),
-      ),
-    );
-  }
-}
-
-class _SummaryText extends StatelessWidget {
-  final String username;
-  final String instanceUrl;
-  final TripsProvider trips;
-  final ThemeData theme;
-  final bool isDark;
-
-  const _SummaryText({
-    required this.username,
-    required this.instanceUrl,
-    required this.trips,
-    required this.theme,
     required this.isDark,
   });
 
   @override
   Widget build(BuildContext context) {
-    final textSecondary = isDark ? AppColors.darkText2 : AppColors.lightText2;
+    final theme = Theme.of(context);
+    final btnBg = isDark ? AppColors.darkSurface : AppColors.lightBg;
+    final btnFg = isDark ? AppColors.darkText : AppColors.lightText;
+    final borderColor = isDark ? AppColors.darkLine : AppColors.lightLine;
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          username,
-          style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
-        ),
-        const SizedBox(height: 2),
-        Text(
-          instanceUrl,
-          style: GoogleFonts.spaceMono(
-            fontSize: 11,
-            color: textSecondary,
+    Widget squareBtn({required IconData icon, required VoidCallback onTap, String? tooltip}) {
+      return Tooltip(
+        message: tooltip ?? '',
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(10),
+          child: Container(
+            width: 38,
+            height: 38,
+            decoration: BoxDecoration(
+              color: btnBg,
+              borderRadius: BorderRadius.circular(10),
+              border: Border.all(color: borderColor, width: 1),
+            ),
+            child: Icon(icon, color: btnFg, size: 20),
           ),
-          overflow: TextOverflow.ellipsis,
         ),
-        const SizedBox(height: 4),
-        _TripCountText(trips: trips, theme: theme, textSecondary: textSecondary),
-      ],
-    );
-  }
-}
+      );
+    }
 
-class _TripCountText extends StatefulWidget {
-  final TripsProvider trips;
-  final ThemeData theme;
-  final Color textSecondary;
-
-  const _TripCountText({
-    required this.trips,
-    required this.theme,
-    required this.textSecondary,
-  });
-
-  @override
-  State<_TripCountText> createState() => _TripCountTextState();
-}
-
-class _TripCountTextState extends State<_TripCountText> {
-  int? _count;
-
-  @override
-  void initState() {
-    super.initState();
-    _loadCount();
-  }
-
-  Future<void> _loadCount() async {
-    final c = await widget.trips.repository?.count();
-    if (mounted) setState(() => _count = c);
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final loc = AppLocalizations.of(context)!;
-    if (_count == null) return const SizedBox.shrink();
-    return Text(
-      loc.menuTripCount(_count!),
-      style: widget.theme.textTheme.bodySmall?.copyWith(color: widget.textSecondary),
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+      child: Row(
+        children: [
+          squareBtn(
+            icon: Icons.keyboard_arrow_down,
+            onTap: onClose,
+            tooltip: MaterialLocalizations.of(context).closeButtonTooltip,
+          ),
+          Expanded(
+            child: Text(
+              loc.menuYouTitle,
+              textAlign: TextAlign.center,
+              style: theme.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w700),
+            ),
+          ),
+          squareBtn(
+            icon: Icons.settings_outlined,
+            onTap: onSettings,
+            tooltip: loc.menuSettingsTitle,
+          ),
+        ],
+      ),
     );
   }
 }
@@ -294,16 +166,16 @@ class _TripCountTextState extends State<_TripCountText> {
 
 class _SectionHeader extends StatelessWidget {
   final String label;
-  final ThemeData theme;
+  final bool isDark;
 
-  const _SectionHeader({required this.label, required this.theme});
+  const _SectionHeader({required this.label, required this.isDark});
 
   @override
   Widget build(BuildContext context) {
-    final isDark = theme.brightness == Brightness.dark;
     return Text(
       label,
-      style: theme.textTheme.labelSmall?.copyWith(
+      style: TextStyle(
+        fontSize: 11,
         fontWeight: FontWeight.w700,
         letterSpacing: 1.2,
         color: isDark ? AppColors.darkText3 : AppColors.lightText3,
@@ -312,7 +184,7 @@ class _SectionHeader extends StatelessWidget {
   }
 }
 
-// ── Explore grid ──────────────────────────────────────────────────────────────
+// ── Explore 2×2 grid ──────────────────────────────────────────────────────────
 
 class _ExploreGrid extends StatelessWidget {
   final void Function(AppPageId id) onPageTap;
@@ -323,28 +195,28 @@ class _ExploreGrid extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final items = [
-      _ExploreCardData(
+      ExploreCardData(
         id: AppPageId.dashboard,
         icon: AdaptiveIcons.dashboard,
         label: loc.menuDashboardTitle,
         color: AppColors.amber,
         subtitle: null,
       ),
-      _ExploreCardData(
+      ExploreCardData(
         id: AppPageId.tags,
         icon: AdaptiveIcons.tags,
         label: loc.menuTagsTitle,
         color: AppColors.blue,
         subtitle: null,
       ),
-      _ExploreCardData(
+      ExploreCardData(
         id: AppPageId.tickets,
         icon: AdaptiveIcons.tickets,
         label: loc.menuTicketsTitle,
         color: AppColors.early,
         subtitle: null,
       ),
-      _ExploreCardData(
+      ExploreCardData(
         id: AppPageId.smartPrerecorder,
         icon: AdaptiveIcons.smartPrerecorder,
         label: loc.menuSmartPrerecorderTitle,
@@ -359,123 +231,27 @@ class _ExploreGrid extends StatelessWidget {
       physics: const NeverScrollableScrollPhysics(),
       crossAxisSpacing: 12,
       mainAxisSpacing: 12,
-      childAspectRatio: 1.4,
+      childAspectRatio: 1.35,
       children: items
-          .map((d) => _ExploreCard(data: d, onTap: () => onPageTap(d.id)))
+          .map((d) => ExploreCard(data: d, onTap: () => onPageTap(d.id)))
           .toList(),
     );
   }
 }
 
-class _ExploreCardData {
-  final AppPageId id;
-  final IconData icon;
-  final String label;
-  final Color color;
-  final _ExploreSubtitle? subtitle;
+// ── Menu block (single grouped list) ─────────────────────────────────────────
 
-  const _ExploreCardData({
-    required this.id,
-    required this.icon,
-    required this.label,
-    required this.color,
-    required this.subtitle,
-  });
-}
-
-class _ExploreSubtitle {
-  final String number;
-  final Color numberColor;
-  final String text;
-
-  const _ExploreSubtitle({
-    required this.number,
-    required this.numberColor,
-    required this.text,
-  });
-}
-
-class _ExploreCard extends StatelessWidget {
-  final _ExploreCardData data;
-  final VoidCallback onTap;
-
-  const _ExploreCard({required this.data, required this.onTap});
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final isDark = theme.brightness == Brightness.dark;
-    final cardBg = isDark ? AppColors.darkSurface : AppColors.lightSurface;
-
-    return GestureDetector(
-      onTap: onTap,
-      child: Container(
-        decoration: BoxDecoration(
-          color: cardBg,
-          borderRadius: BorderRadius.circular(14),
-        ),
-        padding: const EdgeInsets.all(14),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Container(
-              width: 36,
-              height: 36,
-              decoration: BoxDecoration(
-                color: data.color.withOpacity(0.15),
-                borderRadius: BorderRadius.circular(10),
-              ),
-              child: Icon(data.icon, color: data.color, size: 20),
-            ),
-            const Spacer(),
-            Text(
-              data.label,
-              style: theme.textTheme.bodyMedium?.copyWith(
-                fontWeight: FontWeight.w600,
-              ),
-            ),
-            if (data.subtitle != null) ...[
-              const SizedBox(height: 2),
-              RichText(
-                text: TextSpan(
-                  children: [
-                    TextSpan(
-                      text: data.subtitle!.number,
-                      style: theme.textTheme.bodySmall?.copyWith(
-                        color: data.subtitle!.numberColor,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                    TextSpan(
-                      text: ' ${data.subtitle!.text}',
-                      style: theme.textTheme.bodySmall?.copyWith(
-                        color: isDark ? AppColors.darkText2 : AppColors.lightText2,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ],
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-// ── Menu list ─────────────────────────────────────────────────────────────────
-
-class _MenuList extends StatelessWidget {
+class _MenuBlock extends StatelessWidget {
   final AppLocalizations loc;
-  final ThemeData theme;
+  final bool isDark;
   final VoidCallback onInboxTap;
   final VoidCallback onTrainlogStatusTap;
   final VoidCallback onAboutTap;
   final VoidCallback onLogout;
 
-  const _MenuList({
+  const _MenuBlock({
     required this.loc,
-    required this.theme,
+    required this.isDark,
     required this.onInboxTap,
     required this.onTrainlogStatusTap,
     required this.onAboutTap,
@@ -484,79 +260,148 @@ class _MenuList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isDark = theme.brightness == Brightness.dark;
-    final tileColor = isDark ? AppColors.darkSurface : AppColors.lightSurface;
+    final blockBg = isDark ? AppColors.darkSurface : AppColors.lightBg;
+    final borderColor = isDark ? AppColors.darkLine : AppColors.lightLine;
+    final chevronColor = isDark ? AppColors.darkText3 : AppColors.lightText3;
+    final textColor = isDark ? AppColors.darkText : AppColors.lightText;
     final errorColor = isDark ? AppColors.errorDark : AppColors.errorLight;
 
-    Widget tile({
-      required IconData icon,
-      required String label,
-      required VoidCallback onTap,
-      Color? iconColor,
-      Color? labelColor,
-    }) {
-      return Container(
-        margin: const EdgeInsets.symmetric(vertical: 3),
-        decoration: BoxDecoration(
-          color: tileColor,
-          borderRadius: BorderRadius.circular(12),
-        ),
-        child: ListTile(
-          leading: Icon(icon, color: iconColor),
-          title: Text(
-            label,
-            style: theme.textTheme.bodyMedium?.copyWith(
-              fontWeight: FontWeight.w500,
-              color: labelColor,
-            ),
-          ),
-          trailing: Icon(
-            Icons.chevron_right,
-            color: isDark ? AppColors.darkText3 : AppColors.lightText3,
-          ),
-          onTap: onTap,
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-        ),
-      );
-    }
+    final items = <_MenuItemData>[
+      _MenuItemData(
+        icon: AdaptiveIcons.inbox,
+        iconBg: AppColors.amber,
+        label: loc.menuInboxTitle,
+        onTap: onInboxTap,
+      ),
+      _MenuItemData(
+        icon: AdaptiveIcons.ok,
+        iconBg: AppColors.blue,
+        label: loc.trainglogStatusPageTitle,
+        onTap: onTrainlogStatusTap,
+      ),
+      _MenuItemData(
+        icon: AdaptiveIcons.info,
+        iconBg: AppColors.navy,
+        label: loc.menuAboutTitle,
+        onTap: onAboutTap,
+      ),
+      _MenuItemData(
+        icon: AdaptiveIcons.logout,
+        iconBg: errorColor,
+        label: loc.logoutButton,
+        labelColor: errorColor,
+        onTap: onLogout,
+        isDestructive: true,
+      ),
+    ];
 
-    return Column(
-      children: [
-        tile(
-          icon: AdaptiveIcons.inbox,
-          label: loc.menuInboxTitle,
-          onTap: onInboxTap,
-        ),
-        tile(
-          icon: AdaptiveIcons.ok,
-          label: loc.trainglogStatusPageTitle,
-          onTap: onTrainlogStatusTap,
-        ),
-        tile(
-          icon: AdaptiveIcons.info,
-          label: loc.menuAboutTitle,
-          onTap: onAboutTap,
-        ),
-        Container(
-          margin: const EdgeInsets.symmetric(vertical: 3),
-          decoration: BoxDecoration(
-            color: tileColor,
-            borderRadius: BorderRadius.circular(12),
-          ),
-          child: ListTile(
-            leading: Icon(AdaptiveIcons.logout, color: errorColor),
-            title: Text(
-              loc.logoutButton,
-              style: theme.textTheme.bodyMedium?.copyWith(
-                fontWeight: FontWeight.w500,
-                color: errorColor,
+    return Container(
+      decoration: BoxDecoration(
+        color: blockBg,
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: borderColor, width: 1),
+      ),
+      child: Column(
+        children: [
+          for (int i = 0; i < items.length; i++) ...[
+            _MenuTile(
+              data: items[i],
+              isDark: isDark,
+              textColor: textColor,
+              chevronColor: chevronColor,
+              isFirst: i == 0,
+              isLast: i == items.length - 1,
+            ),
+            if (i < items.length - 1)
+              Divider(
+                height: 1,
+                thickness: 1,
+                indent: 16 + 36 + 12, // align with label start
+                endIndent: 0,
+                color: borderColor,
+              ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _MenuItemData {
+  final IconData icon;
+  final Color iconBg;
+  final String label;
+  final Color? labelColor;
+  final VoidCallback onTap;
+  final bool isDestructive;
+
+  const _MenuItemData({
+    required this.icon,
+    required this.iconBg,
+    required this.label,
+    required this.onTap,
+    this.labelColor,
+    this.isDestructive = false,
+  });
+}
+
+class _MenuTile extends StatelessWidget {
+  final _MenuItemData data;
+  final bool isDark;
+  final Color textColor;
+  final Color chevronColor;
+  final bool isFirst;
+  final bool isLast;
+
+  const _MenuTile({
+    required this.data,
+    required this.isDark,
+    required this.textColor,
+    required this.chevronColor,
+    required this.isFirst,
+    required this.isLast,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final resolvedTextColor = data.labelColor ?? textColor;
+
+    return InkWell(
+      onTap: data.onTap,
+      borderRadius: BorderRadius.vertical(
+        top: isFirst ? const Radius.circular(14) : Radius.zero,
+        bottom: isLast ? const Radius.circular(14) : Radius.zero,
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Row(
+          children: [
+            // Coloured square icon background
+            Container(
+              width: 36,
+              height: 36,
+              decoration: BoxDecoration(
+                color: data.iconBg,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Icon(data.icon, color: Colors.white, size: 18),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                data.label,
+                style: TextStyle(
+                  fontSize: 15,
+                  fontWeight: FontWeight.w500,
+                  color: resolvedTextColor,
+                ),
               ),
             ),
-            onTap: onLogout,
-            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-          ),
+            if (!data.isDestructive)
+              Icon(Icons.chevron_right, size: 20, color: chevronColor),
+          ],
         ),
-      ],
+      ),
     );
   }
 }

--- a/lib/features/menu/full_screen_menu_page.dart
+++ b/lib/features/menu/full_screen_menu_page.dart
@@ -240,16 +240,21 @@ class _ExploreGrid extends StatelessWidget {
       ),
     ];
 
-    return GridView.count(
-      crossAxisCount: 2,
-      shrinkWrap: true,
-      physics: const NeverScrollableScrollPhysics(),
-      crossAxisSpacing: 12,
-      mainAxisSpacing: 12,
-      childAspectRatio: 1.15,
-      children: items
-          .map((d) => ExploreCard(data: d, onTap: () => onPageTap(d.id)))
-          .toList(),
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 520),
+        child: GridView.count(
+          crossAxisCount: 2,
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+          crossAxisSpacing: 12,
+          mainAxisSpacing: 12,
+          childAspectRatio: 1.15,
+          children: items
+              .map((d) => ExploreCard(data: d, onTap: () => onPageTap(d.id)))
+              .toList(),
+        ),
+      ),
     );
   }
 }

--- a/lib/features/menu/full_screen_menu_page.dart
+++ b/lib/features/menu/full_screen_menu_page.dart
@@ -1,0 +1,562 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:provider/provider.dart';
+import 'package:trainlog_app/app/app_colors.dart';
+import 'package:trainlog_app/l10n/app_localizations.dart';
+import 'package:trainlog_app/navigation/nav_models.dart';
+import 'package:trainlog_app/providers/settings_provider.dart';
+import 'package:trainlog_app/providers/trainlog_provider.dart';
+import 'package:trainlog_app/providers/trips_provider.dart';
+import 'package:trainlog_app/utils/platform_utils.dart';
+
+/// A full-screen menu that replaces the legacy Drawer on Android and provides
+/// a future entry point for iOS.
+class FullScreenMenuPage extends StatefulWidget {
+  final VoidCallback onClose;
+  final VoidCallback onSettingsTap;
+  final void Function(AppPageId id) onPageTap;
+  final VoidCallback onInboxTap;
+  final VoidCallback onTrainlogStatusTap;
+
+  const FullScreenMenuPage({
+    super.key,
+    required this.onClose,
+    required this.onSettingsTap,
+    required this.onPageTap,
+    required this.onInboxTap,
+    required this.onTrainlogStatusTap,
+  });
+
+  @override
+  State<FullScreenMenuPage> createState() => _FullScreenMenuPageState();
+}
+
+class _FullScreenMenuPageState extends State<FullScreenMenuPage> {
+  @override
+  Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+
+    return Scaffold(
+      backgroundColor: isDark ? AppColors.darkBg : AppColors.lightBg,
+      body: SafeArea(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            _TopBar(
+              onClose: widget.onClose,
+              onSettings: widget.onSettingsTap,
+              loc: loc,
+              theme: theme,
+            ),
+            Expanded(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    const SizedBox(height: 8),
+                    _SummaryCard(isDark: isDark, theme: theme),
+                    const SizedBox(height: 24),
+                    _SectionHeader(label: loc.menuExploreSectionTitle, theme: theme),
+                    const SizedBox(height: 12),
+                    _ExploreGrid(onPageTap: widget.onPageTap, loc: loc),
+                    const SizedBox(height: 24),
+                    _SectionHeader(label: loc.menuMenuSectionTitle, theme: theme),
+                    const SizedBox(height: 4),
+                    _MenuList(
+                      loc: loc,
+                      theme: theme,
+                      onInboxTap: widget.onInboxTap,
+                      onTrainlogStatusTap: widget.onTrainlogStatusTap,
+                      onAboutTap: () => widget.onPageTap(AppPageId.about),
+                      onLogout: () async {
+                        final settings = context.read<SettingsProvider>();
+                        final trips = context.read<TripsProvider>();
+                        final scaffMsg = ScaffoldMessenger.of(context);
+                        widget.onClose();
+                        await context.read<TrainlogProvider>().logout(settings, trips);
+                        scaffMsg.showSnackBar(
+                          SnackBar(content: Text(loc.loggedOut)),
+                        );
+                      },
+                    ),
+                    const SizedBox(height: 24),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ── Top bar ──────────────────────────────────────────────────────────────────
+
+class _TopBar extends StatelessWidget {
+  final VoidCallback onClose;
+  final VoidCallback onSettings;
+  final AppLocalizations loc;
+  final ThemeData theme;
+
+  const _TopBar({
+    required this.onClose,
+    required this.onSettings,
+    required this.loc,
+    required this.theme,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      child: Row(
+        children: [
+          IconButton(
+            icon: const Icon(Icons.arrow_back),
+            tooltip: MaterialLocalizations.of(context).backButtonTooltip,
+            onPressed: onClose,
+          ),
+          Expanded(
+            child: Text(
+              loc.menuYouTitle,
+              textAlign: TextAlign.center,
+              style: theme.textTheme.titleLarge?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+          IconButton(
+            icon: const Icon(Icons.settings_outlined),
+            tooltip: loc.menuSettingsTitle,
+            onPressed: onSettings,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ── Summary card ─────────────────────────────────────────────────────────────
+
+class _SummaryCard extends StatelessWidget {
+  final bool isDark;
+  final ThemeData theme;
+
+  const _SummaryCard({required this.isDark, required this.theme});
+
+  @override
+  Widget build(BuildContext context) {
+    final auth = context.watch<TrainlogProvider>();
+    final trips = context.watch<TripsProvider>();
+
+    final cardBg = isDark ? AppColors.darkSurface : AppColors.lightSurface;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: cardBg,
+        borderRadius: BorderRadius.circular(16),
+      ),
+      padding: const EdgeInsets.all(16),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          _AppIcon(),
+          const SizedBox(width: 16),
+          Expanded(
+            child: _SummaryText(
+              username: auth.username ?? '',
+              instanceUrl: auth.instanceUrl,
+              trips: trips,
+              theme: theme,
+              isDark: isDark,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AppIcon extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 56,
+      height: 56,
+      decoration: const BoxDecoration(
+        color: AppColors.navy,
+        shape: BoxShape.circle,
+      ),
+      padding: const EdgeInsets.all(4),
+      child: Container(
+        decoration: BoxDecoration(
+          color: AppColors.amber,
+          shape: BoxShape.circle,
+        ),
+        padding: const EdgeInsets.all(6),
+        child: SvgPicture.asset(
+          'assets/icon/trainlog_icon_foreground_only.svg',
+          colorFilter: const ColorFilter.mode(AppColors.navy, BlendMode.srcIn),
+        ),
+      ),
+    );
+  }
+}
+
+class _SummaryText extends StatelessWidget {
+  final String username;
+  final String instanceUrl;
+  final TripsProvider trips;
+  final ThemeData theme;
+  final bool isDark;
+
+  const _SummaryText({
+    required this.username,
+    required this.instanceUrl,
+    required this.trips,
+    required this.theme,
+    required this.isDark,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final textSecondary = isDark ? AppColors.darkText2 : AppColors.lightText2;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          username,
+          style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 2),
+        Text(
+          instanceUrl,
+          style: GoogleFonts.spaceMono(
+            fontSize: 11,
+            color: textSecondary,
+          ),
+          overflow: TextOverflow.ellipsis,
+        ),
+        const SizedBox(height: 4),
+        _TripCountText(trips: trips, theme: theme, textSecondary: textSecondary),
+      ],
+    );
+  }
+}
+
+class _TripCountText extends StatefulWidget {
+  final TripsProvider trips;
+  final ThemeData theme;
+  final Color textSecondary;
+
+  const _TripCountText({
+    required this.trips,
+    required this.theme,
+    required this.textSecondary,
+  });
+
+  @override
+  State<_TripCountText> createState() => _TripCountTextState();
+}
+
+class _TripCountTextState extends State<_TripCountText> {
+  int? _count;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadCount();
+  }
+
+  Future<void> _loadCount() async {
+    final c = await widget.trips.repository?.count();
+    if (mounted) setState(() => _count = c);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
+    if (_count == null) return const SizedBox.shrink();
+    return Text(
+      loc.menuTripCount(_count!),
+      style: widget.theme.textTheme.bodySmall?.copyWith(color: widget.textSecondary),
+    );
+  }
+}
+
+// ── Section header ────────────────────────────────────────────────────────────
+
+class _SectionHeader extends StatelessWidget {
+  final String label;
+  final ThemeData theme;
+
+  const _SectionHeader({required this.label, required this.theme});
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = theme.brightness == Brightness.dark;
+    return Text(
+      label,
+      style: theme.textTheme.labelSmall?.copyWith(
+        fontWeight: FontWeight.w700,
+        letterSpacing: 1.2,
+        color: isDark ? AppColors.darkText3 : AppColors.lightText3,
+      ),
+    );
+  }
+}
+
+// ── Explore grid ──────────────────────────────────────────────────────────────
+
+class _ExploreGrid extends StatelessWidget {
+  final void Function(AppPageId id) onPageTap;
+  final AppLocalizations loc;
+
+  const _ExploreGrid({required this.onPageTap, required this.loc});
+
+  @override
+  Widget build(BuildContext context) {
+    final items = [
+      _ExploreCardData(
+        id: AppPageId.dashboard,
+        icon: AdaptiveIcons.dashboard,
+        label: loc.menuDashboardTitle,
+        color: AppColors.amber,
+        subtitle: null,
+      ),
+      _ExploreCardData(
+        id: AppPageId.tags,
+        icon: AdaptiveIcons.tags,
+        label: loc.menuTagsTitle,
+        color: AppColors.blue,
+        subtitle: null,
+      ),
+      _ExploreCardData(
+        id: AppPageId.tickets,
+        icon: AdaptiveIcons.tickets,
+        label: loc.menuTicketsTitle,
+        color: AppColors.early,
+        subtitle: null,
+      ),
+      _ExploreCardData(
+        id: AppPageId.smartPrerecorder,
+        icon: AdaptiveIcons.smartPrerecorder,
+        label: loc.menuSmartPrerecorderTitle,
+        color: AppColors.violet,
+        subtitle: null,
+      ),
+    ];
+
+    return GridView.count(
+      crossAxisCount: 2,
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      crossAxisSpacing: 12,
+      mainAxisSpacing: 12,
+      childAspectRatio: 1.4,
+      children: items
+          .map((d) => _ExploreCard(data: d, onTap: () => onPageTap(d.id)))
+          .toList(),
+    );
+  }
+}
+
+class _ExploreCardData {
+  final AppPageId id;
+  final IconData icon;
+  final String label;
+  final Color color;
+  final _ExploreSubtitle? subtitle;
+
+  const _ExploreCardData({
+    required this.id,
+    required this.icon,
+    required this.label,
+    required this.color,
+    required this.subtitle,
+  });
+}
+
+class _ExploreSubtitle {
+  final String number;
+  final Color numberColor;
+  final String text;
+
+  const _ExploreSubtitle({
+    required this.number,
+    required this.numberColor,
+    required this.text,
+  });
+}
+
+class _ExploreCard extends StatelessWidget {
+  final _ExploreCardData data;
+  final VoidCallback onTap;
+
+  const _ExploreCard({required this.data, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    final cardBg = isDark ? AppColors.darkSurface : AppColors.lightSurface;
+
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        decoration: BoxDecoration(
+          color: cardBg,
+          borderRadius: BorderRadius.circular(14),
+        ),
+        padding: const EdgeInsets.all(14),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Container(
+              width: 36,
+              height: 36,
+              decoration: BoxDecoration(
+                color: data.color.withOpacity(0.15),
+                borderRadius: BorderRadius.circular(10),
+              ),
+              child: Icon(data.icon, color: data.color, size: 20),
+            ),
+            const Spacer(),
+            Text(
+              data.label,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            if (data.subtitle != null) ...[
+              const SizedBox(height: 2),
+              RichText(
+                text: TextSpan(
+                  children: [
+                    TextSpan(
+                      text: data.subtitle!.number,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: data.subtitle!.numberColor,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    TextSpan(
+                      text: ' ${data.subtitle!.text}',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: isDark ? AppColors.darkText2 : AppColors.lightText2,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ── Menu list ─────────────────────────────────────────────────────────────────
+
+class _MenuList extends StatelessWidget {
+  final AppLocalizations loc;
+  final ThemeData theme;
+  final VoidCallback onInboxTap;
+  final VoidCallback onTrainlogStatusTap;
+  final VoidCallback onAboutTap;
+  final VoidCallback onLogout;
+
+  const _MenuList({
+    required this.loc,
+    required this.theme,
+    required this.onInboxTap,
+    required this.onTrainlogStatusTap,
+    required this.onAboutTap,
+    required this.onLogout,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = theme.brightness == Brightness.dark;
+    final tileColor = isDark ? AppColors.darkSurface : AppColors.lightSurface;
+    final errorColor = isDark ? AppColors.errorDark : AppColors.errorLight;
+
+    Widget tile({
+      required IconData icon,
+      required String label,
+      required VoidCallback onTap,
+      Color? iconColor,
+      Color? labelColor,
+    }) {
+      return Container(
+        margin: const EdgeInsets.symmetric(vertical: 3),
+        decoration: BoxDecoration(
+          color: tileColor,
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: ListTile(
+          leading: Icon(icon, color: iconColor),
+          title: Text(
+            label,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              fontWeight: FontWeight.w500,
+              color: labelColor,
+            ),
+          ),
+          trailing: Icon(
+            Icons.chevron_right,
+            color: isDark ? AppColors.darkText3 : AppColors.lightText3,
+          ),
+          onTap: onTap,
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+        ),
+      );
+    }
+
+    return Column(
+      children: [
+        tile(
+          icon: AdaptiveIcons.inbox,
+          label: loc.menuInboxTitle,
+          onTap: onInboxTap,
+        ),
+        tile(
+          icon: AdaptiveIcons.ok,
+          label: loc.trainglogStatusPageTitle,
+          onTap: onTrainlogStatusTap,
+        ),
+        tile(
+          icon: AdaptiveIcons.info,
+          label: loc.menuAboutTitle,
+          onTap: onAboutTap,
+        ),
+        Container(
+          margin: const EdgeInsets.symmetric(vertical: 3),
+          decoration: BoxDecoration(
+            color: tileColor,
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: ListTile(
+            leading: Icon(AdaptiveIcons.logout, color: errorColor),
+            title: Text(
+              loc.logoutButton,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                fontWeight: FontWeight.w500,
+                color: errorColor,
+              ),
+            ),
+            onTap: onLogout,
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/menu/full_screen_menu_page.dart
+++ b/lib/features/menu/full_screen_menu_page.dart
@@ -260,7 +260,7 @@ class _MenuBlock extends StatelessWidget {
       ),
       _MenuItemData(
         icon: AdaptiveIcons.info,
-        iconBg: AppColors.navy,
+        iconBg: Colors.grey,
         label: loc.menuAboutTitle,
         onTap: onAboutTap,
       ),

--- a/lib/features/menu/full_screen_menu_page.dart
+++ b/lib/features/menu/full_screen_menu_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:trainlog_app/features/menu/menu_block.dart';
 import 'package:trainlog_app/features/menu/menu_explore_card.dart';
+import 'package:trainlog_app/features/menu/menu_item_data.dart';
 import 'package:trainlog_app/features/menu/menu_summary_card.dart';
 import 'package:trainlog_app/app/app_colors.dart';
 import 'package:trainlog_app/l10n/app_localizations.dart';
@@ -55,22 +57,46 @@ class FullScreenMenuPage extends StatelessWidget {
                     const SizedBox(height: 24),
                     _SectionHeader(label: loc.menuMenuSectionTitle),
                     const SizedBox(height: 8),
-                    _MenuBlock(
-                      loc: loc,
-                      onInboxTap: onInboxTap,
-                      onTrainlogStatusTap: onTrainlogStatusTap,
-                      onAboutTap: () => onPageTap(AppPageId.about),
-                      onLogout: () async {
-                        final settings = context.read<SettingsProvider>();
-                        final trips = context.read<TripsProvider>();
-                        final scaffMsg = ScaffoldMessenger.of(context);
-                        onClose();
-                        await context.read<TrainlogProvider>().logout(settings, trips);
-                        scaffMsg.showSnackBar(
-                          SnackBar(content: Text(loc.loggedOut)),
-                        );
-                      },
-                    ),
+                    Builder(builder: (context) {
+                      final cs = Theme.of(context).colorScheme;
+                      return MenuBlock(items: [
+                        MenuItemData(
+                          icon: AdaptiveIcons.inbox,
+                          iconBg: AppColors.amber,
+                          label: loc.menuInboxTitle,
+                          onTap: onInboxTap,
+                        ),
+                        MenuItemData(
+                          icon: AdaptiveIcons.ok,
+                          iconBg: AppColors.blue,
+                          label: loc.trainglogStatusPageTitle,
+                          onTap: onTrainlogStatusTap,
+                        ),
+                        MenuItemData(
+                          icon: AdaptiveIcons.info,
+                          iconBg: AppColors.navy,
+                          label: loc.menuAboutTitle,
+                          onTap: () => onPageTap(AppPageId.about),
+                        ),
+                        MenuItemData(
+                          icon: AdaptiveIcons.logout,
+                          iconBg: cs.error,
+                          label: loc.logoutButton,
+                          labelColor: cs.error,
+                          isDestructive: true,
+                          onTap: () async {
+                            final settings = context.read<SettingsProvider>();
+                            final trips = context.read<TripsProvider>();
+                            final scaffMsg = ScaffoldMessenger.of(context);
+                            onClose();
+                            await context.read<TrainlogProvider>().logout(settings, trips);
+                            scaffMsg.showSnackBar(
+                              SnackBar(content: Text(loc.loggedOut)),
+                            );
+                          },
+                        ),
+                      ]);
+                    }),
                     const SizedBox(height: 32),
                   ],
                 ),
@@ -220,158 +246,6 @@ class _ExploreGrid extends StatelessWidget {
       children: items
           .map((d) => ExploreCard(data: d, onTap: () => onPageTap(d.id)))
           .toList(),
-    );
-  }
-}
-
-// ── Menu block (single grouped list) ─────────────────────────────────────────
-
-class _MenuBlock extends StatelessWidget {
-  final AppLocalizations loc;
-  final VoidCallback onInboxTap;
-  final VoidCallback onTrainlogStatusTap;
-  final VoidCallback onAboutTap;
-  final VoidCallback onLogout;
-
-  const _MenuBlock({
-    required this.loc,
-    required this.onInboxTap,
-    required this.onTrainlogStatusTap,
-    required this.onAboutTap,
-    required this.onLogout,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-
-    final items = <_MenuItemData>[
-      _MenuItemData(
-        icon: AdaptiveIcons.inbox,
-        iconBg: AppColors.amber,
-        label: loc.menuInboxTitle,
-        onTap: onInboxTap,
-      ),
-      _MenuItemData(
-        icon: AdaptiveIcons.ok,
-        iconBg: AppColors.blue,
-        label: loc.trainglogStatusPageTitle,
-        onTap: onTrainlogStatusTap,
-      ),
-      _MenuItemData(
-        icon: AdaptiveIcons.info,
-        iconBg: Colors.grey,
-        label: loc.menuAboutTitle,
-        onTap: onAboutTap,
-      ),
-      _MenuItemData(
-        icon: AdaptiveIcons.logout,
-        iconBg: cs.error,
-        label: loc.logoutButton,
-        labelColor: cs.error,
-        onTap: onLogout,
-        isDestructive: true,
-      ),
-    ];
-
-    return Container(
-      decoration: BoxDecoration(
-        color: cs.surface,
-        borderRadius: BorderRadius.circular(14),
-        border: Border.all(color: cs.outlineVariant, width: 1),
-      ),
-      child: Column(
-        children: [
-          for (int i = 0; i < items.length; i++) ...[
-            _MenuTile(
-              data: items[i],
-              isFirst: i == 0,
-              isLast: i == items.length - 1,
-            ),
-            if (i < items.length - 1)
-              Divider(
-                height: 1,
-                thickness: 1,
-                indent: 16 + 28 + 12, // align with label start
-                endIndent: 0,
-                color: cs.outlineVariant,
-              ),
-          ],
-        ],
-      ),
-    );
-  }
-}
-
-class _MenuItemData {
-  final IconData icon;
-  final Color iconBg;
-  final String label;
-  final Color? labelColor;
-  final VoidCallback onTap;
-  final bool isDestructive;
-
-  const _MenuItemData({
-    required this.icon,
-    required this.iconBg,
-    required this.label,
-    required this.onTap,
-    this.labelColor,
-    this.isDestructive = false,
-  });
-}
-
-class _MenuTile extends StatelessWidget {
-  final _MenuItemData data;
-  final bool isFirst;
-  final bool isLast;
-
-  const _MenuTile({
-    required this.data,
-    required this.isFirst,
-    required this.isLast,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    final resolvedTextColor = data.labelColor ?? cs.onSurface;
-
-    return InkWell(
-      onTap: data.onTap,
-      borderRadius: BorderRadius.vertical(
-        top: isFirst ? const Radius.circular(14) : Radius.zero,
-        bottom: isLast ? const Radius.circular(14) : Radius.zero,
-      ),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-        child: Row(
-          children: [
-            Container(
-              width: 28,
-              height: 28,
-              decoration: BoxDecoration(
-                color: data.iconBg,
-                borderRadius: BorderRadius.circular(6),
-              ),
-              child: Icon(data.icon, color: Colors.white, size: 15),
-            ),
-            const SizedBox(width: 12),
-            Expanded(
-              child: Text(
-                data.label,
-                style: TextStyle(
-                  fontSize: 15,
-                  fontWeight: FontWeight.w500,
-                  color: resolvedTextColor,
-                ),
-              ),
-            ),
-            if (!data.isDestructive)
-              Icon(Icons.chevron_right, size: 20, color: cs.onSurfaceVariant),
-          ],
-        ),
-      ),
     );
   }
 }

--- a/lib/features/menu/menu_block.dart
+++ b/lib/features/menu/menu_block.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:trainlog_app/features/menu/menu_item_data.dart';
+
+/// A grouped list block used in the full-screen menu MENU section.
+///
+/// The caller builds and passes [items]; this widget only handles
+/// layout, theming, and dividers — it has no knowledge of what the
+/// items do.
+class MenuBlock extends StatelessWidget {
+  final List<MenuItemData> items;
+
+  const MenuBlock({super.key, required this.items});
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: cs.surface,
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: cs.outlineVariant, width: 1),
+      ),
+      child: Column(
+        children: [
+          for (int i = 0; i < items.length; i++) ...[
+            _MenuTile(
+              data: items[i],
+              isFirst: i == 0,
+              isLast: i == items.length - 1,
+            ),
+            if (i < items.length - 1)
+              Divider(
+                height: 1,
+                thickness: 1,
+                indent: 16 + 28 + 12, // aligns with label start
+                endIndent: 0,
+                color: cs.outlineVariant,
+              ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _MenuTile extends StatelessWidget {
+  final MenuItemData data;
+  final bool isFirst;
+  final bool isLast;
+
+  const _MenuTile({
+    required this.data,
+    required this.isFirst,
+    required this.isLast,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final resolvedTextColor = data.labelColor ?? cs.onSurface;
+
+    return InkWell(
+      onTap: data.onTap,
+      borderRadius: BorderRadius.vertical(
+        top: isFirst ? const Radius.circular(14) : Radius.zero,
+        bottom: isLast ? const Radius.circular(14) : Radius.zero,
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Row(
+          children: [
+            Container(
+              width: 28,
+              height: 28,
+              decoration: BoxDecoration(
+                color: data.iconBg,
+                borderRadius: BorderRadius.circular(6),
+              ),
+              child: Icon(data.icon, color: Colors.white, size: 15),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                data.label,
+                style: TextStyle(
+                  fontSize: 15,
+                  fontWeight: FontWeight.w500,
+                  color: resolvedTextColor,
+                ),
+              ),
+            ),
+            if (!data.isDestructive)
+              Icon(Icons.chevron_right, size: 20, color: cs.onSurfaceVariant),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/menu/menu_explore_card.dart
+++ b/lib/features/menu/menu_explore_card.dart
@@ -63,6 +63,7 @@ class ExploreCard extends StatelessWidget {
         padding: const EdgeInsets.all(14),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.max,
           children: [
             // Solid-colour icon square + top-right arrow
             Row(
@@ -82,11 +83,14 @@ class ExploreCard extends StatelessWidget {
               ],
             ),
             const Spacer(),
-            // Title in Space Mono
+            // Title in Space Mono — capped at 2 lines so long translations
+            // (e.g. French) never overflow the fixed card height.
             Text(
               data.label,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
               style: GoogleFonts.spaceMono(
-                fontSize: 15,
+                fontSize: 14,
                 fontWeight: FontWeight.w700,
                 color: cs.onSurface,
               ),

--- a/lib/features/menu/menu_explore_card.dart
+++ b/lib/features/menu/menu_explore_card.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
-import 'package:trainlog_app/app/app_colors.dart';
 import 'package:trainlog_app/navigation/nav_models.dart';
 
 /// Data model for a card in the Explore grid.
@@ -37,13 +36,12 @@ class ExploreCardSubtitle {
 
 /// A card used in the 2×2 Explore grid on the full-screen menu.
 ///
-/// Visual spec:
-/// - White (light) / dark-surface (dark) background
-/// - Thin border using the theme line colour
-/// - Top-right chevron arrow
-/// - Solid-colour rounded-square icon with a white [icon]
-/// - [label] in Space Mono bold
-/// - Optional coloured [subtitle] number + plain text (Space Mono)
+/// All colours are read directly from [Theme.of(context).colorScheme]:
+/// - background  → [ColorScheme.surface]
+/// - border      → [ColorScheme.outlineVariant]
+/// - arrow icon  → [ColorScheme.onSurfaceVariant]
+/// - title text  → [ColorScheme.onSurface]
+/// - subtitle secondary text → [ColorScheme.onSurfaceVariant]
 class ExploreCard extends StatelessWidget {
   final ExploreCardData data;
   final VoidCallback onTap;
@@ -52,25 +50,21 @@ class ExploreCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
-    final cardBg = isDark ? AppColors.darkSurface : AppColors.lightBg;
-    final borderColor = isDark ? AppColors.darkLine : AppColors.lightLine;
-    final chevronColor = isDark ? AppColors.darkText3 : AppColors.lightText3;
-    final subtitleTextColor = isDark ? AppColors.darkText2 : AppColors.lightText2;
+    final cs = Theme.of(context).colorScheme;
 
     return GestureDetector(
       onTap: onTap,
       child: Container(
         decoration: BoxDecoration(
-          color: cardBg,
+          color: cs.surface,
           borderRadius: BorderRadius.circular(14),
-          border: Border.all(color: borderColor, width: 1),
+          border: Border.all(color: cs.outlineVariant, width: 1),
         ),
         padding: const EdgeInsets.all(14),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // Icon + top-right arrow
+            // Solid-colour icon square + top-right arrow
             Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
@@ -84,20 +78,20 @@ class ExploreCard extends StatelessWidget {
                   child: Icon(data.icon, color: Colors.white, size: 20),
                 ),
                 const Spacer(),
-                Icon(Icons.arrow_outward, size: 16, color: chevronColor),
+                Icon(Icons.arrow_outward, size: 16, color: cs.onSurfaceVariant),
               ],
             ),
             const Spacer(),
-            // Title
+            // Title in Space Mono
             Text(
               data.label,
               style: GoogleFonts.spaceMono(
                 fontSize: 15,
                 fontWeight: FontWeight.w700,
-                color: isDark ? AppColors.darkText : AppColors.lightText,
+                color: cs.onSurface,
               ),
             ),
-            // Subtitle (hidden when null)
+            // Optional coloured subtitle (hidden when null)
             if (data.subtitle != null) ...[
               const SizedBox(height: 2),
               RichText(
@@ -115,7 +109,7 @@ class ExploreCard extends StatelessWidget {
                       text: ' ${data.subtitle!.text}',
                       style: GoogleFonts.spaceMono(
                         fontSize: 11,
-                        color: subtitleTextColor,
+                        color: cs.onSurfaceVariant,
                       ),
                     ),
                   ],

--- a/lib/features/menu/menu_explore_card.dart
+++ b/lib/features/menu/menu_explore_card.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:trainlog_app/app/app_colors.dart';
+import 'package:trainlog_app/navigation/nav_models.dart';
+
+/// Data model for a card in the Explore grid.
+class ExploreCardData {
+  final AppPageId id;
+  final IconData icon;
+  final String label;
+  final Color color;
+
+  /// Optional subtitle: a coloured number and a plain text suffix.
+  /// Pass [null] to hide the subtitle row.
+  final ExploreCardSubtitle? subtitle;
+
+  const ExploreCardData({
+    required this.id,
+    required this.icon,
+    required this.label,
+    required this.color,
+    this.subtitle,
+  });
+}
+
+class ExploreCardSubtitle {
+  final String number;
+  final Color numberColor;
+  final String text;
+
+  const ExploreCardSubtitle({
+    required this.number,
+    required this.numberColor,
+    required this.text,
+  });
+}
+
+/// A card used in the 2×2 Explore grid on the full-screen menu.
+///
+/// Visual spec:
+/// - White (light) / dark-surface (dark) background
+/// - Thin border using the theme line colour
+/// - Top-right chevron arrow
+/// - Solid-colour rounded-square icon with a white [icon]
+/// - [label] in Space Mono bold
+/// - Optional coloured [subtitle] number + plain text (Space Mono)
+class ExploreCard extends StatelessWidget {
+  final ExploreCardData data;
+  final VoidCallback onTap;
+
+  const ExploreCard({super.key, required this.data, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final cardBg = isDark ? AppColors.darkSurface : AppColors.lightBg;
+    final borderColor = isDark ? AppColors.darkLine : AppColors.lightLine;
+    final chevronColor = isDark ? AppColors.darkText3 : AppColors.lightText3;
+    final subtitleTextColor = isDark ? AppColors.darkText2 : AppColors.lightText2;
+
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        decoration: BoxDecoration(
+          color: cardBg,
+          borderRadius: BorderRadius.circular(14),
+          border: Border.all(color: borderColor, width: 1),
+        ),
+        padding: const EdgeInsets.all(14),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Icon + top-right arrow
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Container(
+                  width: 38,
+                  height: 38,
+                  decoration: BoxDecoration(
+                    color: data.color,
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  child: Icon(data.icon, color: Colors.white, size: 20),
+                ),
+                const Spacer(),
+                Icon(Icons.arrow_outward, size: 16, color: chevronColor),
+              ],
+            ),
+            const Spacer(),
+            // Title
+            Text(
+              data.label,
+              style: GoogleFonts.spaceMono(
+                fontSize: 13,
+                fontWeight: FontWeight.w700,
+                color: isDark ? AppColors.darkText : AppColors.lightText,
+              ),
+            ),
+            // Subtitle (hidden when null)
+            if (data.subtitle != null) ...[
+              const SizedBox(height: 2),
+              RichText(
+                text: TextSpan(
+                  children: [
+                    TextSpan(
+                      text: data.subtitle!.number,
+                      style: GoogleFonts.spaceMono(
+                        fontSize: 11,
+                        color: data.subtitle!.numberColor,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    TextSpan(
+                      text: ' ${data.subtitle!.text}',
+                      style: GoogleFonts.spaceMono(
+                        fontSize: 11,
+                        color: subtitleTextColor,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/menu/menu_explore_card.dart
+++ b/lib/features/menu/menu_explore_card.dart
@@ -83,16 +83,18 @@ class ExploreCard extends StatelessWidget {
                 Icon(Icons.chevron_right, size: 20, color: cs.onSurfaceVariant),
               ],
             ),
-            // Title in Space Mono — single line with ellipsis so the card
-            // never overflows on very small screens.
-            Text(
-              data.label,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: GoogleFonts.spaceMono(
-                fontSize: 14,
-                fontWeight: FontWeight.w700,
-                color: cs.onSurface,
+            // Flexible lets the title shrink on very small cards instead of
+            // overflowing; up to 2 lines with ellipsis on truncation.
+            Flexible(
+              child: Text(
+                data.label,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                style: GoogleFonts.spaceMono(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w700,
+                  color: cs.onSurface,
+                ),
               ),
             ),
             // Optional coloured subtitle (hidden when null)

--- a/lib/features/menu/menu_explore_card.dart
+++ b/lib/features/menu/menu_explore_card.dart
@@ -63,6 +63,7 @@ class ExploreCard extends StatelessWidget {
         padding: const EdgeInsets.all(14),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
           mainAxisSize: MainAxisSize.max,
           children: [
             // Solid-colour icon square + top-right arrow
@@ -82,12 +83,11 @@ class ExploreCard extends StatelessWidget {
                 Icon(Icons.chevron_right, size: 20, color: cs.onSurfaceVariant),
               ],
             ),
-            const Spacer(),
-            // Title in Space Mono — capped at 2 lines so long translations
-            // (e.g. French) never overflow the fixed card height.
+            // Title in Space Mono — single line with ellipsis so the card
+            // never overflows on very small screens.
             Text(
               data.label,
-              maxLines: 2,
+              maxLines: 1,
               overflow: TextOverflow.ellipsis,
               style: GoogleFonts.spaceMono(
                 fontSize: 14,

--- a/lib/features/menu/menu_explore_card.dart
+++ b/lib/features/menu/menu_explore_card.dart
@@ -92,7 +92,7 @@ class ExploreCard extends StatelessWidget {
             Text(
               data.label,
               style: GoogleFonts.spaceMono(
-                fontSize: 13,
+                fontSize: 15,
                 fontWeight: FontWeight.w700,
                 color: isDark ? AppColors.darkText : AppColors.lightText,
               ),

--- a/lib/features/menu/menu_explore_card.dart
+++ b/lib/features/menu/menu_explore_card.dart
@@ -78,7 +78,7 @@ class ExploreCard extends StatelessWidget {
                   child: Icon(data.icon, color: Colors.white, size: 20),
                 ),
                 const Spacer(),
-                Icon(Icons.arrow_outward, size: 16, color: cs.onSurfaceVariant),
+                Icon(Icons.chevron_right, size: 20, color: cs.onSurfaceVariant),
               ],
             ),
             const Spacer(),

--- a/lib/features/menu/menu_item_data.dart
+++ b/lib/features/menu/menu_item_data.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+
+/// Data for a single row in a [MenuBlock].
+class MenuItemData {
+  final IconData icon;
+  final Color iconBg;
+  final String label;
+
+  /// Override the label colour — useful for destructive actions (red).
+  final Color? labelColor;
+
+  final VoidCallback onTap;
+
+  /// Destructive items show no trailing chevron.
+  final bool isDestructive;
+
+  const MenuItemData({
+    required this.icon,
+    required this.iconBg,
+    required this.label,
+    required this.onTap,
+    this.labelColor,
+    this.isDestructive = false,
+  });
+}

--- a/lib/features/menu/menu_summary_card.dart
+++ b/lib/features/menu/menu_summary_card.dart
@@ -1,0 +1,164 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:provider/provider.dart';
+import 'package:trainlog_app/app/app_colors.dart';
+import 'package:trainlog_app/l10n/app_localizations.dart';
+import 'package:trainlog_app/providers/trainlog_provider.dart';
+import 'package:trainlog_app/providers/trips_provider.dart';
+
+/// Hero card at the top of the full-screen menu.
+///
+/// The background is always the inverse of the current theme — navy in light
+/// mode, an elevated dark surface in dark mode — so it always reads as a
+/// strong, branded element.
+class MenuSummaryCard extends StatelessWidget {
+  const MenuSummaryCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final auth = context.watch<TrainlogProvider>();
+    final trips = context.watch<TripsProvider>();
+
+    // Reverse-of-theme background: always dark/navy feel.
+    final cardBg = isDark ? AppColors.darkElevated : AppColors.navy;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: cardBg,
+        borderRadius: BorderRadius.circular(16),
+      ),
+      padding: const EdgeInsets.all(16),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          const _TrainlogIcon(),
+          const SizedBox(width: 16),
+          Expanded(
+            child: _CardText(
+              username: auth.username ?? '',
+              instanceUrl: auth.instanceUrl,
+              trips: trips,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ── Branded icon ──────────────────────────────────────────────────────────────
+
+class _TrainlogIcon extends StatelessWidget {
+  const _TrainlogIcon();
+
+  @override
+  Widget build(BuildContext context) {
+    // Colours never change regardless of theme.
+    return Container(
+      width: 60,
+      height: 60,
+      decoration: const BoxDecoration(
+        color: AppColors.navy,
+        shape: BoxShape.circle,
+      ),
+      padding: const EdgeInsets.all(5),
+      child: Container(
+        decoration: const BoxDecoration(
+          color: AppColors.amber,
+          shape: BoxShape.circle,
+        ),
+        padding: const EdgeInsets.all(8),
+        child: SvgPicture.asset(
+          'assets/icon/trainlog_icon_foreground_only.svg',
+          colorFilter: const ColorFilter.mode(AppColors.navy, BlendMode.srcIn),
+        ),
+      ),
+    );
+  }
+}
+
+// ── Text content ──────────────────────────────────────────────────────────────
+
+class _CardText extends StatelessWidget {
+  final String username;
+  final String instanceUrl;
+  final TripsProvider trips;
+
+  const _CardText({
+    required this.username,
+    required this.instanceUrl,
+    required this.trips,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    // Text is always on a dark/navy background, so always use near-white tones.
+    const nameColor = Colors.white;
+    const urlColor = Color(0xFFB0BEC5); // subdued white
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          username,
+          style: const TextStyle(
+            color: nameColor,
+            fontSize: 18,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        const SizedBox(height: 2),
+        Text(
+          instanceUrl,
+          style: GoogleFonts.spaceMono(
+            fontSize: 11,
+            color: urlColor,
+          ),
+          overflow: TextOverflow.ellipsis,
+        ),
+        const SizedBox(height: 6),
+        _TripCount(trips: trips),
+      ],
+    );
+  }
+}
+
+class _TripCount extends StatefulWidget {
+  final TripsProvider trips;
+
+  const _TripCount({required this.trips});
+
+  @override
+  State<_TripCount> createState() => _TripCountState();
+}
+
+class _TripCountState extends State<_TripCount> {
+  int? _count;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadCount();
+  }
+
+  Future<void> _loadCount() async {
+    final c = await widget.trips.repository?.count();
+    if (mounted) setState(() => _count = c);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_count == null) return const SizedBox.shrink();
+    final loc = AppLocalizations.of(context)!;
+    return Text(
+      loc.menuTripCount(_count!),
+      style: GoogleFonts.spaceMono(
+        fontSize: 12,
+        color: AppColors.amber,
+        fontWeight: FontWeight.w600,
+      ),
+    );
+  }
+}

--- a/lib/features/menu/menu_summary_card.dart
+++ b/lib/features/menu/menu_summary_card.dart
@@ -9,24 +9,21 @@ import 'package:trainlog_app/providers/trips_provider.dart';
 
 /// Hero card at the top of the full-screen menu.
 ///
-/// The background is always the inverse of the current theme — navy in light
-/// mode, an elevated dark surface in dark mode — so it always reads as a
-/// strong, branded element.
+/// The background always uses [ColorScheme.inverseSurface] — navy in light
+/// mode, pure white in dark mode — so it reads as a strong branded element
+/// that inverts with the theme without any manual `isDark` checks.
 class MenuSummaryCard extends StatelessWidget {
   const MenuSummaryCard({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final cs = Theme.of(context).colorScheme;
     final auth = context.watch<TrainlogProvider>();
     final trips = context.watch<TripsProvider>();
 
-    // Reverse-of-theme background: navy in light, white/light in dark.
-    final cardBg = isDark ? AppColors.lightBg : AppColors.navy;
-
     return Container(
       decoration: BoxDecoration(
-        color: cardBg,
+        color: cs.inverseSurface,
         borderRadius: BorderRadius.circular(16),
       ),
       padding: const EdgeInsets.all(16),
@@ -55,7 +52,8 @@ class _TrainlogIcon extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Icon colours never change: amber outer circle → navy inner fill → amber icon.
+    // Icon colours NEVER change regardless of theme:
+    // amber outer circle → navy inner fill → amber icon glyph.
     return Container(
       width: 60,
       height: 60,
@@ -94,11 +92,11 @@ class _CardText extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
-    // In dark mode the card is light, so text must be dark. In light mode the
-    // card is navy, so text must be white.
-    final nameColor = isDark ? AppColors.lightText : Colors.white;
-    final urlColor = isDark ? AppColors.lightText2 : const Color(0xFFB0BEC5);
+    final cs = Theme.of(context).colorScheme;
+    // onInverseSurface is the correct readable colour on top of inverseSurface.
+    final nameColor = cs.onInverseSurface;
+    // Subdued secondary text: same hue, lower opacity.
+    final urlColor = cs.onInverseSurface.withOpacity(0.65);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -114,10 +112,7 @@ class _CardText extends StatelessWidget {
         const SizedBox(height: 2),
         Text(
           instanceUrl,
-          style: GoogleFonts.spaceMono(
-            fontSize: 11,
-            color: urlColor,
-          ),
+          style: GoogleFonts.spaceMono(fontSize: 11, color: urlColor),
           overflow: TextOverflow.ellipsis,
         ),
         const SizedBox(height: 6),
@@ -154,14 +149,14 @@ class _TripCountState extends State<_TripCount> {
   Widget build(BuildContext context) {
     if (_count == null) return const SizedBox.shrink();
     final loc = AppLocalizations.of(context)!;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
-    // Render count in amber, the rest of the label in a subdued tone that
-    // works on both the navy (light) and white (dark) card backgrounds.
-    final subtleColor = isDark ? AppColors.lightText2 : const Color(0xFFB0BEC5);
+    final cs = Theme.of(context).colorScheme;
+    final subtleColor = cs.onInverseSurface.withOpacity(0.65);
     final monoBase = GoogleFonts.spaceMono(fontSize: 12, fontWeight: FontWeight.w600);
+
     return RichText(
       text: TextSpan(
         children: [
+          // Only the number is amber.
           TextSpan(
             text: '$_count',
             style: monoBase.copyWith(color: AppColors.amber),

--- a/lib/features/menu/menu_summary_card.dart
+++ b/lib/features/menu/menu_summary_card.dart
@@ -21,8 +21,8 @@ class MenuSummaryCard extends StatelessWidget {
     final auth = context.watch<TrainlogProvider>();
     final trips = context.watch<TripsProvider>();
 
-    // Reverse-of-theme background: always dark/navy feel.
-    final cardBg = isDark ? AppColors.darkElevated : AppColors.navy;
+    // Reverse-of-theme background: navy in light, white/light in dark.
+    final cardBg = isDark ? AppColors.lightBg : AppColors.navy;
 
     return Container(
       decoration: BoxDecoration(
@@ -55,24 +55,24 @@ class _TrainlogIcon extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Colours never change regardless of theme.
+    // Icon colours never change: amber outer circle → navy inner fill → amber icon.
     return Container(
       width: 60,
       height: 60,
       decoration: const BoxDecoration(
-        color: AppColors.navy,
+        color: AppColors.amber,
         shape: BoxShape.circle,
       ),
       padding: const EdgeInsets.all(5),
       child: Container(
         decoration: const BoxDecoration(
-          color: AppColors.amber,
+          color: AppColors.navy,
           shape: BoxShape.circle,
         ),
         padding: const EdgeInsets.all(8),
         child: SvgPicture.asset(
           'assets/icon/trainlog_icon_foreground_only.svg',
-          colorFilter: const ColorFilter.mode(AppColors.navy, BlendMode.srcIn),
+          colorFilter: const ColorFilter.mode(AppColors.amber, BlendMode.srcIn),
         ),
       ),
     );
@@ -94,16 +94,18 @@ class _CardText extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Text is always on a dark/navy background, so always use near-white tones.
-    const nameColor = Colors.white;
-    const urlColor = Color(0xFFB0BEC5); // subdued white
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    // In dark mode the card is light, so text must be dark. In light mode the
+    // card is navy, so text must be white.
+    final nameColor = isDark ? AppColors.lightText : Colors.white;
+    final urlColor = isDark ? AppColors.lightText2 : const Color(0xFFB0BEC5);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
           username,
-          style: const TextStyle(
+          style: TextStyle(
             color: nameColor,
             fontSize: 18,
             fontWeight: FontWeight.bold,
@@ -152,12 +154,23 @@ class _TripCountState extends State<_TripCount> {
   Widget build(BuildContext context) {
     if (_count == null) return const SizedBox.shrink();
     final loc = AppLocalizations.of(context)!;
-    return Text(
-      loc.menuTripCount(_count!),
-      style: GoogleFonts.spaceMono(
-        fontSize: 12,
-        color: AppColors.amber,
-        fontWeight: FontWeight.w600,
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    // Render count in amber, the rest of the label in a subdued tone that
+    // works on both the navy (light) and white (dark) card backgrounds.
+    final subtleColor = isDark ? AppColors.lightText2 : const Color(0xFFB0BEC5);
+    final monoBase = GoogleFonts.spaceMono(fontSize: 12, fontWeight: FontWeight.w600);
+    return RichText(
+      text: TextSpan(
+        children: [
+          TextSpan(
+            text: '$_count',
+            style: monoBase.copyWith(color: AppColors.amber),
+          ),
+          TextSpan(
+            text: ' ${loc.menuTripCountLabel}',
+            style: monoBase.copyWith(color: subtleColor),
+          ),
+        ],
       ),
     );
   }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -167,6 +167,17 @@
   "menuSettingsTitle": "Settings",
   "menuAboutTitle": "About",
   "menuIosMore": "More",
+  "menuYouTitle": "You",
+  "menuExploreSectionTitle": "EXPLORE",
+  "menuMenuSectionTitle": "MENU",
+  "menuInboxTitle": "Inbox",
+  "menuTripCount": "{count, plural, =0 {No trips yet} =1 {1 trip} other {{count} trips}}",
+  "@menuTripCount": {
+    "description": "Number of trips shown in the menu summary card",
+    "placeholders": {
+      "count": {}
+    }
+  },
 
   "mapFilterYearsAllBtn": "All",
   "mapFilterYearsNoneBtn": "None",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -171,6 +171,7 @@
   "menuExploreSectionTitle": "EXPLORE",
   "menuMenuSectionTitle": "MENU",
   "menuInboxTitle": "Inbox",
+  "menuTripCountLabel": "trips",
   "menuTripCount": "{count, plural, =0 {No trips yet} =1 {1 trip} other {{count} trips}}",
   "@menuTripCount": {
     "description": "Number of trips shown in the menu summary card",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -143,6 +143,7 @@
   "menuExploreSectionTitle": "EXPLORER",
   "menuMenuSectionTitle": "MENU",
   "menuInboxTitle": "Boîte de réception",
+  "menuTripCountLabel": "trajets",
   "menuTripCount": "{count, plural, =0 {Aucun trajet} =1 {1 trajet} other {{count} trajets}}",
   "@menuTripCount": {
     "description": "Nombre de trajets affiché dans la carte résumée du menu",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -139,6 +139,17 @@
   "menuSettingsTitle": "Paramètres",
   "menuAboutTitle": "À propos",
   "menuIosMore": "Plus",
+  "menuYouTitle": "Vous",
+  "menuExploreSectionTitle": "EXPLORER",
+  "menuMenuSectionTitle": "MENU",
+  "menuInboxTitle": "Boîte de réception",
+  "menuTripCount": "{count, plural, =0 {Aucun trajet} =1 {1 trajet} other {{count} trajets}}",
+  "@menuTripCount": {
+    "description": "Nombre de trajets affiché dans la carte résumée du menu",
+    "placeholders": {
+      "count": {}
+    }
+  },
 
   "mapFilterYearsAllBtn": "Toutes",
   "mapFilterYearsNoneBtn": "Aucune",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -142,6 +142,7 @@
   "menuExploreSectionTitle": "探索",
   "menuMenuSectionTitle": "メニュー",
   "menuInboxTitle": "受信トレイ",
+  "menuTripCountLabel": "件の旅程",
   "menuTripCount": "{count, plural, =0 {旅程なし} =1 {1件の旅程} other {{count}件の旅程}}",
   "@menuTripCount": {
     "description": "メニューのサマリーカードに表示される旅程数",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -138,6 +138,17 @@
   "menuSettingsTitle": "設定",
   "menuAboutTitle": "ついて",
   "menuIosMore": "もっと",
+  "menuYouTitle": "あなた",
+  "menuExploreSectionTitle": "探索",
+  "menuMenuSectionTitle": "メニュー",
+  "menuInboxTitle": "受信トレイ",
+  "menuTripCount": "{count, plural, =0 {旅程なし} =1 {1件の旅程} other {{count}件の旅程}}",
+  "@menuTripCount": {
+    "description": "メニューのサマリーカードに表示される旅程数",
+    "placeholders": {
+      "count": {}
+    }
+  },
 
   "mapFilterYearsAllBtn": "全て",
   "mapFilterYearsNoneBtn": "なし",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -930,6 +930,42 @@ abstract class AppLocalizations {
   /// **'More'**
   String get menuIosMore;
 
+  /// No description provided for @menuYouTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'You'**
+  String get menuYouTitle;
+
+  /// No description provided for @menuExploreSectionTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'EXPLORE'**
+  String get menuExploreSectionTitle;
+
+  /// No description provided for @menuMenuSectionTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'MENU'**
+  String get menuMenuSectionTitle;
+
+  /// No description provided for @menuInboxTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Inbox'**
+  String get menuInboxTitle;
+
+  /// No description provided for @menuTripCountLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'trips'**
+  String get menuTripCountLabel;
+
+  /// Number of trips shown in the menu summary card
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =0 {No trips yet} =1 {1 trip} other {{count} trips}}'**
+  String menuTripCount(num count);
+
   /// No description provided for @mapFilterYearsAllBtn.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -447,6 +447,33 @@ class AppLocalizationsEn extends AppLocalizations {
   String get menuIosMore => 'More';
 
   @override
+  String get menuYouTitle => 'You';
+
+  @override
+  String get menuExploreSectionTitle => 'EXPLORE';
+
+  @override
+  String get menuMenuSectionTitle => 'MENU';
+
+  @override
+  String get menuInboxTitle => 'Inbox';
+
+  @override
+  String get menuTripCountLabel => 'trips';
+
+  @override
+  String menuTripCount(num count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count trips',
+      one: '1 trip',
+      zero: 'No trips yet',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get mapFilterYearsAllBtn => 'All';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -453,6 +453,33 @@ class AppLocalizationsFr extends AppLocalizations {
   String get menuIosMore => 'Plus';
 
   @override
+  String get menuYouTitle => 'Vous';
+
+  @override
+  String get menuExploreSectionTitle => 'EXPLORER';
+
+  @override
+  String get menuMenuSectionTitle => 'MENU';
+
+  @override
+  String get menuInboxTitle => 'Boîte de réception';
+
+  @override
+  String get menuTripCountLabel => 'trajets';
+
+  @override
+  String menuTripCount(num count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count trajets',
+      one: '1 trajet',
+      zero: 'Aucun trajet',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get mapFilterYearsAllBtn => 'Toutes';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -438,6 +438,33 @@ class AppLocalizationsJa extends AppLocalizations {
   String get menuIosMore => 'もっと';
 
   @override
+  String get menuYouTitle => 'あなた';
+
+  @override
+  String get menuExploreSectionTitle => '探索';
+
+  @override
+  String get menuMenuSectionTitle => 'メニュー';
+
+  @override
+  String get menuInboxTitle => '受信トレイ';
+
+  @override
+  String get menuTripCountLabel => '件の旅程';
+
+  @override
+  String menuTripCount(num count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count件の旅程',
+      one: '1件の旅程',
+      zero: '旅程なし',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get mapFilterYearsAllBtn => '全て';
 
   @override

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -446,6 +446,33 @@ class AppLocalizationsTl extends AppLocalizations {
   String get menuIosMore => 'More';
 
   @override
+  String get menuYouTitle => 'Ikaw';
+
+  @override
+  String get menuExploreSectionTitle => 'TUKLASIN';
+
+  @override
+  String get menuMenuSectionTitle => 'MENU';
+
+  @override
+  String get menuInboxTitle => 'Inbox';
+
+  @override
+  String get menuTripCountLabel => 'biyahe';
+
+  @override
+  String menuTripCount(num count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count biyahe',
+      one: '1 biyahe',
+      zero: 'Walang biyahe',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get mapFilterYearsAllBtn => 'Lahat';
 
   @override

--- a/lib/l10n/app_tl.arb
+++ b/lib/l10n/app_tl.arb
@@ -158,6 +158,17 @@
   "menuSettingsTitle": "Settings",
   "menuAboutTitle": "Tungkol sa app",
   "menuIosMore": "More",
+  "menuYouTitle": "Ikaw",
+  "menuExploreSectionTitle": "TUKLASIN",
+  "menuMenuSectionTitle": "MENU",
+  "menuInboxTitle": "Inbox",
+  "menuTripCount": "{count, plural, =0 {Walang biyahe} =1 {1 biyahe} other {{count} biyahe}}",
+  "@menuTripCount": {
+    "description": "Bilang ng biyahe na ipinapakita sa menu summary card",
+    "placeholders": {
+      "count": {}
+    }
+  },
   "mapFilterYearsAllBtn": "Lahat",
   "mapFilterYearsNoneBtn": "Wala",
   "mapFilterVehicleTypeAllBtn": "Lahat",

--- a/lib/l10n/app_tl.arb
+++ b/lib/l10n/app_tl.arb
@@ -162,6 +162,7 @@
   "menuExploreSectionTitle": "TUKLASIN",
   "menuMenuSectionTitle": "MENU",
   "menuInboxTitle": "Inbox",
+  "menuTripCountLabel": "biyahe",
   "menuTripCount": "{count, plural, =0 {Walang biyahe} =1 {1 biyahe} other {{count} biyahe}}",
   "@menuTripCount": {
     "description": "Bilang ng biyahe na ipinapakita sa menu summary card",

--- a/lib/navigation/material_shell.dart
+++ b/lib/navigation/material_shell.dart
@@ -8,8 +8,10 @@ import 'package:trainlog_app/platform/adaptive_app_bar.dart';
 import 'package:trainlog_app/platform/adaptive_bottom_navbar.dart';
 import 'package:trainlog_app/services/android_update_service.dart';
 import 'package:trainlog_app/utils/platform_utils.dart';
-import 'package:trainlog_app/widgets/menu_header.dart';
 
+import 'package:trainlog_app/features/menu/full_screen_menu_page.dart';
+import 'package:trainlog_app/features/trainlog/inbox_page.dart';
+import 'package:trainlog_app/features/trainlog/trainlog_status_page.dart';
 import 'package:trainlog_app/features/about/about_page.dart';
 import 'package:trainlog_app/features/user/coverage_page.dart';
 import 'package:trainlog_app/features/user/dashboard_page.dart';
@@ -254,6 +256,47 @@ class _MaterialShellState extends State<MaterialShell> {
 
   void _goBackToBottomNavPage() => _onItemTapped(_previousBottomIndex);
 
+  void _openFullScreenMenu(BuildContext context) {
+    Navigator.of(context).push(
+      PageRouteBuilder(
+        opaque: true,
+        pageBuilder: (ctx, _, __) => FullScreenMenuPage(
+          onClose: () => Navigator.of(ctx).pop(),
+          onSettingsTap: () {
+            Navigator.of(ctx).pop();
+            _onItemTapped(_indexOf(AppPageId.settings));
+          },
+          onPageTap: (id) {
+            Navigator.of(ctx).pop();
+            _onItemTapped(_indexOf(id));
+          },
+          onInboxTap: () {
+            Navigator.of(ctx).pop();
+            Navigator.of(context).push(PageRouteBuilder(
+              pageBuilder: (_, __, ___) => const InboxPage(),
+              transitionDuration: Duration.zero,
+              reverseTransitionDuration: Duration.zero,
+            ));
+          },
+          onTrainlogStatusTap: () {
+            Navigator.of(ctx).pop();
+            Navigator.of(context).push(PageRouteBuilder(
+              pageBuilder: (_, __, ___) => const TrainlogStatusPage(),
+              transitionDuration: Duration.zero,
+              reverseTransitionDuration: Duration.zero,
+            ));
+          },
+        ),
+        transitionsBuilder: (_, animation, __, child) => FadeTransition(
+          opacity: animation,
+          child: child,
+        ),
+        transitionDuration: const Duration(milliseconds: 200),
+        reverseTransitionDuration: const Duration(milliseconds: 150),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final currentPage = _pages[_selectedIndex];
@@ -262,10 +305,6 @@ class _MaterialShellState extends State<MaterialShell> {
       canPop: false,
       onPopInvokedWithResult: (didPop, _) {
         if (didPop) return;
-        if (_scaffoldKey.currentState?.isDrawerOpen == true) {
-          _scaffoldKey.currentState!.closeDrawer();
-          return;
-        }
         if (_isDrawerPage) {
           _goBackToBottomNavPage();
           return;
@@ -304,41 +343,7 @@ class _MaterialShellState extends State<MaterialShell> {
           builder: (_, actions, __) => MaterialPrimaryActionsFabStack(actions: actions),
         ),
 
-        drawer: _isDrawerPage
-            ? null
-            : Drawer(
-                child: Column(
-                  children: [
-                    Container(
-                      decoration: const BoxDecoration(
-                        border: Border.symmetric(
-                          horizontal: BorderSide(color: Color(0xFF3772FF), width: 20),
-                        ),
-                      ),
-                      child: const DrawerHeader(
-                        margin: EdgeInsets.all(0),
-                        decoration: BoxDecoration(color: Color(0xFF14213D)),
-                        child: MenuHeader(),
-                      ),
-                    ),
-                    Expanded(
-                      child: ListView(
-                        padding: EdgeInsets.zero,
-                        children: [
-                          _buildDrawerItem(context, _indexOf(AppPageId.dashboard)),
-                          _buildDrawerItem(context, _indexOf(AppPageId.tags)),
-                          _buildDrawerItem(context, _indexOf(AppPageId.tickets)),
-                          //_buildDrawerItem(context, _indexOf(AppPageId.friends)), TODO
-                          _buildDrawerItem(context, _indexOf(AppPageId.smartPrerecorder)),
-                        ],
-                      ),
-                    ),
-                    const Divider(),
-                    _buildDrawerItem(context, _indexOf(AppPageId.about)),
-                    _buildDrawerItem(context, _indexOf(AppPageId.settings)),
-                  ],
-                ),
-              ),
+        drawer: null,
 
         body: Stack(
           children: [
@@ -348,30 +353,28 @@ class _MaterialShellState extends State<MaterialShell> {
               children: _pages.map((p) => p.view).toList(),
             ),
 
-            // Your custom hamburger overlay for bottom-tab pages
+            // Hamburger overlay for bottom-tab pages — opens the full-screen menu
             if (!_isDrawerPage)
               Positioned(
                 top: 16,
                 left: 16,
-                child: Builder(
-                  builder: (innerContext) => Container(
-                    decoration: BoxDecoration(
-                      color: Theme.of(context).colorScheme.surfaceBright,
-                      shape: BoxShape.circle,
-                      border: Border.all(
-                        color: Theme.of(context).colorScheme.primary,
-                        width: 2,
-                      ),
-                      boxShadow: const [
-                        BoxShadow(color: Colors.black12, blurRadius: 4, offset: Offset(2, 2)),
-                      ],
+                child: Container(
+                  decoration: BoxDecoration(
+                    color: Theme.of(context).colorScheme.surfaceBright,
+                    shape: BoxShape.circle,
+                    border: Border.all(
+                      color: Theme.of(context).colorScheme.primary,
+                      width: 2,
                     ),
-                    child: IconButton(
-                      icon: const Icon(Icons.menu),
-                      color: Theme.of(context).colorScheme.onSurface,
-                      tooltip: AppLocalizations.of(context)!.mainMenuButtonTooltip,
-                      onPressed: () => Scaffold.of(innerContext).openDrawer(),
-                    ),
+                    boxShadow: const [
+                      BoxShadow(color: Colors.black12, blurRadius: 4, offset: Offset(2, 2)),
+                    ],
+                  ),
+                  child: IconButton(
+                    icon: const Icon(Icons.menu),
+                    color: Theme.of(context).colorScheme.onSurface,
+                    tooltip: AppLocalizations.of(context)!.mainMenuButtonTooltip,
+                    onPressed: () => _openFullScreenMenu(context),
                   ),
                 ),
               ),


### PR DESCRIPTION
## Summary
Replaces the legacy Material Drawer with a modern full-screen menu page on Android, providing a cleaner, more flexible navigation experience. The new menu is also ready to be wired up for iOS when needed.

## Key Changes

- **New full-screen menu page** (`FullScreenMenuPage`): A dedicated, modern menu interface replacing the drawer, featuring:
  - Top bar with close and settings buttons
  - Hero summary card displaying user info, instance URL, and trip count
  - "Explore" section with a 2×2 grid of navigation cards (Dashboard, Tags, Tickets, Smart Prerecorder)
  - "Menu" section with grouped items (Inbox, Trainlog Status, About, Logout)

- **New menu components**:
  - `MenuSummaryCard`: Branded hero card with user details and trip count
  - `ExploreCard` & `ExploreCardData`: Reusable card component for the explore grid
  - `MenuBlock` & `MenuItemData`: Grouped list block for menu items with dividers

- **Navigation integration**: Updated `MaterialShell` to:
  - Remove the legacy drawer entirely
  - Add a hamburger button overlay on bottom-tab pages that opens the full-screen menu
  - Wire up menu callbacks for navigation, settings, inbox, and trainlog status

- **Localization**: Added new strings across all supported languages (en, fr, ja, tl):
  - Menu section titles and item labels
  - Trip count display with plural support

- **Theme refinements**: Updated `AppTheme` to use `inverseSurface` (navy in light mode, white in dark mode) for the branded summary card background, ensuring proper contrast without manual theme checks.

- **New accent colors**: Added violet and early/success color aliases to `AppColors` for menu card styling.

## Implementation Details

- The full-screen menu uses a fade transition (200ms forward, 150ms reverse) for smooth appearance
- All colors are derived from `ColorScheme` for proper theme support
- The menu summary card icon uses fixed amber/navy branding that never changes with theme
- Trip count is loaded asynchronously and displayed with a colored number and plain text suffix
- Menu items support optional custom label colors (e.g., red for destructive logout action)
- The hamburger button is positioned as an overlay on the main content, only visible on bottom-tab pages

https://claude.ai/code/session_011mRdqexzAmTPrxWWpeBPzk