### PR TITLE
Fix trip sorting for journeys crossing time zones

### DIFF
--- a/lib/features/trips/widgets/trip_card_view.dart
+++ b/lib/features/trips/widgets/trip_card_view.dart
@@ -109,9 +109,11 @@ class _TripCardViewState extends State<TripCardView> {
       filter: widget.filter,
       limit: _pageSize,
       offset: pageIndex * _pageSize,
+      // Order by UTC time so trips crossing time zones (e.g. the IDL)
+      // are sorted chronologically; display still uses local time.
       orderBy: widget.timeMoment == TimeMoment.future
-          ? 'start_datetime ASC'
-          : 'start_datetime DESC',
+          ? 'COALESCE(utc_start_datetime, start_datetime) ASC'
+          : 'COALESCE(utc_start_datetime, start_datetime) DESC',
     );
     for (int i = 0; i < trips.length; i++) {
       final idx = pageIndex * _pageSize + i;


### PR DESCRIPTION
## Summary
Updated trip card sorting to use UTC timestamps instead of local times, ensuring trips that cross time zones (such as those crossing the International Date Line) are sorted chronologically rather than by local time.

## Key Changes
- Modified the `orderBy` clause in trip queries to use `COALESCE(utc_start_datetime, start_datetime)` instead of just `start_datetime`
- Applied this change to both future trips (ASC) and past trips (DESC) sorting
- Added clarifying comments explaining that UTC ordering is used for chronological accuracy while display still uses local time

## Implementation Details
- The `COALESCE` function provides backward compatibility by falling back to `start_datetime` if `utc_start_datetime` is not available
- This ensures correct sorting for international trips while maintaining the existing display behavior that shows local times to users

https://claude.ai/code/session_01Enytgg3J9A1sBXLF3z5MXu