### PR TITLE
Refactor location permission handling to use GeoPermissionService

### DIFF
--- a/lib/features/spr/smart_prerecorder_page.dart
+++ b/lib/features/spr/smart_prerecorder_page.dart
@@ -20,6 +20,7 @@ import 'package:trainlog_app/platform/adaptive_record_tile.dart';
 import 'package:trainlog_app/platform/widget/adaptive_app_bar_square_button.dart';
 import 'package:trainlog_app/providers/settings_provider.dart';
 import 'package:trainlog_app/providers/trainlog_provider.dart';
+import 'package:trainlog_app/services/geo_permission_service.dart';
 import 'package:trainlog_app/utils/date_utils.dart';
 import 'package:trainlog_app/utils/location_utils.dart';
 import 'package:trainlog_app/utils/map_color_palette.dart';
@@ -84,6 +85,7 @@ class SmartPrerecorderPage extends StatefulWidget {
 }
 
 class _SmartPrerecorderPageState extends State<SmartPrerecorderPage> {
+  final GeoPermissionService _geo = const GeoPermissionService();
   List<PreRecordModel> _records = [];
   final List<int> _selectedIds = [];
   bool _ascending = false; // default: newest first
@@ -142,16 +144,6 @@ class _SmartPrerecorderPageState extends State<SmartPrerecorderPage> {
     bool serviceEnabled = await Geolocator.isLocationServiceEnabled();
     if (!serviceEnabled) {
       throw Exception(loc.locationServicesDisabled);
-    }
-
-    LocationPermission permission = await Geolocator.checkPermission();
-    if (permission == LocationPermission.denied) {
-      permission = await Geolocator.requestPermission();
-    }
-
-    if (permission == LocationPermission.denied ||
-        permission == LocationPermission.deniedForever) {
-      throw Exception(loc.locationPermissionDenied);
     }
 
     return Geolocator.getCurrentPosition(
@@ -980,6 +972,15 @@ Widget build(BuildContext context) {
     final trainlog = Provider.of<TrainlogProvider>(context, listen: false);
     final loc = AppLocalizations.of(context)!;
     final settings = context.read<SettingsProvider>();
+
+    // Make sure location access is granted (prompting the user if needed)
+    // before recording anything.
+    final granted = await _geo.requestPermission(settings);
+    if (!granted) {
+      if (!mounted) return;
+      AdaptiveInformationMessage.show(context, loc.locationPermissionDenied);
+      return;
+    }
 
     try {
       final id = DateTime.now().millisecondsSinceEpoch;


### PR DESCRIPTION
## Summary
Refactored location permission handling in the SmartPrerecorderPage to use a dedicated `GeoPermissionService` instead of inline permission checks. This improves code organization and ensures permissions are validated before recording starts.

## Key Changes
- Added import for `GeoPermissionService`
- Introduced `_geo` instance variable of type `GeoPermissionService` in `_SmartPrerecorderPageState`
- Removed inline location permission checking logic (Geolocator.checkPermission and Geolocator.requestPermission calls)
- Added permission validation at the start of the recording flow that:
  - Calls `_geo.requestPermission(settings)` to request location access
  - Shows an error message if permission is denied
  - Prevents recording from proceeding without proper permissions

## Implementation Details
- Permission check is now performed before any recording operations begin
- Uses the centralized `GeoPermissionService` for consistent permission handling across the app
- Maintains the same user-facing behavior with appropriate error messaging via `AdaptiveInformationMessage`
- Includes mounted state check to prevent operations on unmounted widgets

https://claude.ai/code/session_01MawumSjsbrewQ3n36Mhvu6