### PR TITLE
Refactor adaptive UI components into reusable widgets

### DIFF
--- a/lib/features/menu/full_screen_menu_page.dart
+++ b/lib/features/menu/full_screen_menu_page.dart
@@ -10,8 +10,8 @@ import 'package:trainlog_app/navigation/nav_models.dart';
 import 'package:trainlog_app/providers/settings_provider.dart';
 import 'package:trainlog_app/providers/trainlog_provider.dart';
 import 'package:trainlog_app/providers/trips_provider.dart';
+import 'package:trainlog_app/platform/adaptive_widget.dart';
 import 'package:trainlog_app/utils/platform_utils.dart';
-import 'package:trainlog_app/widgets/app_bar_square_button.dart';
 
 /// Full-screen menu replacing the legacy Drawer on Android.
 /// Provides a clean entry point for iOS (wire up from the iOS shell when ready).
@@ -135,7 +135,7 @@ class _TopBar extends StatelessWidget {
       padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
       child: Row(
         children: [
-          AppBarSquareButton(
+          AdaptiveAppBarSquareButton(
             icon: Icons.keyboard_arrow_down,
             onPressed: onClose,
             tooltip: MaterialLocalizations.of(context).closeButtonTooltip,
@@ -147,7 +147,7 @@ class _TopBar extends StatelessWidget {
               style: theme.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w700),
             ),
           ),
-          AppBarSquareButton(
+          AdaptiveAppBarSquareButton(
             icon: Icons.settings_outlined,
             onPressed: onSettings,
             tooltip: loc.menuSettingsTitle,

--- a/lib/features/menu/full_screen_menu_page.dart
+++ b/lib/features/menu/full_screen_menu_page.dart
@@ -11,6 +11,7 @@ import 'package:trainlog_app/providers/settings_provider.dart';
 import 'package:trainlog_app/providers/trainlog_provider.dart';
 import 'package:trainlog_app/providers/trips_provider.dart';
 import 'package:trainlog_app/utils/platform_utils.dart';
+import 'package:trainlog_app/widgets/app_bar_square_button.dart';
 
 /// Full-screen menu replacing the legacy Drawer on Android.
 /// Provides a clean entry point for iOS (wire up from the iOS shell when ready).
@@ -129,35 +130,14 @@ class _TopBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final cs = theme.colorScheme;
-
-    Widget squareBtn({required IconData icon, required VoidCallback onTap, String? tooltip}) {
-      return Tooltip(
-        message: tooltip ?? '',
-        child: InkWell(
-          onTap: onTap,
-          borderRadius: BorderRadius.circular(10),
-          child: Container(
-            width: 38,
-            height: 38,
-            decoration: BoxDecoration(
-              color: cs.surface,
-              borderRadius: BorderRadius.circular(10),
-              border: Border.all(color: cs.outlineVariant, width: 1),
-            ),
-            child: Icon(icon, color: cs.onSurface, size: 20),
-          ),
-        ),
-      );
-    }
 
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
       child: Row(
         children: [
-          squareBtn(
+          AppBarSquareButton(
             icon: Icons.keyboard_arrow_down,
-            onTap: onClose,
+            onPressed: onClose,
             tooltip: MaterialLocalizations.of(context).closeButtonTooltip,
           ),
           Expanded(
@@ -167,9 +147,9 @@ class _TopBar extends StatelessWidget {
               style: theme.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w700),
             ),
           ),
-          squareBtn(
+          AppBarSquareButton(
             icon: Icons.settings_outlined,
-            onTap: onSettings,
+            onPressed: onSettings,
             tooltip: loc.menuSettingsTitle,
           ),
         ],

--- a/lib/features/statistics/statistics_page.dart
+++ b/lib/features/statistics/statistics_page.dart
@@ -19,6 +19,7 @@ import 'package:trainlog_app/features/statistics/widgets/logo_bar_chart.dart';
 import 'package:trainlog_app/features/statistics/widgets/stats_bar_chart.dart';
 import 'package:trainlog_app/features/statistics/widgets/stats_pie_chart.dart';
 import 'package:trainlog_app/features/statistics/widgets/stats_table_chart.dart';
+import 'package:trainlog_app/platform/adaptive_widget.dart';
 import 'package:trainlog_app/widgets/divider_with_widget.dart';
 
 enum StatisticsView { bar, pie, table }
@@ -690,14 +691,14 @@ class _YearChip extends StatelessWidget {
     final cs = Theme.of(context).colorScheme;
     final label = selected == 0 ? allYearsLabel : selected.toString();
 
-    return PopupMenuButton<int>(
+    return AdaptivePopup<int>(
       enabled: enabled,
       initialValue: selected,
       onSelected: onChanged,
-      itemBuilder: (_) => years
-          .map((y) => PopupMenuItem<int>(
+      items: years
+          .map((y) => AdaptivePopupItem(
                 value: y,
-                child: Text(y == 0 ? allYearsLabel : y.toString()),
+                label: y == 0 ? allYearsLabel : y.toString(),
               ))
           .toList(),
       child: Container(

--- a/lib/features/statistics/statistics_page.dart
+++ b/lib/features/statistics/statistics_page.dart
@@ -508,18 +508,14 @@ class _DimensionButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PopupMenuButton<GraphType>(
+    return AdaptivePopup<GraphType>(
       onSelected: onChanged,
-      itemBuilder: (_) => GraphType.values
-          .map((g) => PopupMenuItem<GraphType>(
+      initialValue: graph,
+      items: GraphType.values
+          .map((g) => AdaptivePopupItem(
                 value: g,
-                child: Row(
-                  children: [
-                    g.icon(),
-                    const SizedBox(width: 10),
-                    Text(g.label(context, vehicle)),
-                  ],
-                ),
+                label: g.label(context, vehicle),
+                leading: g.icon(),
               ))
           .toList(),
       child: Row(
@@ -570,23 +566,19 @@ class _OutlinedDropdown<T> extends StatelessWidget {
     final cs = Theme.of(context).colorScheme;
     final icon = iconOf(selected);
 
-    return PopupMenuButton<T>(
-      onSelected: (v) => onChanged(v),
-      itemBuilder: (_) => items
-          .map((item) => PopupMenuItem<T>(
+    return AdaptivePopup<T>(
+      onSelected: onChanged,
+      initialValue: selected,
+      items: items
+          .map((item) => AdaptivePopupItem(
                 value: item,
-                child: Row(
-                  children: [
-                    if (iconOf(item) != null) ...[
-                      IconTheme(
+                label: labelOf(item),
+                leading: iconOf(item) != null
+                    ? IconTheme(
                         data: IconThemeData(size: 18, color: cs.primary),
                         child: iconOf(item)!,
-                      ),
-                      const SizedBox(width: 10),
-                    ],
-                    Text(labelOf(item)),
-                  ],
-                ),
+                      )
+                    : null,
               ))
           .toList(),
       child: Container(

--- a/lib/features/trips/trips_page.dart
+++ b/lib/features/trips/trips_page.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -14,6 +13,7 @@ import 'package:trainlog_app/providers/trips_provider.dart';
 import 'package:trainlog_app/utils/platform_utils.dart';
 import 'package:trainlog_app/widgets/app_steps_tab_bar.dart';
 import 'package:trainlog_app/widgets/past_future_selector.dart';
+import 'package:trainlog_app/widgets/app_bar_square_button.dart';
 import 'package:trainlog_app/widgets/trips_filter_dialog.dart';
 
 const _kViewPrefKey = 'trips_view_mode'; // 'card' or 'table'
@@ -263,19 +263,23 @@ class _PageHeader extends StatelessWidget {
             const Spacer(),
 
           // View toggle
-          _HeaderIconButton(
+          AppBarSquareButton(
             icon: isCardView ? Icons.table_chart_outlined : Icons.view_agenda_outlined,
-            tooltip: isCardView ? 'Table view' : 'Card view',
             onPressed: onToggleView,
+            tooltip: isCardView ? 'Table view' : 'Card view',
+            size: 36,
+            iconSize: 18,
           ),
 
           // Clear filter (when active)
           if (activeFilter != null) ...[
             const SizedBox(width: 8),
-            _HeaderIconButton(
+            AppBarSquareButton(
               icon: Icons.search_off,
-              tooltip: AppLocalizations.of(context)!.filterClearButton,
               onPressed: onClearFilter,
+              tooltip: AppLocalizations.of(context)!.filterClearButton,
+              size: 36,
+              iconSize: 18,
               circle: true,
             ),
           ],
@@ -283,121 +287,14 @@ class _PageHeader extends StatelessWidget {
           const SizedBox(width: 8),
 
           // Filter button
-          _AdaptiveFilterButton(
+          AppBarSquareButton(
+            icon: AdaptiveIcons.filter,
             onPressed: onFilterTap,
             tooltip: AppLocalizations.of(context)!.filterButton,
+            size: 36,
+            iconSize: 18,
           ),
         ],
-      ),
-    );
-  }
-}
-
-/// Rounded-rectangle icon button matching the screenshot design.
-/// Used for view toggle and clear-filter actions.
-class _HeaderIconButton extends StatelessWidget {
-  const _HeaderIconButton({
-    required this.icon,
-    required this.tooltip,
-    required this.onPressed,
-    this.circle = false,
-  });
-
-  final IconData icon;
-  final String tooltip;
-  final VoidCallback onPressed;
-  /// When true renders as a circle (used for the clear-filter action).
-  final bool circle;
-
-  @override
-  Widget build(BuildContext context) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
-    final cs = Theme.of(context).colorScheme;
-    final bg = isDark ? cs.surfaceContainerHigh : cs.surface;
-    final fg = cs.onSurface;
-    final radius = circle ? BorderRadius.circular(20) : BorderRadius.circular(10);
-
-    if (AppPlatform.isApple) {
-      return CupertinoButton(
-        padding: EdgeInsets.zero,
-        onPressed: onPressed,
-        child: Container(
-          width: 36,
-          height: 36,
-          decoration: BoxDecoration(
-            color: CupertinoColors.systemFill.resolveFrom(context),
-            borderRadius: radius,
-          ),
-          child: Icon(icon, size: 18, color: CupertinoTheme.of(context).primaryColor),
-        ),
-      );
-    }
-    return Tooltip(
-      message: tooltip,
-      child: InkWell(
-        onTap: onPressed,
-        borderRadius: radius,
-        child: Container(
-          width: 36,
-          height: 36,
-          decoration: BoxDecoration(
-            color: bg,
-            borderRadius: radius,
-            border: Border.all(
-              color: cs.outline.withValues(alpha: 0.3),
-            ),
-          ),
-          child: Icon(icon, size: 18, color: fg),
-        ),
-      ),
-    );
-  }
-}
-
-class _AdaptiveFilterButton extends StatelessWidget {
-  final VoidCallback onPressed;
-  final String tooltip;
-
-  const _AdaptiveFilterButton({required this.onPressed, required this.tooltip});
-
-  @override
-  Widget build(BuildContext context) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
-    final cs = Theme.of(context).colorScheme;
-    const radius = BorderRadius.all(Radius.circular(10));
-
-    if (AppPlatform.isApple) {
-      return CupertinoButton(
-        padding: EdgeInsets.zero,
-        onPressed: onPressed,
-        child: Container(
-          width: 36,
-          height: 36,
-          decoration: BoxDecoration(
-            color: CupertinoColors.systemFill.resolveFrom(context),
-            borderRadius: radius,
-          ),
-          child: Icon(AdaptiveIcons.filter, size: 20,
-              color: CupertinoTheme.of(context).primaryColor),
-        ),
-      );
-    }
-
-    return Tooltip(
-      message: tooltip,
-      child: InkWell(
-        onTap: onPressed,
-        borderRadius: radius,
-        child: Container(
-          width: 36,
-          height: 36,
-          decoration: BoxDecoration(
-            color: isDark ? cs.surfaceContainerHigh : cs.surface,
-            borderRadius: radius,
-            border: Border.all(color: cs.outline.withValues(alpha: 0.3)),
-          ),
-          child: Icon(Icons.filter_alt_outlined, size: 18, color: cs.onSurface),
-        ),
       ),
     );
   }

--- a/lib/features/trips/trips_page.dart
+++ b/lib/features/trips/trips_page.dart
@@ -13,7 +13,7 @@ import 'package:trainlog_app/providers/trips_provider.dart';
 import 'package:trainlog_app/utils/platform_utils.dart';
 import 'package:trainlog_app/widgets/app_steps_tab_bar.dart';
 import 'package:trainlog_app/widgets/past_future_selector.dart';
-import 'package:trainlog_app/widgets/app_bar_square_button.dart';
+import 'package:trainlog_app/platform/adaptive_widget.dart';
 import 'package:trainlog_app/widgets/trips_filter_dialog.dart';
 
 const _kViewPrefKey = 'trips_view_mode'; // 'card' or 'table'
@@ -263,7 +263,7 @@ class _PageHeader extends StatelessWidget {
             const Spacer(),
 
           // View toggle
-          AppBarSquareButton(
+          AdaptiveAppBarSquareButton(
             icon: isCardView ? Icons.table_chart_outlined : Icons.view_agenda_outlined,
             onPressed: onToggleView,
             tooltip: isCardView ? 'Table view' : 'Card view',
@@ -274,7 +274,7 @@ class _PageHeader extends StatelessWidget {
           // Clear filter (when active)
           if (activeFilter != null) ...[
             const SizedBox(width: 8),
-            AppBarSquareButton(
+            AdaptiveAppBarSquareButton(
               icon: Icons.search_off,
               onPressed: onClearFilter,
               tooltip: AppLocalizations.of(context)!.filterClearButton,
@@ -287,7 +287,7 @@ class _PageHeader extends StatelessWidget {
           const SizedBox(width: 8),
 
           // Filter button
-          AppBarSquareButton(
+          AdaptiveAppBarSquareButton(
             icon: AdaptiveIcons.filter,
             onPressed: onFilterTap,
             tooltip: AppLocalizations.of(context)!.filterButton,

--- a/lib/navigation/cupertino_shell.dart
+++ b/lib/navigation/cupertino_shell.dart
@@ -11,6 +11,7 @@ import 'package:trainlog_app/utils/platform_utils.dart';
 import 'package:trainlog_app/features/map/map_page.dart';
 import 'package:trainlog_app/features/menu/full_screen_menu_page.dart';
 import 'package:trainlog_app/features/ranking/ranking_page.dart';
+import 'package:trainlog_app/features/settings/settings_page.dart';
 import 'package:trainlog_app/features/statistics/statistics_page.dart';
 import 'package:trainlog_app/features/trainlog/inbox_page.dart';
 import 'package:trainlog_app/features/trainlog/trainlog_status_page.dart';
@@ -50,7 +51,14 @@ class _CupertinoShellState extends State<CupertinoShell> {
         opaque: true,
         pageBuilder: (ctx, _, __) => FullScreenMenuPage(
           onClose: () => Navigator.of(ctx).pop(),
-          onSettingsTap: () => Navigator.of(ctx).pop(),
+          onSettingsTap: () {
+            Navigator.of(ctx).pop();
+            Navigator.of(context).push(PageRouteBuilder(
+              pageBuilder: (_, __, ___) => const SettingsPage(),
+              transitionDuration: Duration.zero,
+              reverseTransitionDuration: Duration.zero,
+            ));
+          },
           onPageTap: (id) => Navigator.of(ctx).pop(),
           onInboxTap: () {
             Navigator.of(ctx).pop();

--- a/lib/platform/adaptive_widget.dart
+++ b/lib/platform/adaptive_widget.dart
@@ -1,3 +1,4 @@
+export 'widget/adaptive_app_bar_square_button.dart';
 export 'widget/adaptive_destructive_button.dart';
 export 'widget/adaptive_filled_button.dart';
 export 'widget/adaptive_filled_icon_button.dart';

--- a/lib/platform/adaptive_widget.dart
+++ b/lib/platform/adaptive_widget.dart
@@ -2,3 +2,4 @@ export 'widget/adaptive_app_bar_square_button.dart';
 export 'widget/adaptive_destructive_button.dart';
 export 'widget/adaptive_filled_button.dart';
 export 'widget/adaptive_filled_icon_button.dart';
+export 'widget/adaptive_popup.dart';

--- a/lib/platform/widget/adaptive_app_bar_square_button.dart
+++ b/lib/platform/widget/adaptive_app_bar_square_button.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:trainlog_app/utils/platform_utils.dart';
+import 'package:trainlog_app/platform/widget/adaptive_widget_base.dart';
 
 /// A small square (or circular) icon button used in app bars and page headers.
-class AppBarSquareButton extends StatelessWidget {
-  const AppBarSquareButton({
+class AdaptiveAppBarSquareButton extends AdaptiveWidget {
+  const AdaptiveAppBarSquareButton({
     super.key,
     required this.icon,
     required this.onPressed,
@@ -23,42 +23,43 @@ class AppBarSquareButton extends StatelessWidget {
   /// When true, renders with a fully circular border radius.
   final bool circle;
 
+  BorderRadius get _radius => BorderRadius.circular(circle ? size / 2 : 10);
+
   @override
-  Widget build(BuildContext context) {
-    final radius = BorderRadius.circular(circle ? size / 2 : 10);
-
-    if (AppPlatform.isApple) {
-      return CupertinoButton(
-        padding: EdgeInsets.zero,
-        onPressed: onPressed,
-        child: Container(
-          width: size,
-          height: size,
-          decoration: BoxDecoration(
-            color: CupertinoColors.systemFill.resolveFrom(context),
-            borderRadius: radius,
-          ),
-          child: Icon(icon, size: iconSize, color: CupertinoTheme.of(context).primaryColor),
-        ),
-      );
-    }
-
+  Widget buildMaterial(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     return Tooltip(
       message: tooltip,
       child: InkWell(
         onTap: onPressed,
-        borderRadius: radius,
+        borderRadius: _radius,
         child: Container(
           width: size,
           height: size,
           decoration: BoxDecoration(
             color: cs.surface,
-            borderRadius: radius,
+            borderRadius: _radius,
             border: Border.all(color: cs.outlineVariant),
           ),
           child: Icon(icon, size: iconSize, color: cs.onSurface),
         ),
+      ),
+    );
+  }
+
+  @override
+  Widget buildCupertino(BuildContext context) {
+    return CupertinoButton(
+      padding: EdgeInsets.zero,
+      onPressed: onPressed,
+      child: Container(
+        width: size,
+        height: size,
+        decoration: BoxDecoration(
+          color: CupertinoColors.systemFill.resolveFrom(context),
+          borderRadius: _radius,
+        ),
+        child: Icon(icon, size: iconSize, color: CupertinoTheme.of(context).primaryColor),
       ),
     );
   }

--- a/lib/platform/widget/adaptive_app_bar_square_button.dart
+++ b/lib/platform/widget/adaptive_app_bar_square_button.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:trainlog_app/platform/widget/adaptive_widget_base.dart';
 
@@ -49,17 +48,18 @@ class AdaptiveAppBarSquareButton extends AdaptiveWidget {
 
   @override
   Widget buildCupertino(BuildContext context) {
-    return CupertinoButton(
-      padding: EdgeInsets.zero,
-      onPressed: onPressed,
+    final cs = Theme.of(context).colorScheme;
+    return GestureDetector(
+      onTap: onPressed,
       child: Container(
         width: size,
         height: size,
         decoration: BoxDecoration(
-          color: CupertinoColors.systemFill.resolveFrom(context),
+          color: cs.surface,
           borderRadius: _radius,
+          border: Border.all(color: cs.outlineVariant),
         ),
-        child: Icon(icon, size: iconSize, color: CupertinoTheme.of(context).primaryColor),
+        child: Icon(icon, size: iconSize, color: cs.onSurface),
       ),
     );
   }

--- a/lib/platform/widget/adaptive_popup.dart
+++ b/lib/platform/widget/adaptive_popup.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:trainlog_app/platform/widget/adaptive_widget_base.dart';
+
+/// A single item in an [AdaptivePopup] menu.
+class AdaptivePopupItem<T> {
+  const AdaptivePopupItem({required this.value, required this.label});
+
+  final T value;
+  final String label;
+}
+
+/// A popup menu button that uses [PopupMenuButton] on Material and a
+/// [CupertinoActionSheet] on Apple platforms.
+///
+/// The [child] is the widget used as the tap target to open the menu.
+class AdaptivePopup<T> extends AdaptiveWidget {
+  const AdaptivePopup({
+    super.key,
+    required this.items,
+    required this.onSelected,
+    required this.child,
+    this.initialValue,
+    this.enabled = true,
+  });
+
+  final List<AdaptivePopupItem<T>> items;
+  final ValueChanged<T> onSelected;
+  final Widget child;
+  final T? initialValue;
+  final bool enabled;
+
+  @override
+  Widget buildMaterial(BuildContext context) {
+    return PopupMenuButton<T>(
+      enabled: enabled,
+      initialValue: initialValue,
+      onSelected: onSelected,
+      itemBuilder: (_) => items
+          .map((item) => PopupMenuItem<T>(
+                value: item.value,
+                child: Text(item.label),
+              ))
+          .toList(),
+      child: child,
+    );
+  }
+
+  @override
+  Widget buildCupertino(BuildContext context) {
+    return GestureDetector(
+      onTap: enabled
+          ? () => showCupertinoModalPopup<void>(
+                context: context,
+                builder: (_) => CupertinoActionSheet(
+                  actions: items
+                      .map(
+                        (item) => CupertinoActionSheetAction(
+                          isDefaultAction: item.value == initialValue,
+                          onPressed: () {
+                            Navigator.of(context).pop();
+                            onSelected(item.value);
+                          },
+                          child: Text(item.label),
+                        ),
+                      )
+                      .toList(),
+                  cancelButton: CupertinoActionSheetAction(
+                    onPressed: () => Navigator.of(context).pop(),
+                    child: Text(CupertinoLocalizations.of(context).cancelButtonLabel),
+                  ),
+                ),
+              )
+          : null,
+      child: child,
+    );
+  }
+}

--- a/lib/platform/widget/adaptive_popup.dart
+++ b/lib/platform/widget/adaptive_popup.dart
@@ -3,11 +3,14 @@ import 'package:flutter/material.dart';
 import 'package:trainlog_app/platform/widget/adaptive_widget_base.dart';
 
 /// A single item in an [AdaptivePopup] menu.
+///
+/// [leading] is shown before the label on both platforms (icon, etc.).
 class AdaptivePopupItem<T> {
-  const AdaptivePopupItem({required this.value, required this.label});
+  const AdaptivePopupItem({required this.value, required this.label, this.leading});
 
   final T value;
   final String label;
+  final Widget? leading;
 }
 
 /// A popup menu button that uses [PopupMenuButton] on Material and a
@@ -30,6 +33,17 @@ class AdaptivePopup<T> extends AdaptiveWidget {
   final T? initialValue;
   final bool enabled;
 
+  Widget _itemChild(AdaptivePopupItem<T> item) {
+    if (item.leading == null) return Text(item.label);
+    return Row(
+      children: [
+        item.leading!,
+        const SizedBox(width: 10),
+        Text(item.label),
+      ],
+    );
+  }
+
   @override
   Widget buildMaterial(BuildContext context) {
     return PopupMenuButton<T>(
@@ -39,7 +53,7 @@ class AdaptivePopup<T> extends AdaptiveWidget {
       itemBuilder: (_) => items
           .map((item) => PopupMenuItem<T>(
                 value: item.value,
-                child: Text(item.label),
+                child: _itemChild(item),
               ))
           .toList(),
       child: child,
@@ -61,7 +75,7 @@ class AdaptivePopup<T> extends AdaptiveWidget {
                             Navigator.of(context).pop();
                             onSelected(item.value);
                           },
-                          child: Text(item.label),
+                          child: _itemChild(item),
                         ),
                       )
                       .toList(),

--- a/lib/platform/widget/adaptive_popup.dart
+++ b/lib/platform/widget/adaptive_popup.dart
@@ -66,13 +66,13 @@ class AdaptivePopup<T> extends AdaptiveWidget {
       onTap: enabled
           ? () => showCupertinoModalPopup<void>(
                 context: context,
-                builder: (_) => CupertinoActionSheet(
+                builder: (sheetContext) => CupertinoActionSheet(
                   actions: items
                       .map(
                         (item) => CupertinoActionSheetAction(
                           isDefaultAction: item.value == initialValue,
                           onPressed: () {
-                            Navigator.of(context).pop();
+                            Navigator.of(sheetContext).pop();
                             onSelected(item.value);
                           },
                           child: _itemChild(item),
@@ -80,8 +80,8 @@ class AdaptivePopup<T> extends AdaptiveWidget {
                       )
                       .toList(),
                   cancelButton: CupertinoActionSheetAction(
-                    onPressed: () => Navigator.of(context).pop(),
-                    child: Text(CupertinoLocalizations.of(context).cancelButtonLabel),
+                    onPressed: () => Navigator.of(sheetContext).pop(),
+                    child: Text(CupertinoLocalizations.of(sheetContext).cancelButtonLabel),
                   ),
                 ),
               )

--- a/lib/widgets/app_bar_square_button.dart
+++ b/lib/widgets/app_bar_square_button.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:trainlog_app/utils/platform_utils.dart';
+
+/// A small square (or circular) icon button used in app bars and page headers.
+class AppBarSquareButton extends StatelessWidget {
+  const AppBarSquareButton({
+    super.key,
+    required this.icon,
+    required this.onPressed,
+    this.tooltip = '',
+    this.size = 38,
+    this.iconSize = 20,
+    this.circle = false,
+  });
+
+  final IconData icon;
+  final VoidCallback onPressed;
+  final String tooltip;
+  final double size;
+  final double iconSize;
+
+  /// When true, renders with a fully circular border radius.
+  final bool circle;
+
+  @override
+  Widget build(BuildContext context) {
+    final radius = BorderRadius.circular(circle ? size / 2 : 10);
+
+    if (AppPlatform.isApple) {
+      return CupertinoButton(
+        padding: EdgeInsets.zero,
+        onPressed: onPressed,
+        child: Container(
+          width: size,
+          height: size,
+          decoration: BoxDecoration(
+            color: CupertinoColors.systemFill.resolveFrom(context),
+            borderRadius: radius,
+          ),
+          child: Icon(icon, size: iconSize, color: CupertinoTheme.of(context).primaryColor),
+        ),
+      );
+    }
+
+    final cs = Theme.of(context).colorScheme;
+    return Tooltip(
+      message: tooltip,
+      child: InkWell(
+        onTap: onPressed,
+        borderRadius: radius,
+        child: Container(
+          width: size,
+          height: size,
+          decoration: BoxDecoration(
+            color: cs.surface,
+            borderRadius: radius,
+            border: Border.all(color: cs.outlineVariant),
+          ),
+          child: Icon(icon, size: iconSize, color: cs.onSurface),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
Extracted platform-specific UI button and popup implementations into reusable adaptive widget components to reduce code duplication and improve maintainability across the app.

## Key Changes

- **New adaptive widgets created:**
  - `AdaptiveAppBarSquareButton`: A small square/circular icon button for app bars and headers that adapts between Material and Cupertino designs
  - `AdaptivePopup`: A popup menu that uses `PopupMenuButton` on Material and `CupertinoActionSheet` on Apple platforms
  - `AdaptivePopupItem`: A data class for popup menu items with support for leading widgets

- **Refactored existing code:**
  - Removed `_HeaderIconButton` and `_AdaptiveFilterButton` from `trips_page.dart` and replaced with `AdaptiveAppBarSquareButton`
  - Updated `statistics_page.dart` to use `AdaptivePopup` instead of inline `PopupMenuButton` implementations in `_DimensionButton`, `_OutlinedDropdown`, and `_YearChip`
  - Updated `full_screen_menu_page.dart` to use `AdaptiveAppBarSquareButton` instead of inline button implementation
  - Updated `cupertino_shell.dart` to properly navigate to settings page

- **Updated exports:**
  - Added new adaptive widgets to `lib/platform/adaptive_widget.dart` barrel export

## Implementation Details

- `AdaptiveAppBarSquareButton` supports customizable size, icon size, and circular/rounded styling
- `AdaptivePopup` maintains consistent API with Material's `PopupMenuButton` while providing native Cupertino experience
- All new components extend `AdaptiveWidget` base class for consistent platform-specific rendering
- Removed unused `flutter/cupertino.dart` import from `trips_page.dart`

https://claude.ai/code/session_01JJU8p2AG6KpfTFjLxS5SyD