### PR TITLE
Add AppStepsTabBar widget and integrate menu button into nav bar

### DIFF
--- a/lib/app/app_root.dart
+++ b/lib/app/app_root.dart
@@ -14,6 +14,27 @@ import 'package:trainlog_app/l10n/app_localizations.dart';
 import 'package:trainlog_app/providers/settings_provider.dart';
 import 'package:trainlog_app/utils/platform_utils.dart';
 
+/// Wraps [CountryLocalizations.delegate] and falls back to English for any
+/// locale the country_picker package does not ship a translation for (e.g. tl).
+class _FallbackCountryLocalizationsDelegate
+    extends LocalizationsDelegate<CountryLocalizations> {
+  const _FallbackCountryLocalizationsDelegate();
+
+  @override
+  bool isSupported(Locale locale) => true;
+
+  @override
+  Future<CountryLocalizations> load(Locale locale) {
+    final effective = CountryLocalizations.delegate.isSupported(locale)
+        ? locale
+        : const Locale('en');
+    return CountryLocalizations.delegate.load(effective);
+  }
+
+  @override
+  bool shouldReload(_FallbackCountryLocalizationsDelegate old) => false;
+}
+
 class CrashlyticsNavigationObserver extends NavigatorObserver {
   @override
   void didPush(Route route, Route? previousRoute) {
@@ -60,7 +81,7 @@ class AppRoot extends StatelessWidget {
       locale: settings.locale,
       localizationsDelegates: [
         ...AppLocalizations.localizationsDelegates,
-        CountryLocalizations.delegate,
+        const _FallbackCountryLocalizationsDelegate(),
       ],
       supportedLocales: AppLocalizations.supportedLocales,
       theme: AppTheme.light,
@@ -92,7 +113,7 @@ class AppRoot extends StatelessWidget {
       locale: settings.locale,
       localizationsDelegates: [
         ...AppLocalizations.localizationsDelegates,
-        CountryLocalizations.delegate,
+        const _FallbackCountryLocalizationsDelegate(),
       ],
       supportedLocales: AppLocalizations.supportedLocales,
       theme: CupertinoThemeData(

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -130,7 +130,7 @@
   "menuMapTitle": "Carte",
   "menuTripsTitle": "Trajets",
   "menuRankingTitle": "Classement",
-  "menuStatisticsTitle": "Statistiques",
+  "menuStatisticsTitle": "Stat.",
   "menuDashboardTitle": "Tableau de bord",
   "menuCoverageTitle": "Couverture",
   "menuTagsTitle": "Tags",    

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -426,7 +426,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get menuRankingTitle => 'Classement';
 
   @override
-  String get menuStatisticsTitle => 'Statistiques';
+  String get menuStatisticsTitle => 'Stat.';
 
   @override
   String get menuDashboardTitle => 'Tableau de bord';

--- a/lib/navigation/cupertino_shell.dart
+++ b/lib/navigation/cupertino_shell.dart
@@ -1,6 +1,6 @@
 // cupertino_shell.dart
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart' show Icon, Theme;
+import 'package:flutter/material.dart' show Icon, PageRouteBuilder, Theme;
 import 'package:trainlog_app/l10n/app_localizations.dart';
 import 'package:trainlog_app/navigation/nav_models.dart';
 import 'package:trainlog_app/platform/adaptive_bottom_navbar.dart'
@@ -9,8 +9,11 @@ import 'package:trainlog_app/platform/cupertino_fab.dart';
 import 'package:trainlog_app/utils/platform_utils.dart';
 
 import 'package:trainlog_app/features/map/map_page.dart';
+import 'package:trainlog_app/features/menu/full_screen_menu_page.dart';
 import 'package:trainlog_app/features/ranking/ranking_page.dart';
 import 'package:trainlog_app/features/statistics/statistics_page.dart';
+import 'package:trainlog_app/features/trainlog/inbox_page.dart';
+import 'package:trainlog_app/features/trainlog/trainlog_status_page.dart';
 import 'package:trainlog_app/features/trips/trips_page.dart';
 
 typedef SetPrimaryActions = void Function(List<AppPrimaryAction> actions);
@@ -39,6 +42,41 @@ class _CupertinoShellState extends State<CupertinoShell> {
     } else {
       setState(() => _currentIndex = index);
     }
+  }
+
+  void _openFullScreenMenu(BuildContext context) {
+    Navigator.of(context).push(
+      PageRouteBuilder(
+        opaque: true,
+        pageBuilder: (ctx, _, __) => FullScreenMenuPage(
+          onClose: () => Navigator.of(ctx).pop(),
+          onSettingsTap: () => Navigator.of(ctx).pop(),
+          onPageTap: (id) => Navigator.of(ctx).pop(),
+          onInboxTap: () {
+            Navigator.of(ctx).pop();
+            Navigator.of(context).push(PageRouteBuilder(
+              pageBuilder: (_, __, ___) => const InboxPage(),
+              transitionDuration: Duration.zero,
+              reverseTransitionDuration: Duration.zero,
+            ));
+          },
+          onTrainlogStatusTap: () {
+            Navigator.of(ctx).pop();
+            Navigator.of(context).push(PageRouteBuilder(
+              pageBuilder: (_, __, ___) => const TrainlogStatusPage(),
+              transitionDuration: Duration.zero,
+              reverseTransitionDuration: Duration.zero,
+            ));
+          },
+        ),
+        transitionsBuilder: (_, animation, __, child) => FadeTransition(
+          opacity: animation,
+          child: child,
+        ),
+        transitionDuration: const Duration(milliseconds: 200),
+        reverseTransitionDuration: const Duration(milliseconds: 150),
+      ),
+    );
   }
 
   @override
@@ -110,6 +148,7 @@ class _CupertinoShellState extends State<CupertinoShell> {
               currentIndex: _currentIndex,
               items: navItems,
               onTap: _onTabTapped,
+              onMenuTap: () => _openFullScreenMenu(context),
             ),
           ),
         ],

--- a/lib/navigation/material_shell.dart
+++ b/lib/navigation/material_shell.dart
@@ -1,8 +1,6 @@
 // material_shell.dart
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_svg/svg.dart';
-import 'package:trainlog_app/app/app_colors.dart';
 import 'package:trainlog_app/l10n/app_localizations.dart';
 import 'package:trainlog_app/navigation/nav_models.dart';
 import 'package:trainlog_app/features/settings/settings_page.dart';
@@ -347,45 +345,10 @@ class _MaterialShellState extends State<MaterialShell> {
 
         drawer: null,
 
-        body: Stack(
-          children: [
-            PageView(
-              controller: _pageController,
-              physics: const NeverScrollableScrollPhysics(),
-              children: _pages.map((p) => p.view).toList(),
-            ),
-
-            // Hamburger overlay for bottom-tab pages — opens the full-screen menu
-            if (!_isDrawerPage)
-              Positioned(
-                top: 16,
-                left: 16,
-                child: Container(
-                  decoration: BoxDecoration(
-                    color: AppColors.navy,
-                    shape: BoxShape.circle,
-                    border: Border.all(
-                      color: Theme.of(context).colorScheme.primary,
-                      width: 2,
-                    ),
-                    boxShadow: const [
-                      BoxShadow(color: Colors.black12, blurRadius: 4, offset: Offset(2, 2)),
-                    ],
-                  ),
-                  child: IconButton(
-                    icon: SvgPicture.asset(
-                      width: 24,
-                      height: 24,
-                      'assets/icon/trainlog_icon_foreground_only.svg',
-                      colorFilter: const ColorFilter.mode(AppColors.amber, BlendMode.srcIn),
-                    ),
-                    //color: Theme.of(context).colorScheme.onSurface,
-                    tooltip: AppLocalizations.of(context)!.mainMenuButtonTooltip,
-                    onPressed: () => _openFullScreenMenu(context),
-                  ),
-                ),
-              ),
-          ],
+        body: PageView(
+          controller: _pageController,
+          physics: const NeverScrollableScrollPhysics(),
+          children: _pages.map((p) => p.view).toList(),
         ),
 
         bottomNavigationBar: _isDrawerPage
@@ -393,6 +356,7 @@ class _MaterialShellState extends State<MaterialShell> {
             : AdaptiveBottomNavBar(
                 currentIndex: _selectedIndex, // 0..3 here
                 onTap: _onItemTapped,
+                onMenuTap: () => _openFullScreenMenu(context),
                 items: [
                   for (int i = 0; i < 4; i++)
                     BottomNavigationBarItem(

--- a/lib/platform/adaptive_bottom_navbar.dart
+++ b/lib/platform/adaptive_bottom_navbar.dart
@@ -109,7 +109,7 @@ class AdaptiveBottomNavBar extends StatelessWidget {
             ),
           ),
         // Gap in the centre for the protruding button
-        const SizedBox(width: 72),
+        const SizedBox(width: 60),
         for (int i = 0; i < right.length; i++)
           Expanded(
             child: _NavBarItem(

--- a/lib/platform/adaptive_bottom_navbar.dart
+++ b/lib/platform/adaptive_bottom_navbar.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/svg.dart';
+import 'package:trainlog_app/app/app_colors.dart';
 import 'package:trainlog_app/app/app_nav_bar_theme.dart';
 
 /// Height of the nav bar pill + its top/bottom padding, excluding the system
@@ -6,16 +8,25 @@ import 'package:trainlog_app/app/app_nav_bar_theme.dart';
 /// scrollable pages can add the right clearance without knowing about the nav.
 const double kNavBarClearance = 80.0;
 
+/// Extra vertical space above the pill that the center menu button occupies.
+const double _kMenuButtonOverhang = 22.0;
+
 class AdaptiveBottomNavBar extends StatelessWidget {
   final int currentIndex;
   final List<BottomNavigationBarItem> items;
   final ValueChanged<int> onTap;
+
+  /// When provided, a circular menu button is rendered in the centre of the
+  /// bar, protruding slightly above the pill. The [items] list must have
+  /// exactly 4 entries (2 left + 2 right).
+  final VoidCallback? onMenuTap;
 
   const AdaptiveBottomNavBar({
     super.key,
     required this.currentIndex,
     required this.items,
     required this.onTap,
+    this.onMenuTap,
   });
 
   @override
@@ -23,40 +34,124 @@ class AdaptiveBottomNavBar extends StatelessWidget {
     final navColors = Theme.of(context).extension<AppNavBarColors>()!;
     final mq = MediaQuery.of(context);
 
+    final pill = Container(
+      height: 64,
+      decoration: BoxDecoration(
+        color: navColors.background,
+        borderRadius: BorderRadius.circular(24),
+        boxShadow: [
+          BoxShadow(
+            color: navColors.shadow,
+            blurRadius: 20,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: onMenuTap != null
+          ? _rowWithGap(navColors)
+          : _rowFull(navColors),
+    );
+
     return Container(
       color: Colors.transparent,
       padding: EdgeInsets.only(
         left: 16,
         right: 16,
         bottom: mq.padding.bottom + 8,
-        top: 8,
+        top: onMenuTap != null ? _kMenuButtonOverhang : 8,
       ),
-      child: Container(
-        height: 64,
-        decoration: BoxDecoration(
-          color: navColors.background,
-          borderRadius: BorderRadius.circular(24),
-          boxShadow: [
-            BoxShadow(
-              color: navColors.shadow,
-              blurRadius: 20,
-              offset: const Offset(0, 4),
+      child: onMenuTap != null
+          ? Stack(
+              clipBehavior: Clip.none,
+              alignment: Alignment.topCenter,
+              children: [
+                pill,
+                Positioned(
+                  top: -_kMenuButtonOverhang,
+                  child: _MenuButton(onTap: onMenuTap!),
+                ),
+              ],
+            )
+          : pill,
+    );
+  }
+
+  Widget _rowFull(AppNavBarColors navColors) {
+    return Row(
+      children: [
+        for (int i = 0; i < items.length; i++)
+          Expanded(
+            child: _NavBarItem(
+              item: items[i],
+              isSelected: i == currentIndex,
+              activeColor: navColors.active,
+              inactiveColor: navColors.inactive,
+              onTap: () => onTap(i),
             ),
+          ),
+      ],
+    );
+  }
+
+  Widget _rowWithGap(AppNavBarColors navColors) {
+    final left = items.sublist(0, 2);
+    final right = items.sublist(2, 4);
+    return Row(
+      children: [
+        for (int i = 0; i < left.length; i++)
+          Expanded(
+            child: _NavBarItem(
+              item: left[i],
+              isSelected: i == currentIndex,
+              activeColor: navColors.active,
+              inactiveColor: navColors.inactive,
+              onTap: () => onTap(i),
+            ),
+          ),
+        // Gap in the centre for the protruding button
+        const SizedBox(width: 72),
+        for (int i = 0; i < right.length; i++)
+          Expanded(
+            child: _NavBarItem(
+              item: right[i],
+              isSelected: i + 2 == currentIndex,
+              activeColor: navColors.active,
+              inactiveColor: navColors.inactive,
+              onTap: () => onTap(i + 2),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _MenuButton extends StatelessWidget {
+  final VoidCallback onTap;
+
+  const _MenuButton({required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        width: 56,
+        height: 56,
+        decoration: BoxDecoration(
+          color: AppColors.navy,
+          shape: BoxShape.circle,
+          border: Border.all(color: AppColors.amber, width: 2.5),
+          boxShadow: const [
+            BoxShadow(color: Colors.black26, blurRadius: 8, offset: Offset(0, 3)),
           ],
         ),
-        child: Row(
-          children: [
-            for (int i = 0; i < items.length; i++)
-              Expanded(
-                child: _NavBarItem(
-                  item: items[i],
-                  isSelected: i == currentIndex,
-                  activeColor: navColors.active,
-                  inactiveColor: navColors.inactive,
-                  onTap: () => onTap(i),
-                ),
-              ),
-          ],
+        child: Center(
+          child: SvgPicture.asset(
+            'assets/icon/trainlog_icon_foreground_only.svg',
+            width: 26,
+            height: 26,
+            colorFilter: const ColorFilter.mode(AppColors.amber, BlendMode.srcIn),
+          ),
         ),
       ),
     );

--- a/lib/widgets/app_steps_tab_bar.dart
+++ b/lib/widgets/app_steps_tab_bar.dart
@@ -1,0 +1,236 @@
+import 'package:flutter/material.dart';
+
+class AppStepsTab {
+  final String label;
+
+  /// Optional step/item count rendered as a trailing badge. When null the chip
+  /// shows the label only — used for plain text-only segmented tabs.
+  final int? count;
+
+  const AppStepsTab({required this.label, this.count});
+}
+
+/// Segmented-control-style horizontally-scrollable tab bar with a smooth
+/// sliding indicator animation when the selected tab changes.
+///
+/// A grey rounded track contains all chips. The selected tab's position is
+/// highlighted by a white elevated card that slides from chip to chip via
+/// [AnimatedPositioned]. Unselected tabs show muted label + count text with
+/// no background — the sliding card provides the visual emphasis.
+class AppStepsTabBar extends StatefulWidget {
+  final List<AppStepsTab> tabs;
+  final int selectedIndex;
+  final ValueChanged<int> onTabChanged;
+
+  const AppStepsTabBar({
+    super.key,
+    required this.tabs,
+    required this.selectedIndex,
+    required this.onTabChanged,
+  });
+
+  @override
+  State<AppStepsTabBar> createState() => _AppStepsTabBarState();
+}
+
+class _AppStepsTabBarState extends State<AppStepsTabBar> {
+  static const _trackPadding = 4.0;
+
+  final List<GlobalKey> _keys = [];
+  List<double> _widths = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _initKeys();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _measureWidths());
+  }
+
+  @override
+  void didUpdateWidget(AppStepsTabBar old) {
+    super.didUpdateWidget(old);
+    final labelsChanged = old.tabs.length != widget.tabs.length ||
+        Iterable.generate(widget.tabs.length)
+            .any((i) => old.tabs[i].label != widget.tabs[i].label);
+    if (old.tabs.length != widget.tabs.length) {
+      _initKeys();
+    }
+    if (labelsChanged) {
+      WidgetsBinding.instance.addPostFrameCallback((_) => _measureWidths());
+    }
+  }
+
+  void _initKeys() {
+    _keys.clear();
+    for (int i = 0; i < widget.tabs.length; i++) {
+      _keys.add(GlobalKey());
+    }
+    _widths = [];
+  }
+
+  void _measureWidths() {
+    if (!mounted) return;
+    final widths = <double>[];
+    for (final key in _keys) {
+      final box = key.currentContext?.findRenderObject() as RenderBox?;
+      widths.add(box?.size.width ?? 0);
+    }
+    if (widths.any((w) => w > 0)) {
+      setState(() => _widths = widths);
+    }
+  }
+
+  /// Left offset of the indicator relative to the Stack's origin (= content
+  /// origin inside the track padding).
+  double get _indicatorLeft {
+    if (_widths.isEmpty) return 0;
+    double left = 0;
+    for (int i = 0; i < widget.selectedIndex && i < _widths.length; i++) {
+      left += _widths[i];
+    }
+    return left;
+  }
+
+  double get _indicatorWidth {
+    if (_widths.isEmpty || widget.selectedIndex >= _widths.length) return 0;
+    return _widths[widget.selectedIndex];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final cs = Theme.of(context).colorScheme;
+    final trackColor = isDark
+        ? cs.surfaceContainerHighest
+        : const Color(0xFFEEEEF2);
+
+    return Container(
+      height: 46,
+      decoration: BoxDecoration(
+        color: trackColor,
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.all(_trackPadding),
+        child: Stack(
+          // Row (non-positioned) determines Stack size; indicator overlaps it.
+          clipBehavior: Clip.none,
+          children: [
+            // ── Sliding white indicator card (behind chips) ──────────────
+            if (_widths.isNotEmpty)
+              AnimatedPositioned(
+                duration: const Duration(milliseconds: 250),
+                curve: Curves.easeInOut,
+                left: _indicatorLeft,
+                top: 0,
+                bottom: 0,
+                width: _indicatorWidth,
+                child: Container(
+                  decoration: BoxDecoration(
+                    color: isDark ? cs.surface : Colors.white,
+                    borderRadius: BorderRadius.circular(10),
+                    boxShadow: [
+                      BoxShadow(
+                        color: Colors.black
+                            .withValues(alpha: isDark ? 0.25 : 0.10),
+                        blurRadius: 6,
+                        offset: const Offset(0, 1),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+
+            // ── Tab chips (on top of indicator) ─────────────────────────
+            Row(
+              children: [
+                for (int i = 0; i < widget.tabs.length; i++)
+                  _AppStepsTabChip(
+                    key: _keys[i],
+                    label: widget.tabs[i].label,
+                    count: widget.tabs[i].count,
+                    isSelected: i == widget.selectedIndex,
+                    onTap: () => widget.onTabChanged(i),
+                  ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _AppStepsTabChip extends StatelessWidget {
+  final String label;
+  final int? count;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  const _AppStepsTabChip({
+    super.key,
+    required this.label,
+    required this.count,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+
+    // Keep the same layout/sizing for selected and unselected so that
+    // _widths stays stable and the indicator slides correctly.
+    return GestureDetector(
+      onTap: onTap,
+      behavior: HitTestBehavior.opaque,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 7),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            AnimatedDefaultTextStyle(
+              duration: const Duration(milliseconds: 200),
+              style: TextStyle(
+                color: isSelected
+                    ? cs.onSurface
+                    : cs.onSurface.withValues(alpha: 0.50),
+                fontSize: 13,
+                fontWeight:
+                    isSelected ? FontWeight.w700 : FontWeight.w500,
+              ),
+              child: Text(label),
+            ),
+            // Badge — only rendered when a count is supplied. Text-only tabs
+            // (count == null) omit both the gap and the badge entirely.
+            if (count != null) ...[
+              const SizedBox(width: 6),
+              AnimatedContainer(
+                duration: const Duration(milliseconds: 200),
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                decoration: BoxDecoration(
+                  color: isSelected
+                      ? cs.primary
+                      : cs.onSurface.withValues(alpha: 0.10),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Text(
+                  '$count',
+                  style: TextStyle(
+                    color: isSelected
+                        ? cs.onPrimary
+                        : cs.onSurface.withValues(alpha: 0.45),
+                    fontSize: 11,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
This PR introduces a new `AppStepsTabBar` widget for segmented-control-style tab navigation and refactors the bottom navigation bar to integrate a central menu button that was previously overlaid on the page content.

## Key Changes

- **New Widget: AppStepsTabBar** (`lib/widgets/app_steps_tab_bar.dart`)
  - Horizontally-scrollable tab bar with smooth sliding indicator animation
  - Supports optional count badges on tabs
  - Uses `AnimatedPositioned` for the sliding white card indicator
  - Measures tab widths dynamically to position the indicator correctly
  - Handles both text-only and text-with-badge tab variants

- **Bottom Navigation Bar Refactor** (`lib/platform/adaptive_bottom_navbar.dart`)
  - Added optional `onMenuTap` callback to support a central menu button
  - Menu button protrudes above the pill with navy background and amber border
  - When menu is enabled, nav items are split into left (2) and right (2) groups with a gap in the center
  - Maintains backward compatibility when `onMenuTap` is null

- **Shell Navigation Updates**
  - **Material Shell** (`lib/navigation/material_shell.dart`): Removed hamburger overlay from page stack; menu button now integrated into nav bar
  - **Cupertino Shell** (`lib/navigation/cupertino_shell.dart`): Added `_openFullScreenMenu()` method and connected it to nav bar's `onMenuTap` callback

- **Localization & Theme**
  - Updated French localization: shortened "Statistiques" to "Stat." for nav bar space
  - Added `_FallbackCountryLocalizationsDelegate` in `app_root.dart` to gracefully handle unsupported locales (e.g., Tagalog) by falling back to English

## Notable Implementation Details

- The `AppStepsTabBar` uses `GlobalKey` to measure individual tab widths and calculates indicator position dynamically
- Tab width measurements are cached and only recalculated when labels change or widget is updated
- The menu button uses SVG assets and is positioned absolutely above the nav bar pill
- Navigation logic properly handles the 4-item split layout when menu is present

https://claude.ai/code/session_01YYAQmtha2FTUVrXrCinR3Q