### PR TITLE
Add map follow mode indicator pill with animation

### DIFF
--- a/lib/features/map/map_page.dart
+++ b/lib/features/map/map_page.dart
@@ -35,7 +35,8 @@ class MapPage extends StatefulWidget {
   State<MapPage> createState() => _MapPageState();
 }
 
-class _MapPageState extends State<MapPage> with WidgetsBindingObserver, AutomaticKeepAliveClientMixin {
+class _MapPageState extends State<MapPage>
+    with WidgetsBindingObserver, AutomaticKeepAliveClientMixin, SingleTickerProviderStateMixin {
   // --- Map state
   final MapController _mapController = MapController();
   final GeoPermissionService _geo = const GeoPermissionService();
@@ -52,6 +53,10 @@ class _MapPageState extends State<MapPage> with WidgetsBindingObserver, Automati
   bool _showFilterModal = false;
   final ValueNotifier<double> _rotationNotifier = ValueNotifier(0.0);
 
+  // Drives the slow blink of the "locked on position" pill shown while
+  // [_followUser] is active.
+  late final AnimationController _pillBlinkController;
+
   @override
   bool get wantKeepAlive => true;
 
@@ -59,6 +64,11 @@ class _MapPageState extends State<MapPage> with WidgetsBindingObserver, Automati
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
+
+    _pillBlinkController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1200),
+    )..repeat(reverse: true);
 
     final settings = context.read<SettingsProvider>();
     _initCenterAndMarker(settings);
@@ -74,6 +84,7 @@ class _MapPageState extends State<MapPage> with WidgetsBindingObserver, Automati
 
   @override
   void dispose() {
+    _pillBlinkController.dispose();
     _stopUserLocationUpdates();
     WidgetsBinding.instance.removeObserver(this);
     super.dispose();
@@ -145,6 +156,28 @@ class _MapPageState extends State<MapPage> with WidgetsBindingObserver, Automati
   Future<void> _stopUserLocationUpdates() async {
     await _posSub?.cancel();
     _posSub = null;
+  }
+
+  /// Ensures we have a live fix for the user's position, requesting OS
+  /// permission and starting the location stream if needed.
+  ///
+  /// Only call from explicit user actions (recenter / follow buttons): this is
+  /// allowed to prompt for permission. Returns the position, or `null` if
+  /// permission was denied or no fix could be obtained.
+  Future<LatLng?> _ensureUserPosition() async {
+    if (_userPosition != null) return _userPosition;
+
+    final settings = context.read<SettingsProvider>();
+    final granted = await _geo.requestPermission(settings);
+    if (!granted || !mounted) return null;
+
+    final current = await _geo.getCurrentPositionOrNull();
+    if (current == null || !mounted) return null;
+
+    settings.setLastUserPosition(current);
+    setState(() => _userPosition = current);
+    await _startUserLocationUpdates(settings, requestInitialFix: false);
+    return current;
   }
 
   @override
@@ -233,6 +266,7 @@ class _MapPageState extends State<MapPage> with WidgetsBindingObserver, Automati
               ),
           ],
         ),
+        if (_followUser) _lockedOnPositionPill(appLocalizations),
         if (!_showFilterModal || AppPlatform.isApple) _mapButtonHelper(),
         if (_showFilterModal) ...[
           GestureDetector(
@@ -274,21 +308,10 @@ class _MapPageState extends State<MapPage> with WidgetsBindingObserver, Automati
     }
 
     Future<void> recenterFct () async {
-      final settings = context.read<SettingsProvider>();
-      var p = _userPosition;
-
       // No fix yet: this is an explicit user action, so it's fine to ask the
-      // OS for permission now (the only place on the map that does so).
-      if (p == null) {
-        final granted = await _geo.requestPermission(settings);
-        if (!granted || !mounted) return;
-        final current = await _geo.getCurrentPositionOrNull();
-        if (current == null || !mounted) return;
-        settings.setLastUserPosition(current);
-        setState(() => _userPosition = current);
-        await _startUserLocationUpdates(settings, requestInitialFix: false);
-        p = current;
-      }
+      // OS for permission now (one of the only places on the map that does so).
+      final p = await _ensureUserPosition();
+      if (p == null || !mounted) return;
 
       double z = _zoom;
       if (_center == p) {
@@ -298,11 +321,27 @@ class _MapPageState extends State<MapPage> with WidgetsBindingObserver, Automati
         _mapController.move(p, _zoom);
       }
       setState(() {
-        _center = p!;
+        _center = p;
         _zoom = z;
       });
     }
-    void followUserFct () => setState(() => _followUser = !_followUser);
+    Future<void> followUserFct () async {
+      // Turning follow off needs no location access.
+      if (_followUser) {
+        setState(() => _followUser = false);
+        return;
+      }
+
+      // Enabling follow requires a position: prompt for permission if needed.
+      final p = await _ensureUserPosition();
+      if (p == null || !mounted) return;
+
+      _mapController.move(p, _zoom);
+      setState(() {
+        _center = p;
+        _followUser = true;
+      });
+    }
     void resetMapOrientationFct () {
       _mapController.rotate(0);
       _rotationNotifier.value = 0;
@@ -348,8 +387,8 @@ class _MapPageState extends State<MapPage> with WidgetsBindingObserver, Automati
                   ),
                   child: 
                   AdaptiveFilledIconButton(
-                    onPressed: followUserFct,
-                    colorScheme: FilledButtonColorScheme.floating, 
+                    onPressed: () => followUserFct(),
+                    colorScheme: FilledButtonColorScheme.floating,
                     child: followUserIcon,
                   ),
                 ),
@@ -371,6 +410,42 @@ class _MapPageState extends State<MapPage> with WidgetsBindingObserver, Automati
                   ),
                 ),
               ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// A slowly blinking black pill anchored at the top of the map, shown while
+  /// the map is locked on the user's position ([_followUser]).
+  Widget _lockedOnPositionPill(AppLocalizations appLocalizations) {
+    return Positioned(
+      top: MediaQuery.of(context).padding.top + 12,
+      left: 0,
+      right: 0,
+      child: IgnorePointer(
+        child: Center(
+          child: FadeTransition(
+            opacity: Tween<double>(begin: 0.25, end: 1.0).animate(
+              CurvedAnimation(
+                parent: _pillBlinkController,
+                curve: Curves.easeInOut,
+              ),
+            ),
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              decoration: BoxDecoration(
+                color: Colors.black,
+                borderRadius: BorderRadius.circular(24),
+              ),
+              child: Text(
+                appLocalizations.mapLockedOnPosition,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
             ),
           ),
         ),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -198,7 +198,7 @@
   "mapFilterVehicleTypeNoneBtn": "None",
 
   "tripPathLoading": "Trips' path loading, please wait",
-  "mapLockedOnPosition": "Map locked on your position",
+  "mapLockedOnPosition": "Map following your position",
   "yearTitle": "Years",
   "yearAllList": "All",
   "yearPastList": "Past",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -198,6 +198,7 @@
   "mapFilterVehicleTypeNoneBtn": "None",
 
   "tripPathLoading": "Trips' path loading, please wait",
+  "mapLockedOnPosition": "Map locked on your position",
   "yearTitle": "Years",
   "yearAllList": "All",
   "yearPastList": "Past",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -164,7 +164,7 @@
   "mapFilterVehicleTypeNoneBtn": "Aucun",
 
   "tripPathLoading": "Trajets en cours de chargement, veuillez patienter",
-  "mapLockedOnPosition": "Carte verrouillée sur votre position",
+  "mapLockedOnPosition": "La carte suit votre position",
   "yearTitle": "Années",
   "yearAllList": "Tout",
   "yearPastList": "Passé",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -164,6 +164,7 @@
   "mapFilterVehicleTypeNoneBtn": "Aucun",
 
   "tripPathLoading": "Trajets en cours de chargement, veuillez patienter",
+  "mapLockedOnPosition": "Carte verrouillée sur votre position",
   "yearTitle": "Années",
   "yearAllList": "Tout",
   "yearPastList": "Passé",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -163,7 +163,7 @@
   "mapFilterVehicleTypeNoneBtn": "なし",
 
   "tripPathLoading": "旅行のパスを読み込んでいます。お待ちください",
-  "mapLockedOnPosition": "地図を現在地に固定中",
+  "mapLockedOnPosition": "地図が現在地を追従中",
   "yearTitle": "年",
   "yearAllList": "全て",
   "yearPastList": "過去",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -163,6 +163,7 @@
   "mapFilterVehicleTypeNoneBtn": "なし",
 
   "tripPathLoading": "旅行のパスを読み込んでいます。お待ちください",
+  "mapLockedOnPosition": "地図を現在地に固定中",
   "yearTitle": "年",
   "yearAllList": "全て",
   "yearPastList": "過去",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1032,6 +1032,12 @@ abstract class AppLocalizations {
   /// **'Trips\' path loading, please wait'**
   String get tripPathLoading;
 
+  /// No description provided for @mapLockedOnPosition.
+  ///
+  /// In en, this message translates to:
+  /// **'Map locked on your position'**
+  String get mapLockedOnPosition;
+
   /// No description provided for @yearTitle.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1035,7 +1035,7 @@ abstract class AppLocalizations {
   /// No description provided for @mapLockedOnPosition.
   ///
   /// In en, this message translates to:
-  /// **'Map locked on your position'**
+  /// **'Map following your position'**
   String get mapLockedOnPosition;
 
   /// No description provided for @yearTitle.

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -516,6 +516,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get tripPathLoading => 'Trips\' path loading, please wait';
 
   @override
+  String get mapLockedOnPosition => 'Map locked on your position';
+
+  @override
   String get yearTitle => 'Years';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -516,7 +516,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get tripPathLoading => 'Trips\' path loading, please wait';
 
   @override
-  String get mapLockedOnPosition => 'Map locked on your position';
+  String get mapLockedOnPosition => 'Map following your position';
 
   @override
   String get yearTitle => 'Years';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -523,6 +523,9 @@ class AppLocalizationsFr extends AppLocalizations {
       'Trajets en cours de chargement, veuillez patienter';
 
   @override
+  String get mapLockedOnPosition => 'Carte verrouillée sur votre position';
+
+  @override
   String get yearTitle => 'Années';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -523,7 +523,7 @@ class AppLocalizationsFr extends AppLocalizations {
       'Trajets en cours de chargement, veuillez patienter';
 
   @override
-  String get mapLockedOnPosition => 'Carte verrouillée sur votre position';
+  String get mapLockedOnPosition => 'La carte suit votre position';
 
   @override
   String get yearTitle => 'Années';

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -505,6 +505,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get tripPathLoading => '旅行のパスを読み込んでいます。お待ちください';
 
   @override
+  String get mapLockedOnPosition => '地図を現在地に固定中';
+
+  @override
   String get yearTitle => '年';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -505,7 +505,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get tripPathLoading => '旅行のパスを読み込んでいます。お待ちください';
 
   @override
-  String get mapLockedOnPosition => '地図を現在地に固定中';
+  String get mapLockedOnPosition => '地図が現在地を追従中';
 
   @override
   String get yearTitle => '年';

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -514,6 +514,9 @@ class AppLocalizationsTl extends AppLocalizations {
       'Ang byahe mo ay nag loload, mag hintay ng saglit';
 
   @override
+  String get mapLockedOnPosition => 'Naka-lock ang mapa sa iyong posisyon';
+
+  @override
   String get yearTitle => 'Taon';
 
   @override

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -514,7 +514,7 @@ class AppLocalizationsTl extends AppLocalizations {
       'Ang byahe mo ay nag loload, mag hintay ng saglit';
 
   @override
-  String get mapLockedOnPosition => 'Naka-lock ang mapa sa iyong posisyon';
+  String get mapLockedOnPosition => 'Sinusundan ng mapa ang iyong posisyon';
 
   @override
   String get yearTitle => 'Taon';

--- a/lib/l10n/app_tl.arb
+++ b/lib/l10n/app_tl.arb
@@ -181,7 +181,7 @@
   "mapFilterVehicleTypeAllBtn": "Lahat",
   "mapFilterVehicleTypeNoneBtn": "Wala",
   "tripPathLoading": "Ang byahe mo ay nag loload, mag hintay ng saglit",
-  "mapLockedOnPosition": "Naka-lock ang mapa sa iyong posisyon",
+  "mapLockedOnPosition": "Sinusundan ng mapa ang iyong posisyon",
   "yearTitle": "Taon",
   "yearAllList": "Lahat",
   "yearPastList": "Nakaraan",

--- a/lib/l10n/app_tl.arb
+++ b/lib/l10n/app_tl.arb
@@ -181,6 +181,7 @@
   "mapFilterVehicleTypeAllBtn": "Lahat",
   "mapFilterVehicleTypeNoneBtn": "Wala",
   "tripPathLoading": "Ang byahe mo ay nag loload, mag hintay ng saglit",
+  "mapLockedOnPosition": "Naka-lock ang mapa sa iyong posisyon",
   "yearTitle": "Taon",
   "yearAllList": "Lahat",
   "yearPastList": "Nakaraan",


### PR DESCRIPTION
## Summary
This PR enhances the map's follow user mode by adding a visual indicator pill that appears at the top of the map when follow mode is active, with a subtle blinking animation to draw user attention.

## Key Changes
- **Animation Support**: Added `SingleTickerProviderStateMixin` to `_MapPageState` to enable animation capabilities
- **Follow Mode Indicator**: Implemented `_lockedOnPositionPill()` widget that displays a black pill with text "Map following your position" at the top of the map when `_followUser` is true
- **Blink Animation**: Created `_pillBlinkController` AnimationController that drives a fade transition (opacity 0.25 to 1.0) with a 1200ms duration, repeating in reverse for a subtle blinking effect
- **Improved Follow Logic**: Refactored `followUserFct()` to be async and use the new `_ensureUserPosition()` helper method, which:
  - Requests OS permission if needed (only on explicit user action)
  - Gets current position or returns null if permission denied
  - Starts location updates and centers the map before enabling follow mode
- **Code Extraction**: Created `_ensureUserPosition()` helper method to consolidate permission and position acquisition logic, reducing duplication between recenter and follow functions
- **Internationalization**: Added `mapLockedOnPosition` localization string in English, French, Japanese, and Tagalog

## Notable Implementation Details
- The pill uses `IgnorePointer` to prevent interaction while remaining visible
- Animation controller is properly disposed in the `dispose()` method
- Follow mode toggle now properly handles the case where follow is already active (simply disables it without requesting permissions)
- The indicator only appears when actively following the user, providing clear visual feedback of the map's locked state

https://claude.ai/code/session_01SiZpC1oc712bzS5pG2bvxR