### PR TITLE
Improve layout flexibility and text overflow handling in statistics page

### DIFF
--- a/lib/features/statistics/statistics_page.dart
+++ b/lib/features/statistics/statistics_page.dart
@@ -75,13 +75,16 @@ class _StatisticsPageState extends State<StatisticsPage> {
               Row(
                 crossAxisAlignment: CrossAxisAlignment.center,
                 children: [
-                  Text(
-                    loc.statisticsTitle,
-                    style: Theme.of(context).textTheme.headlineMedium?.copyWith(
-                          fontWeight: FontWeight.w700,
-                        ),
+                  Flexible(
+                    child: Text(
+                      loc.statisticsTitle,
+                      style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                            fontWeight: FontWeight.w700,
+                          ),
+                      overflow: TextOverflow.ellipsis,
+                    ),
                   ),
-                  const Spacer(),
+                  const SizedBox(width: 8),
                   _YearChip(
                     years: [0, ...tripsProv.years],
                     selected: statsProv.year ?? 0,

--- a/lib/features/statistics/statistics_page.dart
+++ b/lib/features/statistics/statistics_page.dart
@@ -75,22 +75,21 @@ class _StatisticsPageState extends State<StatisticsPage> {
               Row(
                 crossAxisAlignment: CrossAxisAlignment.center,
                 children: [
-                  Flexible(
-                    child: Text(
-                      loc.statisticsTitle,
-                      style: Theme.of(context).textTheme.headlineMedium?.copyWith(
-                            fontWeight: FontWeight.w700,
-                          ),
-                      overflow: TextOverflow.ellipsis,
-                    ),
+                  Text(
+                    loc.statisticsTitle,
+                    style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                          fontWeight: FontWeight.w700,
+                        ),
                   ),
-                  const SizedBox(width: 8),
-                  _YearChip(
-                    years: [0, ...tripsProv.years],
-                    selected: statsProv.year ?? 0,
-                    enabled: !disabledYears,
-                    allYearsLabel: loc.tripsFilterAllYears,
-                    onChanged: (y) => statsProv.year = y,
+                  const Spacer(),
+                  Flexible(
+                    child: _YearChip(
+                      years: [0, ...tripsProv.years],
+                      selected: statsProv.year ?? 0,
+                      enabled: !disabledYears,
+                      allYearsLabel: loc.tripsFilterAllYears,
+                      onChanged: (y) => statsProv.year = y,
+                    ),
                   ),
                 ],
               ),
@@ -708,12 +707,15 @@ class _YearChip extends StatelessWidget {
           children: [
             Icon(Icons.calendar_today_outlined, size: 14, color: cs.onSurfaceVariant),
             const SizedBox(width: 6),
-            Text(
-              label,
-              style: Theme.of(context)
-                  .textTheme
-                  .labelLarge
-                  ?.copyWith(fontWeight: FontWeight.w600),
+            Flexible(
+              child: Text(
+                label,
+                overflow: TextOverflow.ellipsis,
+                style: Theme.of(context)
+                    .textTheme
+                    .labelLarge
+                    ?.copyWith(fontWeight: FontWeight.w600),
+              ),
             ),
             const SizedBox(width: 4),
             Icon(Icons.keyboard_arrow_down, size: 16, color: cs.onSurfaceVariant),

--- a/lib/features/statistics/statistics_page.dart
+++ b/lib/features/statistics/statistics_page.dart
@@ -81,14 +81,17 @@ class _StatisticsPageState extends State<StatisticsPage> {
                           fontWeight: FontWeight.w700,
                         ),
                   ),
-                  const Spacer(),
-                  Flexible(
-                    child: _YearChip(
-                      years: [0, ...tripsProv.years],
-                      selected: statsProv.year ?? 0,
-                      enabled: !disabledYears,
-                      allYearsLabel: loc.tripsFilterAllYears,
-                      onChanged: (y) => statsProv.year = y,
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Align(
+                      alignment: Alignment.centerRight,
+                      child: _YearChip(
+                        years: [0, ...tripsProv.years],
+                        selected: statsProv.year ?? 0,
+                        enabled: !disabledYears,
+                        allYearsLabel: loc.tripsFilterAllYears,
+                        onChanged: (y) => statsProv.year = y,
+                      ),
                     ),
                   ),
                 ],

--- a/lib/features/statistics/statistics_page.dart
+++ b/lib/features/statistics/statistics_page.dart
@@ -356,9 +356,12 @@ class _StatsCard extends StatelessWidget {
                   vehicle: statsProv.vehicle,
                   onChanged: (g) => statsProv.graph = g,
                 ),
-                const Spacer(),
-                // AppStepsTabBar — icon-only tabs, not full width
-                Builder(builder: (context) {                  
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Align(
+                    alignment: Alignment.centerRight,
+                    // AppStepsTabBar — icon-only tabs, not full width
+                    child: Builder(builder: (context) {
                   return AppStepsTabBar(
                     fullWidth: false,
                     selectedIndex: view.index,
@@ -382,6 +385,8 @@ class _StatsCard extends StatelessWidget {
                     ],
                   );
                 }),
+                  ),
+                ),
               ],
             ),
           ),


### PR DESCRIPTION
## Summary
This PR refactors the layout structure in the statistics page to improve responsiveness and prevent text overflow issues. The changes replace `Spacer` widgets with `SizedBox` and `Expanded` combinations to provide better control over spacing and alignment, while adding text overflow handling to the year chip label.

## Key Changes
- **Statistics page header**: Replaced `Spacer()` with `SizedBox(width: 8)` + `Expanded` + `Align` wrapper around `_YearChip` for more predictable right-alignment behavior
- **Stats card header**: Applied the same layout pattern to the graph view selector section, replacing `Spacer()` with fixed spacing and expanded alignment
- **Year chip label**: Wrapped the year label text in a `Flexible` widget with `TextOverflow.ellipsis` to prevent text overflow when space is constrained

## Implementation Details
- The `Spacer()` → `SizedBox(width: 8)` + `Expanded(child: Align(alignment: Alignment.centerRight, ...))` pattern provides explicit spacing while maintaining right alignment
- The `Flexible` wrapper on the year chip text ensures graceful text truncation instead of layout overflow
- These changes improve the UI's responsiveness on smaller screen sizes and with longer text content

https://claude.ai/code/session_01TX5gTVaPKce83cyFp8iKv8