### PR TITLE
Replace user location icon with custom map marker widget

### DIFF
--- a/lib/features/map/map_marker.dart
+++ b/lib/features/map/map_marker.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:trainlog_app/app/theme/app_colors.dart';
+
+/// A modern "current location" marker, similar to the blue dot Google Maps
+/// shows for the user's position: a solid blue dot wrapped in a white ring and
+/// surrounded by a soft, blueish halo.
+///
+/// The marker is square; size it through the enclosing [Marker]'s width/height.
+/// [color] defaults to [AppColors.blue].
+class MapMarker extends StatelessWidget {
+  /// Base colour of the dot and halo.
+  final Color color;
+
+  const MapMarker({super.key, this.color = AppColors.blue});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: AspectRatio(
+        aspectRatio: 1,
+        child: CustomPaint(
+          painter: _MapMarkerPainter(color: color),
+        ),
+      ),
+    );
+  }
+}
+
+class _MapMarkerPainter extends CustomPainter {
+  final Color color;
+
+  const _MapMarkerPainter({required this.color});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final center = Offset(size.width / 2, size.height / 2);
+    final radius = size.shortestSide / 2;
+
+    // Soft blueish halo filling the marker bounds.
+    final haloPaint = Paint()
+      ..color = color.withValues(alpha: 0.20)
+      ..style = PaintingStyle.fill;
+    canvas.drawCircle(center, radius, haloPaint);
+
+    // White ring around the dot, giving it contrast against the map.
+    final dotRadius = radius * 0.42;
+    final ringWidth = radius * 0.14;
+    final ringPaint = Paint()
+      ..color = Colors.white
+      ..style = PaintingStyle.fill;
+    canvas.drawCircle(center, dotRadius + ringWidth, ringPaint);
+
+    // Solid blue dot in the centre.
+    final dotPaint = Paint()
+      ..color = color
+      ..style = PaintingStyle.fill;
+    canvas.drawCircle(center, dotRadius, dotPaint);
+  }
+
+  @override
+  bool shouldRepaint(_MapMarkerPainter oldDelegate) => oldDelegate.color != color;
+}

--- a/lib/features/map/map_page.dart
+++ b/lib/features/map/map_page.dart
@@ -258,8 +258,8 @@ class _MapPageState extends State<MapPage>
               MarkerLayer(
                 markers: [
                   Marker(
-                    width: 40,
-                    height: 40,
+                    width: 30,
+                    height: 30,
                     point: _userPosition!,
                     child: const MapMarker(),
                   ),

--- a/lib/features/map/map_page.dart
+++ b/lib/features/map/map_page.dart
@@ -15,6 +15,7 @@ import 'package:trainlog_app/app/theme/app_colors.dart';
 import 'package:trainlog_app/app/theme/app_nav_bar_theme.dart';
 import 'package:trainlog_app/l10n/app_localizations.dart';
 import 'package:trainlog_app/features/map/map_filter_widget.dart';
+import 'package:trainlog_app/features/map/map_marker.dart';
 import 'package:trainlog_app/navigation/nav_models.dart';
 import 'package:trainlog_app/platform/adaptive_trip_card.dart';
 import 'package:trainlog_app/platform/adaptive_widget.dart';
@@ -260,7 +261,7 @@ class _MapPageState extends State<MapPage>
                     width: 40,
                     height: 40,
                     point: _userPosition!,
-                    child: const Icon(Icons.my_location, size: 28, color: Colors.red),
+                    child: const MapMarker(),
                   ),
                 ],
               ),


### PR DESCRIPTION
## Summary
Replaced the generic location icon with a custom `MapMarker` widget that provides a modern, Google Maps-style "current location" indicator featuring a blue dot with a white ring and soft halo effect.

## Changes
- **New widget**: Added `MapMarker` class in `lib/features/map/map_marker.dart`
  - Custom painter implementation (`_MapMarkerPainter`) that draws three layers: soft halo, white ring, and solid center dot
  - Configurable color with default to `AppColors.blue`
  - Responsive sizing based on parent constraints
  
- **Updated map page**: Modified `lib/features/map/map_page.dart`
  - Replaced `Icon(Icons.my_location)` with `MapMarker()` widget
  - Reduced marker size from 40x40 to 30x30 pixels
  - Added import for the new `MapMarker` widget

## Implementation Details
The `MapMarker` uses a `CustomPaint` approach with three concentric circles:
1. Outer halo with 20% opacity for a soft glow effect
2. White ring for contrast against map backgrounds
3. Solid colored center dot (default blue)

The marker maintains a 1:1 aspect ratio and scales proportionally based on the parent `Marker` dimensions.

https://claude.ai/code/session_01UKZ6Sm63iYyZRRuWKAcjdH