### PR TITLE
Reposition FABs and filters on Cupertino map page

### DIFF
--- a/lib/features/map/map_filter_widget.dart
+++ b/lib/features/map/map_filter_widget.dart
@@ -4,6 +4,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:trainlog_app/l10n/app_localizations.dart';
+import 'package:trainlog_app/platform/adaptive_bottom_navbar.dart' show kNavBarClearance;
 import 'package:trainlog_app/platform/adaptive_vehicle_type_filter_chips.dart';
 import 'package:trainlog_app/providers/polyline_provider.dart';
 import 'package:trainlog_app/utils/platform_utils.dart';
@@ -226,8 +227,15 @@ class _CupertinoMapFilter extends StatelessWidget {
       darkColor: const Color(0xE61C1C1E),
     ).resolveFrom(context);
 
+    // The map page lives inside a Padding(bottom: mq.padding.bottom), so its
+    // coordinate origin is already above the system home indicator. The nav bar
+    // sits at kNavBarClearance from the screen bottom, which translates to
+    // (kNavBarClearance - padding.bottom) from the map page viewport bottom.
+    final double filterBottom =
+        kNavBarClearance - mediaQuery.padding.bottom + 8;
+
     return Positioned(
-      bottom: 16,
+      bottom: filterBottom,
       left: 16,
       right: 16,
       child: ConstrainedBox(

--- a/lib/features/map/map_page.dart
+++ b/lib/features/map/map_page.dart
@@ -346,9 +346,14 @@ class _MapPageState extends State<MapPage> with WidgetsBindingObserver, Automati
       _rotationNotifier.value = 0;
     }
 
+    // On Apple the primary-action FAB sits at kNavBarClearance+16 from the
+    // screen bottom and is 56 px tall, so push these controls clear of it.
+    final double buttonsBottom = AppPlatform.isApple
+        ? 160.0 - MediaQuery.of(context).padding.bottom
+        : 16 + MediaQuery.of(context).padding.bottom + 56 + 12;
+
     return Positioned(
-      //top: 70,
-      bottom: 16 + MediaQuery.of(context).padding.bottom + 56 + 12, // above nav bar + some spacing
+      bottom: buttonsBottom,
       right: 16,
       child: ClipRRect(
         borderRadius: BorderRadius.circular(14),

--- a/lib/navigation/cupertino_shell.dart
+++ b/lib/navigation/cupertino_shell.dart
@@ -1,6 +1,6 @@
 // cupertino_shell.dart
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart' show Icon;
+import 'package:flutter/material.dart' show Icon, Theme;
 import 'package:trainlog_app/l10n/app_localizations.dart';
 import 'package:trainlog_app/navigation/nav_models.dart';
 import 'package:trainlog_app/platform/adaptive_bottom_navbar.dart'
@@ -242,19 +242,20 @@ class _CupertinoRootPageState extends State<_CupertinoRootPage> {
           ),
         ),
         Positioned(
-          top: mq.padding.top + 8,
-          right: 12,
+          bottom: kNavBarClearance + 16,
+          right: 16,
           child: ValueListenableBuilder<List<AppPrimaryAction>>(
             valueListenable: _actions,
             builder: (_, actions, __) {
               if (actions.isEmpty) return const SizedBox.shrink();
               final reversed = actions.reversed.toList();
-              return Row(
+              return Column(
                 mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.end,
                 children: [
                   for (int i = 0; i < reversed.length; i++) ...[
-                    CupertinoFloatingActionButton(action: reversed[i]),
-                    if (i != reversed.length - 1) const SizedBox(width: 8),
+                    _CupertinoMapFab(action: reversed[i]),
+                    if (i != reversed.length - 1) const SizedBox(height: 8),
                   ],
                 ],
               );
@@ -262,6 +263,44 @@ class _CupertinoRootPageState extends State<_CupertinoRootPage> {
           ),
         ),
       ],
+    );
+  }
+}
+
+/// Squarish primary-colour FAB used on the Cupertino map page (no nav bar).
+class _CupertinoMapFab extends StatelessWidget {
+  final AppPrimaryAction action;
+
+  const _CupertinoMapFab({required this.action});
+
+  @override
+  Widget build(BuildContext context) {
+    final primary = Theme.of(context).colorScheme.primary;
+    final onPrimary = Theme.of(context).colorScheme.onPrimary;
+
+    return CupertinoButton(
+      padding: EdgeInsets.zero,
+      onPressed: action.onPressed,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: primary,
+          borderRadius: BorderRadius.circular(16),
+          boxShadow: const [
+            BoxShadow(
+              color: Color(0x44000000),
+              blurRadius: 12,
+              offset: Offset(0, 6),
+            ),
+          ],
+        ),
+        child: SizedBox(
+          width: 56,
+          height: 56,
+          child: Center(
+            child: Icon(action.icon, size: 24, color: onPrimary),
+          ),
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
Refactors the layout of floating action buttons (FABs) and filter widgets on the Cupertino map page to improve positioning and visual hierarchy. The primary action FAB is repositioned from the top-right to the bottom-right corner and redesigned as a custom square button component.

## Key Changes
- **FAB repositioning**: Moved primary action button from top-right (`top: mq.padding.top + 8`) to bottom-right (`bottom: kNavBarClearance + 16`) to avoid overlap with status bar and improve accessibility
- **FAB layout**: Changed from horizontal `Row` to vertical `Column` layout to stack multiple actions vertically
- **Custom FAB component**: Introduced `_CupertinoMapFab` widget to replace `CupertinoFloatingActionButton`, providing a squarish design with custom styling (56x56 px, rounded corners, shadow)
- **Theme integration**: Updated imports to include `Theme` and use `colorScheme.primary` and `colorScheme.onPrimary` for consistent theming
- **Filter positioning**: Updated map filter widget bottom positioning to account for `kNavBarClearance` and media query padding, ensuring it sits above the navigation bar
- **Map controls positioning**: Refactored map control buttons (zoom/rotation) positioning logic with platform-specific calculations to avoid overlap with the repositioned FAB

## Implementation Details
- The `_CupertinoMapFab` uses `CupertinoButton` with a `DecoratedBox` for custom styling instead of the standard floating action button
- Bottom positioning calculations now properly account for system padding and navigation bar clearance across different screen layouts
- Added clarifying comments explaining coordinate system transformations for positioned widgets

https://claude.ai/code/session_01GXqBNhiAZvjJvEJMeaTKBs