### PR TITLE
Sort statistics by localized labels instead of keys

### DIFF
--- a/lib/features/statistics/statistics_page.dart
+++ b/lib/features/statistics/statistics_page.dart
@@ -145,8 +145,12 @@ class _StatisticsPageState extends State<StatisticsPage> {
       case StatisticsView.bar:
         // Order first, then build images from the SAME ordered keys so the
         // icons follow the bars when sorting mode changes.
-        final orderedBar =
-            _orderedStats(statsShort, alpha: _sortedAlpha, otherLabel: otherLabel);
+        final orderedBar = _orderedStats(
+          statsShort,
+          alpha: _sortedAlpha,
+          otherLabel: otherLabel,
+          labelOf: labelBuilder,
+        );
         final images = p.graphImagesForKeys(
           context,
           orderedBar.keys.toList(),
@@ -241,19 +245,23 @@ class _StatisticsPageState extends State<StatisticsPage> {
     Map<String, ({double past, double future})> stats, {
     required bool alpha,
     required String otherLabel,
+    String Function(String key)? labelOf,
   }) {
     final entries = stats.entries.toList();
     final other = entries.where((e) => e.key == otherLabel).toList();
     final rest = entries.where((e) => e.key != otherLabel).toList();
 
+    // Sort on the displayed label (e.g. localized country name), not the key.
+    String sortKey(String key) => (labelOf?.call(key) ?? key).toLowerCase();
+
     if (alpha) {
-      rest.sort((a, b) => a.key.toLowerCase().compareTo(b.key.toLowerCase()));
+      rest.sort((a, b) => sortKey(a.key).compareTo(sortKey(b.key)));
     } else {
       rest.sort((a, b) {
         final ta = a.value.past + a.value.future;
         final tb = b.value.past + b.value.future;
         final cmp = tb.compareTo(ta);
-        return cmp != 0 ? cmp : a.key.toLowerCase().compareTo(b.key.toLowerCase());
+        return cmp != 0 ? cmp : sortKey(a.key).compareTo(sortKey(b.key));
       });
     }
     return LinkedHashMap.fromEntries([...rest, ...other]);


### PR DESCRIPTION
## Summary
Updated the statistics sorting logic to sort by displayed labels (e.g., localized country names) rather than by the underlying key values. This ensures that when labels are translated or formatted differently from their keys, the sorting order matches what users see on screen.

## Key Changes
- Added optional `labelOf` parameter to `_orderedStats()` method to accept a label builder function
- Introduced `sortKey()` helper function that applies the label transformation before sorting
- Updated both alphabetical and value-based sorting to use the localized label for comparison
- Passed `labelBuilder` to `_orderedStats()` call in the bar chart view case

## Implementation Details
- The `sortKey()` helper function converts keys to their display labels (if a `labelOf` function is provided) and lowercases them for case-insensitive comparison
- Both sorting modes (alphabetical and by value) now consistently use the displayed label for ordering
- The change maintains backward compatibility by making `labelOf` optional with a fallback to the original key

https://claude.ai/code/session_01FU2Y1F5TxxxoWavnnN83wL