### PR TITLE
Refactor shell navigation to centralize app bar handling

### DIFF
--- a/lib/features/trainlog/inbox_page.dart
+++ b/lib/features/trainlog/inbox_page.dart
@@ -1,12 +1,11 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:material_symbols_icons/symbols.dart';
 import 'package:provider/provider.dart';
 import 'package:trainlog_app/data/models/news_model.dart';
+import 'package:trainlog_app/platform/adaptive_app_bar.dart';
 import 'package:trainlog_app/providers/settings_provider.dart';
 import 'package:trainlog_app/providers/trainlog_provider.dart';
 import 'package:trainlog_app/utils/date_utils.dart';
-import 'package:trainlog_app/utils/platform_utils.dart';
 import 'package:trainlog_app/widgets/error_banner.dart';
 import 'package:trainlog_app/l10n/app_localizations.dart';
 
@@ -221,20 +220,11 @@ class _InboxPageState extends State<InboxPage> {
     final locale = Localizations.localeOf(context).languageCode;
     final theme = Theme.of(context);
 
-    if(AppPlatform.isApple) {
-      return _bodyHelper(locale, loc, theme);
-    }
-
     return SafeArea(
       child: Scaffold(
-        appBar: AppBar(
-          title: Text(loc.inboxPageTitle),
-          leading: IconButton(
-            icon: const Icon(Icons.arrow_back),
-            onPressed: () {
-              Navigator.pop(context);
-            },
-          ),
+        appBar: AdaptiveAppBar(
+          title: loc.inboxPageTitle,
+          onBack: () => Navigator.pop(context),
         ),
         body: _bodyHelper(locale, loc, theme),
       ),

--- a/lib/features/trainlog/inbox_page.dart
+++ b/lib/features/trainlog/inbox_page.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:material_symbols_icons/symbols.dart';
 import 'package:provider/provider.dart';
 import 'package:trainlog_app/data/models/news_model.dart';
-import 'package:trainlog_app/platform/adaptive_app_bar.dart';
 import 'package:trainlog_app/providers/settings_provider.dart';
 import 'package:trainlog_app/providers/trainlog_provider.dart';
 import 'package:trainlog_app/utils/date_utils.dart';
@@ -220,15 +219,9 @@ class _InboxPageState extends State<InboxPage> {
     final locale = Localizations.localeOf(context).languageCode;
     final theme = Theme.of(context);
 
-    return SafeArea(
-      child: Scaffold(
-        appBar: AdaptiveAppBar(
-          title: loc.inboxPageTitle,
-          onBack: () => Navigator.pop(context),
-        ),
-        body: _bodyHelper(locale, loc, theme),
-      ),
-    );
+    // The surrounding app bar (and back button) is provided by the shell, the
+    // same way it is for the other pages — see material/cupertino shell.
+    return _bodyHelper(locale, loc, theme);
   }
 
   Padding _bodyHelper(String locale, AppLocalizations loc, ThemeData theme) {

--- a/lib/features/trainlog/trainlog_status_page.dart
+++ b/lib/features/trainlog/trainlog_status_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:trainlog_app/l10n/app_localizations.dart';
-import 'package:trainlog_app/utils/platform_utils.dart';
+import 'package:trainlog_app/platform/adaptive_app_bar.dart';
 
 class TrainlogStatusPage extends StatelessWidget {
   const TrainlogStatusPage({super.key});
@@ -10,20 +10,11 @@ class TrainlogStatusPage extends StatelessWidget {
   Widget build(BuildContext context) {
     final loc = AppLocalizations.of(context)!;
 
-    if(AppPlatform.isApple) {
-      return _bodyHelper();
-    }
-
     return SafeArea(
       child: Scaffold(
-        appBar: AppBar(
-          title: Text(loc.trainglogStatusPageTitle),
-          leading: IconButton(
-            icon: const Icon(Icons.arrow_back),
-            onPressed: () {
-              Navigator.pop(context);
-            },
-          ),
+        appBar: AdaptiveAppBar(
+          title: loc.trainglogStatusPageTitle,
+          onBack: () => Navigator.pop(context),
         ),
         body: _bodyHelper(),
       ),

--- a/lib/features/trainlog/trainlog_status_page.dart
+++ b/lib/features/trainlog/trainlog_status_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:trainlog_app/l10n/app_localizations.dart';
-import 'package:trainlog_app/platform/adaptive_app_bar.dart';
 
 class TrainlogStatusPage extends StatelessWidget {
   const TrainlogStatusPage({super.key});
@@ -8,17 +7,9 @@ class TrainlogStatusPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final loc = AppLocalizations.of(context)!;
-
-    return SafeArea(
-      child: Scaffold(
-        appBar: AdaptiveAppBar(
-          title: loc.trainglogStatusPageTitle,
-          onBack: () => Navigator.pop(context),
-        ),
-        body: _bodyHelper(),
-      ),
-    );
+    // The surrounding app bar (and back button) is provided by the shell, the
+    // same way it is for the other pages — see material/cupertino shell.
+    return _bodyHelper();
   }
 
   Padding _bodyHelper() {

--- a/lib/navigation/cupertino_shell.dart
+++ b/lib/navigation/cupertino_shell.dart
@@ -1,8 +1,9 @@
 // cupertino_shell.dart
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart' show Icon, PageRouteBuilder, Theme;
+import 'package:flutter/material.dart' show Icon, PageRouteBuilder, Scaffold, Theme;
 import 'package:trainlog_app/l10n/app_localizations.dart';
 import 'package:trainlog_app/navigation/nav_models.dart';
+import 'package:trainlog_app/platform/adaptive_app_bar.dart';
 import 'package:trainlog_app/platform/adaptive_bottom_navbar.dart'
     show AdaptiveBottomNavBar, kNavBarClearance;
 import 'package:trainlog_app/platform/cupertino_fab.dart';
@@ -45,6 +46,31 @@ class _CupertinoShellState extends State<CupertinoShell> {
     }
   }
 
+  /// Pushes a full-screen sub-page, giving it the shared [AdaptiveAppBar] (with
+  /// the back button) here in the shell rather than inside the page itself —
+  /// the same way the root pages get their navigation bar from the shell.
+  void _pushAppBarPage(
+    BuildContext context,
+    String Function(BuildContext) titleBuilder,
+    Widget page,
+  ) {
+    Navigator.of(context).push(
+      PageRouteBuilder(
+        pageBuilder: (routeContext, _, __) => SafeArea(
+          child: Scaffold(
+            appBar: AdaptiveAppBar(
+              title: titleBuilder(routeContext),
+              onBack: () => Navigator.of(routeContext).pop(),
+            ),
+            body: page,
+          ),
+        ),
+        transitionDuration: Duration.zero,
+        reverseTransitionDuration: Duration.zero,
+      ),
+    );
+  }
+
   void _openFullScreenMenu(BuildContext context) {
     Navigator.of(context).push(
       PageRouteBuilder(
@@ -62,19 +88,15 @@ class _CupertinoShellState extends State<CupertinoShell> {
           onPageTap: (id) => Navigator.of(ctx).pop(),
           onInboxTap: () {
             Navigator.of(ctx).pop();
-            Navigator.of(context).push(PageRouteBuilder(
-              pageBuilder: (_, __, ___) => const InboxPage(),
-              transitionDuration: Duration.zero,
-              reverseTransitionDuration: Duration.zero,
-            ));
+            _pushAppBarPage(context, InboxPage.pageTitle, const InboxPage());
           },
           onTrainlogStatusTap: () {
             Navigator.of(ctx).pop();
-            Navigator.of(context).push(PageRouteBuilder(
-              pageBuilder: (_, __, ___) => const TrainlogStatusPage(),
-              transitionDuration: Duration.zero,
-              reverseTransitionDuration: Duration.zero,
-            ));
+            _pushAppBarPage(
+              context,
+              TrainlogStatusPage.pageTitle,
+              const TrainlogStatusPage(),
+            );
           },
         ),
         transitionsBuilder: (_, animation, __, child) => FadeTransition(

--- a/lib/navigation/cupertino_shell.dart
+++ b/lib/navigation/cupertino_shell.dart
@@ -9,14 +9,21 @@ import 'package:trainlog_app/platform/adaptive_bottom_navbar.dart'
 import 'package:trainlog_app/platform/cupertino_fab.dart';
 import 'package:trainlog_app/utils/platform_utils.dart';
 
+import 'package:trainlog_app/features/about/about_page.dart';
+import 'package:trainlog_app/features/friends/friends_page.dart';
 import 'package:trainlog_app/features/map/map_page.dart';
 import 'package:trainlog_app/features/menu/full_screen_menu_page.dart';
 import 'package:trainlog_app/features/ranking/ranking_page.dart';
 import 'package:trainlog_app/features/settings/settings_page.dart';
+import 'package:trainlog_app/features/spr/smart_prerecorder_page.dart';
 import 'package:trainlog_app/features/statistics/statistics_page.dart';
+import 'package:trainlog_app/features/tags/tags_page.dart';
+import 'package:trainlog_app/features/tickets/tickets_page.dart';
 import 'package:trainlog_app/features/trainlog/inbox_page.dart';
 import 'package:trainlog_app/features/trainlog/trainlog_status_page.dart';
 import 'package:trainlog_app/features/trips/trips_page.dart';
+import 'package:trainlog_app/features/user/coverage_page.dart';
+import 'package:trainlog_app/features/user/dashboard_page.dart';
 
 typedef SetPrimaryActions = void Function(List<AppPrimaryAction> actions);
 
@@ -49,26 +56,66 @@ class _CupertinoShellState extends State<CupertinoShell> {
   /// Pushes a full-screen sub-page, giving it the shared [AdaptiveAppBar] (with
   /// the back button) here in the shell rather than inside the page itself —
   /// the same way the root pages get their navigation bar from the shell.
-  void _pushAppBarPage(
+  void _pushSubPage(
     BuildContext context,
     String Function(BuildContext) titleBuilder,
-    Widget page,
+    Widget Function(BuildContext, SetPrimaryActions) builder,
   ) {
     Navigator.of(context).push(
       PageRouteBuilder(
-        pageBuilder: (routeContext, _, __) => SafeArea(
-          child: Scaffold(
-            appBar: AdaptiveAppBar(
-              title: titleBuilder(routeContext),
-              onBack: () => Navigator.of(routeContext).pop(),
-            ),
-            body: page,
-          ),
+        pageBuilder: (_, __, ___) => _ShellSubPage(
+          titleBuilder: titleBuilder,
+          builder: builder,
         ),
         transitionDuration: Duration.zero,
         reverseTransitionDuration: Duration.zero,
       ),
     );
+  }
+
+  /// Resolves an [AppPageId] coming from the menu to its page and pushes it.
+  /// The bottom-tab pages live in the tab bar and so are ignored here.
+  void _pushPage(BuildContext context, AppPageId id) {
+    switch (id) {
+      case AppPageId.dashboard:
+        _pushSubPage(context, (c) => AppLocalizations.of(c)!.menuDashboardTitle,
+            (_, __) => const DashboardPage());
+        break;
+      case AppPageId.coverage:
+        _pushSubPage(context, (c) => AppLocalizations.of(c)!.menuCoverageTitle,
+            (_, __) => const CoveragePage());
+        break;
+      case AppPageId.tags:
+        _pushSubPage(context, (c) => AppLocalizations.of(c)!.menuTagsTitle,
+            (_, setActions) => TagsPage(onPrimaryActionsReady: setActions));
+        break;
+      case AppPageId.tickets:
+        _pushSubPage(context, (c) => AppLocalizations.of(c)!.menuTicketsTitle,
+            (_, setActions) => TicketsPage(onPrimaryActionsReady: setActions));
+        break;
+      case AppPageId.friends:
+        _pushSubPage(context, (c) => AppLocalizations.of(c)!.menuFriendsTitle,
+            (_, __) => const FriendsPage());
+        break;
+      case AppPageId.smartPrerecorder:
+        _pushSubPage(
+            context,
+            (c) => AppLocalizations.of(c)!.menuSmartPrerecorderTitle,
+            (_, setActions) =>
+                SmartPrerecorderPage(onPrimaryActionsReady: setActions));
+        break;
+      case AppPageId.about:
+        _pushSubPage(context, (c) => AppLocalizations.of(c)!.menuAboutTitle,
+            (_, __) => const AboutPage());
+        break;
+      case AppPageId.settings:
+      case AppPageId.map:
+      case AppPageId.trips:
+      case AppPageId.ranking:
+      case AppPageId.statistics:
+        // Settings has its own menu entry; the tab pages live in the bottom bar.
+        break;
+    }
   }
 
   void _openFullScreenMenu(BuildContext context) {
@@ -85,18 +132,19 @@ class _CupertinoShellState extends State<CupertinoShell> {
               reverseTransitionDuration: Duration.zero,
             ));
           },
-          onPageTap: (id) => Navigator.of(ctx).pop(),
+          onPageTap: (id) {
+            Navigator.of(ctx).pop();
+            _pushPage(context, id);
+          },
           onInboxTap: () {
             Navigator.of(ctx).pop();
-            _pushAppBarPage(context, InboxPage.pageTitle, const InboxPage());
+            _pushSubPage(
+                context, InboxPage.pageTitle, (_, __) => const InboxPage());
           },
           onTrainlogStatusTap: () {
             Navigator.of(ctx).pop();
-            _pushAppBarPage(
-              context,
-              TrainlogStatusPage.pageTitle,
-              const TrainlogStatusPage(),
-            );
+            _pushSubPage(context, TrainlogStatusPage.pageTitle,
+                (_, __) => const TrainlogStatusPage());
           },
         ),
         transitionsBuilder: (_, animation, __, child) => FadeTransition(
@@ -237,6 +285,47 @@ class CupertinoPrimaryActionsRow extends StatelessWidget {
           if (i != reversed.length - 1) const SizedBox(width: 6),
         ],
       ],
+    );
+  }
+}
+
+/// Full-screen sub-page pushed from the menu (inbox, tags, about, …).
+/// Provides the shared [AdaptiveAppBar] with a back button, and surfaces any
+/// primary actions the page reports into the navigation bar trailing —
+/// mirroring how [_CupertinoRootPage] handles the bottom-tab pages.
+class _ShellSubPage extends StatefulWidget {
+  final String Function(BuildContext context) titleBuilder;
+  final Widget Function(BuildContext context, SetPrimaryActions setActions) builder;
+
+  const _ShellSubPage({required this.titleBuilder, required this.builder});
+
+  @override
+  State<_ShellSubPage> createState() => _ShellSubPageState();
+}
+
+class _ShellSubPageState extends State<_ShellSubPage> {
+  final ValueNotifier<List<AppPrimaryAction>> _actions = ValueNotifier(const []);
+
+  @override
+  void dispose() {
+    _actions.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Scaffold(
+        appBar: AdaptiveAppBar(
+          title: widget.titleBuilder(context),
+          onBack: () => Navigator.of(context).pop(),
+          cupertinoTrailing: ValueListenableBuilder<List<AppPrimaryAction>>(
+            valueListenable: _actions,
+            builder: (_, actions, __) => CupertinoPrimaryActionsRow(actions: actions),
+          ),
+        ),
+        body: widget.builder(context, (actions) => _actions.value = actions),
+      ),
     );
   }
 }

--- a/lib/navigation/material_shell.dart
+++ b/lib/navigation/material_shell.dart
@@ -256,6 +256,31 @@ class _MaterialShellState extends State<MaterialShell> {
 
   void _goBackToBottomNavPage() => _onItemTapped(_previousBottomIndex);
 
+  /// Pushes a full-screen sub-page, giving it the shared [AdaptiveAppBar] (with
+  /// the back button) here in the shell rather than inside the page itself —
+  /// the same way the drawer pages get their app bar from the shell.
+  void _pushAppBarPage(
+    BuildContext context,
+    String Function(BuildContext) titleBuilder,
+    Widget page,
+  ) {
+    Navigator.of(context).push(
+      PageRouteBuilder(
+        pageBuilder: (routeContext, _, __) => SafeArea(
+          child: Scaffold(
+            appBar: AdaptiveAppBar(
+              title: titleBuilder(routeContext),
+              onBack: () => Navigator.of(routeContext).pop(),
+            ),
+            body: page,
+          ),
+        ),
+        transitionDuration: Duration.zero,
+        reverseTransitionDuration: Duration.zero,
+      ),
+    );
+  }
+
   void _openFullScreenMenu(BuildContext context) {
     Navigator.of(context).push(
       PageRouteBuilder(
@@ -272,19 +297,15 @@ class _MaterialShellState extends State<MaterialShell> {
           },
           onInboxTap: () {
             Navigator.of(ctx).pop();
-            Navigator.of(context).push(PageRouteBuilder(
-              pageBuilder: (_, __, ___) => const InboxPage(),
-              transitionDuration: Duration.zero,
-              reverseTransitionDuration: Duration.zero,
-            ));
+            _pushAppBarPage(context, InboxPage.pageTitle, const InboxPage());
           },
           onTrainlogStatusTap: () {
             Navigator.of(ctx).pop();
-            Navigator.of(context).push(PageRouteBuilder(
-              pageBuilder: (_, __, ___) => const TrainlogStatusPage(),
-              transitionDuration: Duration.zero,
-              reverseTransitionDuration: Duration.zero,
-            ));
+            _pushAppBarPage(
+              context,
+              TrainlogStatusPage.pageTitle,
+              const TrainlogStatusPage(),
+            );
           },
         ),
         transitionsBuilder: (_, animation, __, child) => FadeTransition(

--- a/lib/platform/adaptive_app_bar.dart
+++ b/lib/platform/adaptive_app_bar.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:trainlog_app/platform/widget/adaptive_app_bar_square_button.dart';
 import 'package:trainlog_app/utils/platform_utils.dart';
 
 class AdaptiveAppBar extends StatelessWidget implements PreferredSizeWidget {
@@ -23,28 +24,29 @@ class AdaptiveAppBar extends StatelessWidget implements PreferredSizeWidget {
             : kToolbarHeight,
       );
 
+  /// Square back button matching the size used by [AdaptiveAppBarSquareButton]
+  /// elsewhere (e.g. the menu page top bar).
+  Widget _backButton(BuildContext context) {
+    return AdaptiveAppBarSquareButton(
+      icon: Icons.chevron_left,
+      onPressed: onBack!,
+      tooltip: MaterialLocalizations.of(context).backButtonTooltip,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     if (AppPlatform.isApple) {
       return CupertinoNavigationBar(
         middle: Text(title),
-        leading: onBack == null
-            ? null
-            : CupertinoNavigationBarBackButton(
-                onPressed: onBack,
-              ),
+        leading: onBack == null ? null : _backButton(context),
         trailing: cupertinoTrailing,
       );
     }
 
     return AppBar(
       title: Text(title),
-      leading: onBack == null
-          ? null
-          : IconButton(
-              icon: const Icon(Icons.arrow_back),
-              onPressed: onBack,
-            ),
+      leading: onBack == null ? null : Center(child: _backButton(context)),
       actions: materialActions,
     );
   }


### PR DESCRIPTION
## Summary
This PR refactors the navigation shell architecture to centralize app bar and back button handling at the shell level, rather than having each sub-page implement its own. This reduces code duplication and ensures consistent navigation UI across the app.

## Key Changes

- **Centralized app bar management**: Created `_ShellSubPage` widget in `cupertino_shell.dart` that provides a shared `AdaptiveAppBar` with back button for all full-screen sub-pages (inbox, tags, about, etc.)

- **New navigation methods**: 
  - Added `_pushSubPage()` in `CupertinoShell` to push pages with the shared app bar
  - Added `_pushPage()` to resolve menu page IDs and route them appropriately
  - Added `_pushAppBarPage()` in `MaterialShell` for Material design equivalent

- **Simplified page implementations**: Removed redundant `SafeArea`, `Scaffold`, and `AppBar` code from:
  - `InboxPage`
  - `TrainlogStatusPage`
  - Pages now only return their body content, relying on the shell for navigation chrome

- **Unified back button styling**: Updated `AdaptiveAppBar` to use `AdaptiveAppBarSquareButton` for consistent back button appearance across platforms

- **Primary actions support**: `_ShellSubPage` surfaces primary actions from sub-pages into the navigation bar trailing, mirroring how root tab pages work

- **Menu integration**: Updated full-screen menu to use the new `_pushPage()` method for routing menu selections

## Implementation Details

- Sub-pages now receive a `SetPrimaryActions` callback to report action buttons to the shell
- Pages use static `pageTitle()` methods for localized titles passed to the shell
- Transition durations set to zero for instant navigation (consistent with existing behavior)
- Material and Cupertino shells maintain their platform-specific implementations while sharing the same navigation pattern

https://claude.ai/code/session_01CKEbp7Ka39vYcM7NaL3yGN