### PR TITLE
Add month/year dividers to trip list and improve sorting

### DIFF
--- a/lib/features/statistics/statistics_page.dart
+++ b/lib/features/statistics/statistics_page.dart
@@ -478,7 +478,7 @@ class _StatsCard extends StatelessWidget {
   Tooltip _tooltipWidget(BuildContext context, Map<UnitFactor, String> units) {
     final cs = Theme.of(context).colorScheme;
     return Tooltip(
-      triggerMode: TooltipTriggerMode.longPress,
+      triggerMode: TooltipTriggerMode.tap,
       richMessage: TextSpan(children: [_tooltipRich(context, units)]),
       decoration: BoxDecoration(
         color: Theme.of(context).colorScheme.primaryContainer,

--- a/lib/features/trips/widgets/trip_card_view.dart
+++ b/lib/features/trips/widgets/trip_card_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:trainlog_app/app/theme/app_colors.dart';
 import 'package:trainlog_app/app/theme/app_theme.dart';
@@ -11,6 +12,7 @@ import 'package:trainlog_app/providers/trainlog_provider.dart';
 import 'package:trainlog_app/utils/date_utils.dart' as date_utils;
 import 'package:trainlog_app/utils/map_color_palette.dart';
 import 'package:trainlog_app/utils/style_utils.dart';
+import 'package:trainlog_app/widgets/divider_with_widget.dart';
 import 'package:trainlog_app/widgets/past_future_selector.dart';
 import 'package:trainlog_app/widgets/trips_filter_dialog.dart';
 
@@ -132,24 +134,58 @@ class _TripCardViewState extends State<TripCardView> {
     }
 
     final bottomInset = MediaQuery.of(context).padding.bottom;
-    return ListView.builder(
+    final locale = Localizations.localeOf(context).toString();
+
+    // Build a flat list of items (dividers + cards) from loaded trips.
+    final List<Widget> listItems = [];
+    String? lastMonthKey;
+
+    for (int index = 0; index < _totalCount; index++) {
+      final trip = index < _items.length ? _items[index] : null;
+
+      if (trip == null) {
+        WidgetsBinding.instance.addPostFrameCallback((_) => _loadMoreIfNeeded());
+        listItems.add(const _TripCardSkeleton());
+        lastMonthKey = null; // reset so divider is re-evaluated once loaded
+        continue;
+      }
+
+      final dt = trip.startDatetime;
+      final monthKey = '${dt.year}-${dt.month}';
+
+      if (monthKey != lastMonthKey) {
+        final isJanuary = dt.month == 1;
+        final label = isJanuary
+            ? DateFormat('MMMM yyyy', locale).format(dt)
+            : DateFormat('MMMM', locale).format(dt);
+        listItems.add(
+          Padding(
+            padding: const EdgeInsets.only(top: 12, bottom: 4),
+            child: DividerWithText(
+              text: label,
+              style: isJanuary ? const TextStyle(fontWeight: FontWeight.bold) : null,
+            ),
+          ),
+        );
+        lastMonthKey = monthKey;
+      }
+
+      listItems.add(_TripCard(trip: trip, trainlog: widget.trainlog));
+    }
+
+    if (_isLoadingMore) {
+      listItems.add(
+        const Padding(
+          padding: EdgeInsets.symmetric(vertical: 16),
+          child: Center(child: CircularProgressIndicator()),
+        ),
+      );
+    }
+
+    return ListView(
       controller: _scrollController,
       padding: EdgeInsets.fromLTRB(16, 8, 16, bottomInset + 90),
-      itemCount: _totalCount + (_isLoadingMore ? 1 : 0),
-      itemBuilder: (context, index) {
-        if (index >= _totalCount) {
-          return const Padding(
-            padding: EdgeInsets.symmetric(vertical: 16),
-            child: Center(child: CircularProgressIndicator()),
-          );
-        }
-        final trip = index < _items.length ? _items[index] : null;
-        if (trip == null) {
-          WidgetsBinding.instance.addPostFrameCallback((_) => _loadMoreIfNeeded());
-          return const _TripCardSkeleton();
-        }
-        return _TripCard(trip: trip, trainlog: widget.trainlog);
-      },
+      children: listItems,
     );
   }
 }

--- a/lib/features/trips/widgets/trip_card_view.dart
+++ b/lib/features/trips/widgets/trip_card_view.dart
@@ -134,11 +134,14 @@ class _TripCardViewState extends State<TripCardView> {
     }
 
     final bottomInset = MediaQuery.of(context).padding.bottom;
+    final cs = Theme.of(context).colorScheme;
     final locale = Localizations.localeOf(context).toString();
 
     // Build a flat list of items (dividers + cards) from loaded trips.
     final List<Widget> listItems = [];
     String? lastMonthKey;
+    DateTime? lastMonthDate; // date of the month above (newer, already processed)
+    bool isFirstDivider = true;
 
     for (int index = 0; index < _totalCount; index++) {
       final trip = index < _items.length ? _items[index] : null;
@@ -146,7 +149,8 @@ class _TripCardViewState extends State<TripCardView> {
       if (trip == null) {
         WidgetsBinding.instance.addPostFrameCallback((_) => _loadMoreIfNeeded());
         listItems.add(const _TripCardSkeleton());
-        lastMonthKey = null; // reset so divider is re-evaluated once loaded
+        lastMonthKey = null;
+        lastMonthDate = null;
         continue;
       }
 
@@ -154,20 +158,62 @@ class _TripCardViewState extends State<TripCardView> {
       final monthKey = '${dt.year}-${dt.month}';
 
       if (monthKey != lastMonthKey) {
-        final isJanuary = dt.month == 1;
-        final label = isJanuary
-            ? DateFormat('MMMM yyyy', locale).format(dt)
-            : DateFormat('MMMM', locale).format(dt);
+        final Widget dividerChild;
+
+        if (isFirstDivider || lastMonthDate == null) {
+          // Top of the list: show only the year.
+          dividerChild = Text(
+            '${dt.year}',
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: cs.onSurfaceVariant,
+                ),
+          );
+          isFirstDivider = false;
+        } else {
+          // Between two months: "↓ olderMonth / newerMonth ↑"
+          // dt        = current (older, below in list)
+          // lastMonthDate = previous (newer, above in list)
+          final newerDt = lastMonthDate!;
+          final yearTransition = dt.year != newerDt.year;
+          final bold = yearTransition ? FontWeight.bold : FontWeight.normal;
+          final baseStyle = Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: cs.onSurfaceVariant,
+                fontWeight: bold,
+              );
+
+          String monthName(DateTime d, {required bool showYear}) {
+            final raw = DateFormat('MMMM', locale).format(d);
+            final capitalized = raw[0].toUpperCase() + raw.substring(1);
+            return showYear ? '$capitalized ${d.year}' : capitalized;
+          }
+
+          final olderLabel = monthName(dt, showYear: yearTransition);
+          final newerLabel = monthName(newerDt, showYear: yearTransition);
+
+          dividerChild = Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.keyboard_arrow_down_rounded,
+                  size: 16, color: cs.onSurfaceVariant),
+              const SizedBox(width: 2),
+              Text(olderLabel, style: baseStyle),
+              Text('  /  ', style: baseStyle),
+              Text(newerLabel, style: baseStyle),
+              const SizedBox(width: 2),
+              Icon(Icons.keyboard_arrow_up_rounded,
+                  size: 16, color: cs.onSurfaceVariant),
+            ],
+          );
+        }
+
         listItems.add(
           Padding(
-            padding: const EdgeInsets.only(top: 12, bottom: 4),
-            child: DividerWithText(
-              text: label,
-              style: isJanuary ? const TextStyle(fontWeight: FontWeight.bold) : null,
-            ),
+            padding: const EdgeInsets.symmetric(vertical: 8),
+            child: DividerWithWidget(child: dividerChild),
           ),
         );
         lastMonthKey = monthKey;
+        lastMonthDate = dt;
       }
 
       listItems.add(_TripCard(trip: trip, trainlog: widget.trainlog));

--- a/lib/features/trips/widgets/trip_card_view.dart
+++ b/lib/features/trips/widgets/trip_card_view.dart
@@ -176,8 +176,9 @@ class _TripCardViewState extends State<TripCardView> {
           final newerDt = lastMonthDate!;
           final yearTransition = dt.year != newerDt.year;
           final bold = yearTransition ? FontWeight.bold : FontWeight.normal;
+          final color = yearTransition ? cs.primary : cs.onSurfaceVariant;
           final baseStyle = Theme.of(context).textTheme.bodyMedium?.copyWith(
-                color: cs.onSurfaceVariant,
+                color: color,
                 fontWeight: bold,
               );
 
@@ -194,21 +195,21 @@ class _TripCardViewState extends State<TripCardView> {
             mainAxisSize: MainAxisSize.min,
             children: [
               Icon(Icons.keyboard_arrow_down_rounded,
-                  size: 16, color: cs.onSurfaceVariant),
+                  size: 16, color: color),
               const SizedBox(width: 2),
               Text(olderLabel, style: baseStyle),
               Text('  /  ', style: baseStyle),
               Text(newerLabel, style: baseStyle),
               const SizedBox(width: 2),
               Icon(Icons.keyboard_arrow_up_rounded,
-                  size: 16, color: cs.onSurfaceVariant),
+                  size: 16, color: color),
             ],
           );
         }
 
         listItems.add(
           Padding(
-            padding: const EdgeInsets.symmetric(vertical: 8),
+            padding: const EdgeInsets.fromLTRB(0, 8, 0, 16),
             child: DividerWithWidget(child: dividerChild),
           ),
         );

--- a/lib/features/trips/widgets/trip_card_view.dart
+++ b/lib/features/trips/widgets/trip_card_view.dart
@@ -109,7 +109,9 @@ class _TripCardViewState extends State<TripCardView> {
       filter: widget.filter,
       limit: _pageSize,
       offset: pageIndex * _pageSize,
-      orderBy: 'start_datetime DESC',
+      orderBy: widget.timeMoment == TimeMoment.future
+          ? 'start_datetime ASC'
+          : 'start_datetime DESC',
     );
     for (int i = 0; i < trips.length; i++) {
       final idx = pageIndex * _pageSize + i;
@@ -160,21 +162,25 @@ class _TripCardViewState extends State<TripCardView> {
       if (monthKey != lastMonthKey) {
         final Widget dividerChild;
 
+        final l10n = AppLocalizations.of(context)!;
+        final isUnknown = dt.year == 0 || dt.year == 9999;
+
         if (isFirstDivider || lastMonthDate == null) {
-          // Top of the list: show only the year.
+          // Top of the list: year only (or "Undefined" for unknown dates).
           dividerChild = Text(
-            '${dt.year}',
+            isUnknown ? l10n.tripCardDateUndefined : '${dt.year}',
             style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                   color: cs.onSurfaceVariant,
                 ),
           );
           isFirstDivider = false;
         } else {
-          // Between two months: "↓ olderMonth / newerMonth ↑"
-          // dt        = current (older, below in list)
-          // lastMonthDate = previous (newer, above in list)
-          final newerDt = lastMonthDate!;
-          final yearTransition = dt.year != newerDt.year;
+          // Between two months: "↓ belowMonth / aboveMonth ↑"
+          // dt            = month below the divider (just entered)
+          // lastMonthDate = month above the divider (previously processed)
+          final aboveDt = lastMonthDate!;
+          final isAboveUnknown = aboveDt.year == 0 || aboveDt.year == 9999;
+          final yearTransition = !isUnknown && !isAboveUnknown && dt.year != aboveDt.year;
           final bold = yearTransition ? FontWeight.bold : FontWeight.normal;
           final color = yearTransition ? cs.primary : cs.onSurfaceVariant;
           final baseStyle = Theme.of(context).textTheme.bodyMedium?.copyWith(
@@ -182,14 +188,15 @@ class _TripCardViewState extends State<TripCardView> {
                 fontWeight: bold,
               );
 
-          String monthName(DateTime d, {required bool showYear}) {
+          String monthLabel(DateTime d, bool unknown, {required bool showYear}) {
+            if (unknown) return l10n.tripCardDateUndefined;
             final raw = DateFormat('MMMM', locale).format(d);
             final capitalized = raw[0].toUpperCase() + raw.substring(1);
             return showYear ? '$capitalized ${d.year}' : capitalized;
           }
 
-          final olderLabel = monthName(dt, showYear: yearTransition);
-          final newerLabel = monthName(newerDt, showYear: yearTransition);
+          final belowLabel = monthLabel(dt, isUnknown, showYear: yearTransition);
+          final aboveLabel = monthLabel(aboveDt, isAboveUnknown, showYear: yearTransition);
 
           dividerChild = Row(
             mainAxisSize: MainAxisSize.min,
@@ -197,9 +204,9 @@ class _TripCardViewState extends State<TripCardView> {
               Icon(Icons.keyboard_arrow_down_rounded,
                   size: 16, color: color),
               const SizedBox(width: 2),
-              Text(olderLabel, style: baseStyle),
+              Text(belowLabel, style: baseStyle),
               Text('  /  ', style: baseStyle),
-              Text(newerLabel, style: baseStyle),
+              Text(aboveLabel, style: baseStyle),
               const SizedBox(width: 2),
               Icon(Icons.keyboard_arrow_up_rounded,
                   size: 16, color: color),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -567,5 +567,6 @@
   "onboardingPage4Subtitle": "Are you a frequent traveller? See how your travels stack up against other members worldwide.",
 
   "tapAgainToExit": "Tap again to exit",
-  "tripsEmptyList": "No trips yet"
+  "tripsEmptyList": "No trips yet",
+  "tripCardDateUndefined": "Undefined"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -373,5 +373,6 @@
   "onboardingPage4Subtitle": "Êtes-vous un grand voyageur ? Comparez vos voyages avec ceux des autres membres du monde entier.",
 
   "tapAgainToExit": "Appuyez à nouveau pour quitter",
-  "tripsEmptyList": "Aucun trajet"
+  "tripsEmptyList": "Aucun trajet",
+  "tripCardDateUndefined": "Indéfinie"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -374,5 +374,6 @@
   "onboardingPage4Subtitle": "よく旅をするあなたへ。世界中のメンバーと旅の記録を比べてみましょう。",
 
   "tapAgainToExit": "もう一度タップすると終了します",
-  "tripsEmptyList": "まだ旅はありません"
+  "tripsEmptyList": "まだ旅はありません",
+  "tripCardDateUndefined": "未定義"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2195,6 +2195,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'No trips yet'**
   String get tripsEmptyList;
+
+  /// No description provided for @tripCardDateUndefined.
+  ///
+  /// In en, this message translates to:
+  /// **'Undefined'**
+  String get tripCardDateUndefined;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1270,4 +1270,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get tripsEmptyList => 'No trips yet';
+
+  @override
+  String get tripCardDateUndefined => 'Undefined';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1278,4 +1278,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get tripsEmptyList => 'Aucun trajet';
+
+  @override
+  String get tripCardDateUndefined => 'Indéfinie';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1250,4 +1250,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get tripsEmptyList => 'まだ旅はありません';
+
+  @override
+  String get tripCardDateUndefined => '未定義';
 }

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -1252,4 +1252,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String get tripsEmptyList => 'Wala pang biyahe';
+
+  @override
+  String get tripCardDateUndefined => 'Hindi natukoy';
 }

--- a/lib/l10n/app_tl.arb
+++ b/lib/l10n/app_tl.arb
@@ -539,5 +539,6 @@
   "onboardingPage4Subtitle": "Ikaw ba ay madalas maglakbay? Tingnan kung paano ang iyong mga paglalakbay kumpara sa ibang mga miyembro sa buong mundo.",
 
   "tapAgainToExit": "I-tap muli para lumabas",
-  "tripsEmptyList": "Wala pang biyahe"
+  "tripsEmptyList": "Wala pang biyahe",
+  "tripCardDateUndefined": "Hindi natukoy"
 }

--- a/lib/widgets/divider_with_widget.dart
+++ b/lib/widgets/divider_with_widget.dart
@@ -38,10 +38,12 @@ class DividerWithWidget extends StatelessWidget {
 
 class DividerWithText extends StatelessWidget {
   final String text;
+  final TextStyle? style;
 
   const DividerWithText({
     super.key,
     required this.text,
+    this.style,
   });
 
   @override
@@ -53,7 +55,7 @@ class DividerWithText extends StatelessWidget {
         text,
         style: Theme.of(context).textTheme.bodyMedium?.copyWith(
               color: cs.onSurfaceVariant,
-            ),
+            ).merge(style),
       ),
     );
   }


### PR DESCRIPTION
## Summary
This PR enhances the trip card view by adding visual month/year dividers between trips and improving the sorting logic for future trips. The changes provide better organization and readability of the trip list.

## Key Changes
- **Month/Year Dividers**: Trips are now grouped by month with dividers showing:
  - Year only at the top of the list
  - Month transitions between trips with directional indicators (↓/↑) and month labels
  - Special handling for undefined dates (year 0 or 9999)
  - Bold styling and primary color highlighting for year transitions

- **Improved Sorting**: Future trips now sort in ascending order (earliest first) while past trips remain in descending order (most recent first)

- **UI Enhancements**:
  - Refactored `ListView.builder` to `ListView` with pre-built list items for better divider integration
  - Updated `DividerWithWidget` to support custom text styling via optional `style` parameter
  - Added new localization string `tripCardDateUndefined` for handling trips with undefined dates

- **Localization**: Added translations for "Undefined" in English, French, Japanese, and Tagalog

- **Minor Fix**: Changed tooltip trigger mode in statistics page from `longPress` to `tap` for better UX

## Implementation Details
- Dividers are built dynamically based on month transitions while iterating through trips
- Locale-aware month formatting using `intl` package
- Skeleton loaders are still shown for unloaded items during pagination
- Loading indicator remains at the bottom when more items are being fetched

https://claude.ai/code/session_016G1JgHwR76c6C68mjJmwns