### PR TITLE
Add trip duration and delay calculations to Trips model

### DIFF
--- a/lib/data/models/trips.dart
+++ b/lib/data/models/trips.dart
@@ -128,6 +128,33 @@ class Trips {
     return arrivalDelayDate ?? endDatetime;
   }
 
+  /// Scheduled trip duration: manual value if set, otherwise the UTC
+  /// start/end difference, otherwise the estimated duration.
+  Duration get duration {
+    // UTC start shouldn't be NULL if UTC end is not NULL, so startDatetime
+    // shouldn't be used (placed here to avoid NULL error)
+    final utcDuration = utcEndDatetime?.difference(utcStartDatetime ?? startDatetime);
+    return Duration(
+      seconds: (manualTripDuration ?? utcDuration?.inSeconds ?? estimatedTripDuration)
+          .round()
+          .toInt(),
+    );
+  }
+
+  String get durationFormatted => formatSecondsToHMS(duration.inSeconds);
+
+  /// Trip duration taking the departure/arrival delays into account,
+  /// or null when no delay information is available.
+  Duration? get realDuration {
+    if (!hasDelay) return null;
+    return duration + Duration(seconds: (arrivalDelay ?? 0) - (departureDelay ?? 0));
+  }
+
+  String? get realDurationFormatted {
+    final real = realDuration;
+    return real == null ? null : formatSecondsToHMS(real.inSeconds);
+  }
+
   //       hasTimeRange: trip.hasTimeRange,
 
   bool get isDateOnly => (startDatetime == endDatetime) && utcEndDatetime == null;

--- a/lib/features/trips/widgets/trip_card_view.dart
+++ b/lib/features/trips/widgets/trip_card_view.dart
@@ -492,10 +492,11 @@ class _MetaRow extends StatelessWidget {
         : date_utils.formatDateRange(
             context, trip.startDatetime, trip.endDatetime);
 
-    final duration = trip.utcEndDatetime?.difference(trip.utcStartDatetime ?? trip.startDatetime); // UTC start shouldn't be NULL if UTC end is not NULL, so startDatetime shouldn't be used (placed here to avoid NULL error)
-    final durationStr = date_utils.formatSecondsToHMS(
-        (trip.manualTripDuration ?? duration?.inSeconds ?? trip.estimatedTripDuration).round().toInt()
-    );
+    final durationStr = trip.durationFormatted;
+    final realDuration = trip.realDuration;
+    final realDeltaMinutes = realDuration == null
+        ? 0
+        : ((realDuration - trip.duration).inSeconds / 60).round();
 
     return Row(
       children: [
@@ -509,6 +510,13 @@ class _MetaRow extends StatelessWidget {
           Icon(Icons.schedule_outlined, size: 13, color: iconColor),
           const SizedBox(width: 4),
           Text(durationStr, style: metaStyle),
+          if (realDeltaMinutes != 0)
+            Text(
+              ' (${realDeltaMinutes > 0 ? '+' : ''}$realDeltaMinutes)',
+              style: metaStyle?.copyWith(
+                color: realDeltaMinutes > 0 ? Colors.red : Colors.green,
+              ),
+            ),
           const SizedBox(width: 12),
           Icon(Icons.calendar_today_outlined, size: 13, color: iconColor),
           const SizedBox(width: 4),

--- a/lib/widgets/trip_time_line.dart
+++ b/lib/widgets/trip_time_line.dart
@@ -27,6 +27,9 @@ class TripTimeline extends StatelessWidget {
     final lineName = trip.lineName;
     final distance = "${(trip.tripLength / 1000).round()} km";
     final durationStr = trip.durationFormatted;
+    final realDuration = trip.realDuration;
+    final showRealDuration = realDuration != null &&
+        ((realDuration - trip.duration).inSeconds / 60).round() != 0;
 
     final settings = context.read<SettingsProvider>();
     final palette = MapColorPaletteHelper.getPalette(settings.mapColorPalette);
@@ -154,8 +157,23 @@ class TripTimeline extends StatelessWidget {
                             style: const TextStyle(fontWeight: FontWeight.bold),
                           ),
                           const SizedBox(height: 4),
-                          Text(
-                            '$durationStr - $distance',
+                          Text.rich(
+                            TextSpan(children: [
+                              TextSpan(
+                                text: durationStr,
+                                style: showRealDuration
+                                    ? const TextStyle(decoration: TextDecoration.lineThrough)
+                                    : null,
+                              ),
+                              if (showRealDuration)
+                                TextSpan(
+                                  text: ' (${trip.realDurationFormatted})',
+                                  style: TextStyle(
+                                    color: realDuration! > trip.duration ? Colors.red : Colors.green,
+                                  ),
+                                ),
+                              TextSpan(text: ' - $distance'),
+                            ]),
                             style: TextStyle(color: Theme.of(context).colorScheme.secondary),
                           ),
                         ],

--- a/lib/widgets/trip_time_line.dart
+++ b/lib/widgets/trip_time_line.dart
@@ -4,7 +4,6 @@ import 'package:trainlog_app/data/models/trips.dart';
 import 'package:trainlog_app/providers/settings_provider.dart';
 import 'package:trainlog_app/providers/trainlog_provider.dart';
 import 'package:trainlog_app/utils/date_utils.dart';
-import 'package:trainlog_app/utils/date_utils.dart' as date_utils;
 import 'package:trainlog_app/utils/map_color_palette.dart';
 import 'package:trainlog_app/utils/style_utils.dart';
 
@@ -27,8 +26,7 @@ class TripTimeline extends StatelessWidget {
     final operatorName = trip.operatorName;
     final lineName = trip.lineName;
     final distance = "${(trip.tripLength / 1000).round()} km";
-    final duration = trip.utcEndDatetime?.difference(trip.utcStartDatetime ?? trip.startDatetime); // UTC start shouldn't be NULL if UTC end is not NULL, so startDatetime shouldn't be used (placed here to avoid NULL error)
-    final durationStr = date_utils.formatSecondsToHMS((trip.manualTripDuration ?? duration?.inSeconds ?? trip.estimatedTripDuration).round().toInt());
+    final durationStr = trip.durationFormatted;
 
     final settings = context.read<SettingsProvider>();
     final palette = MapColorPaletteHelper.getPalette(settings.mapColorPalette);


### PR DESCRIPTION
## Summary
Refactored trip duration calculation logic by moving it from individual widgets into the `Trips` model as computed properties. This eliminates code duplication and provides a single source of truth for duration calculations across the app.

## Key Changes
- **Added computed properties to `Trips` model:**
  - `duration`: Scheduled trip duration (manual value → UTC difference → estimated duration)
  - `durationFormatted`: Formatted duration string (HH:MM:SS)
  - `realDuration`: Actual duration accounting for departure/arrival delays
  - `realDurationFormatted`: Formatted real duration string

- **Updated `TripTimeline` widget:**
  - Replaced inline duration calculation with `trip.durationFormatted`
  - Added visual indicator for delay impact: strikethrough scheduled duration when delays exist
  - Shows real duration in parentheses with color coding (red for delays, green for early arrival)
  - Removed duplicate import of `date_utils`

- **Updated `TripCardView` widget:**
  - Replaced inline duration calculation with `trip.durationFormatted`
  - Added delay delta display showing minutes difference from scheduled duration
  - Color-coded delta: red for positive delays, green for negative (early arrival)

## Implementation Details
- Duration calculation priority: manual value → UTC start/end difference → estimated duration
- Real duration only calculated when delay information is available (`hasDelay` check)
- Delay delta shown only when the difference is non-zero (rounded to nearest minute)
- Maintains null-safety by handling cases where UTC start might be null

https://claude.ai/code/session_01UqgoSUyqYyPMq73UZETEKU