### PR TITLE
Add leaderboard/ranking API and models

### DIFF
--- a/lib/data/models/country_detail.dart
+++ b/lib/data/models/country_detail.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/widgets.dart';
+import 'package:trainlog_app/utils/text_utils.dart';
+
+/// A country resolved for display: its ISO 3166-1 alpha-2 [code], the
+/// localized [name] (according to the user's locale) and the flag [emoji].
+class CountryDetail {
+  final String code;
+  final String name;
+  final String emoji;
+
+  const CountryDetail({
+    required this.code,
+    required this.name,
+    required this.emoji,
+  });
+
+  /// Builds a [CountryDetail] from an ISO country [code], resolving the
+  /// localized name through the active [CountryLocalizations] and deriving the
+  /// flag emoji from the code.
+  factory CountryDetail.fromCode(String code, BuildContext context) {
+    return CountryDetail(
+      code: code,
+      name: countryCodeToName(code, context),
+      emoji: countryCodeToEmoji(code),
+    );
+  }
+}

--- a/lib/data/models/ranking_model.dart
+++ b/lib/data/models/ranking_model.dart
@@ -206,6 +206,148 @@ extension CountryResultSorting on RankingResult<CountryLeaderboardEntry> {
       sortedBy((e) => e.countryCount, descending: descending);
 }
 
+/// A single coverage tier within a country/subdivision: the [percent] of the
+/// rail network covered and the [usernames] of the users who reached it.
+class RailCoverage {
+  final double percent;
+  final List<String> usernames;
+
+  const RailCoverage({required this.percent, required this.usernames});
+}
+
+/// Rail-coverage stats for one country or subdivision, from
+/// `/getLeaderboardUsers/train_countries`:
+/// ```json
+/// { "cc": "AT", "data": [ { "percent": 99.0, "usernames": ["Wandering Pom"] }, ... ] }
+/// ```
+///
+/// [code] is either a country code (`"AT"`) or an ISO 3166-2 subdivision code
+/// (`"AT-1"`, `"FR-ARA"`); [RailPercentageResult] keeps the two kinds apart.
+class RailPercentageEntry {
+  /// Raw area code: a country code or an ISO 3166-2 subdivision code.
+  final String code;
+
+  /// Per-percentage coverage tiers (highest first, as returned by the backend).
+  final List<RailCoverage> data;
+
+  const RailPercentageEntry({required this.code, required this.data});
+
+  /// Whether [code] denotes a subdivision (ISO 3166-2, contains a hyphen).
+  bool get isSubdivision => code.contains('-');
+
+  /// The country code: the parent for a subdivision (`"AT-1"` -> `"AT"`) or
+  /// [code] itself for a country.
+  String get countryCode => isSubdivision ? code.split('-').first : code;
+
+  /// The subdivision part (`"AT-1"` -> `"1"`, `"FR-ARA"` -> `"ARA"`), or `null`
+  /// for a country.
+  String? get subdivisionCode =>
+      isSubdivision ? code.split('-').sublist(1).join('-') : null;
+
+  /// The highest coverage percentage reached in this area (0 when empty).
+  double get highestPercent => data.isEmpty
+      ? 0
+      : data.map((c) => c.percent).reduce((a, b) => a > b ? a : b);
+
+  /// The country resolved to a [CountryDetail] (code, localized name, emoji).
+  CountryDetail country(BuildContext context) =>
+      CountryDetail.fromCode(countryCode, context);
+
+  /// Parses one `leaderboard_data` row, dropping users in [nonPublic] (and any
+  /// tier or whole entry left empty as a result). Returns `null` when no public
+  /// users remain.
+  static RailPercentageEntry? fromJson(
+    Map<String, dynamic> json, {
+    Set<String> nonPublic = const {},
+  }) {
+    final code = json['cc']?.toString() ?? '';
+    if (code.isEmpty) return null;
+
+    final coverages = <RailCoverage>[];
+    for (final d in (json['data'] as List<dynamic>? ?? [])
+        .whereType<Map<String, dynamic>>()) {
+      final users = (d['usernames'] as List<dynamic>? ?? [])
+          .map((e) => e.toString())
+          .where((u) => !nonPublic.contains(u))
+          .toList();
+      if (users.isEmpty) continue;
+      coverages
+          .add(RailCoverage(percent: _toDouble(d['percent']), usernames: users));
+    }
+
+    if (coverages.isEmpty) return null;
+    return RailPercentageEntry(code: code, data: coverages);
+  }
+}
+
+/// The result of the rail-percentage leaderboard, with country-level and
+/// subdivision-level entries kept apart (public users only).
+class RailPercentageResult {
+  /// Country-level entries (`cc` without a hyphen).
+  final List<RailPercentageEntry> countries;
+
+  /// Subdivision-level entries (`cc` in ISO 3166-2 form, with a hyphen).
+  final List<RailPercentageEntry> subdivisions;
+
+  const RailPercentageResult({
+    required this.countries,
+    required this.subdivisions,
+  });
+
+  bool get isEmpty => countries.isEmpty && subdivisions.isEmpty;
+  bool get isNotEmpty => !isEmpty;
+
+  /// All subdivisions belonging to [countryCode] (e.g. `"AT"` -> AT-1, AT-2…),
+  /// in the order they appear.
+  List<RailPercentageEntry> subdivisionsOf(String countryCode) {
+    final cc = countryCode.toUpperCase();
+    return subdivisions.where((e) => e.countryCode.toUpperCase() == cc).toList();
+  }
+
+  /// Countries sorted by highest coverage percentage (highest first); ties
+  /// broken alphabetically by localized country name.
+  List<RailPercentageEntry> countriesSortedByPercent(BuildContext context) =>
+      _sortByPercent(countries, (e) => e.country(context).name);
+
+  /// Countries sorted alphabetically by localized country name.
+  List<RailPercentageEntry> countriesSortedByName(BuildContext context) =>
+      _sortByName(countries, (e) => e.country(context).name);
+
+  /// Subdivisions sorted by highest coverage percentage (highest first); ties
+  /// broken alphabetically by subdivision code.
+  List<RailPercentageEntry> subdivisionsSortedByPercent() =>
+      _sortByPercent(subdivisions, (e) => e.code);
+
+  /// Subdivisions sorted alphabetically by subdivision code.
+  List<RailPercentageEntry> subdivisionsSortedByName() =>
+      _sortByName(subdivisions, (e) => e.code);
+}
+
+/// Sorts by highest coverage percentage (descending), breaking ties
+/// alphabetically (ascending) on [name].
+List<RailPercentageEntry> _sortByPercent(
+  List<RailPercentageEntry> list,
+  String Function(RailPercentageEntry entry) name,
+) {
+  final copy = List<RailPercentageEntry>.of(list);
+  copy.sort((a, b) {
+    final cmp = b.highestPercent.compareTo(a.highestPercent);
+    if (cmp != 0) return cmp;
+    return name(a).toLowerCase().compareTo(name(b).toLowerCase());
+  });
+  return copy;
+}
+
+/// Sorts alphabetically (ascending) on [name].
+List<RailPercentageEntry> _sortByName(
+  List<RailPercentageEntry> list,
+  String Function(RailPercentageEntry entry) name,
+) {
+  final copy = List<RailPercentageEntry>.of(list);
+  copy.sort((a, b) => name(a).toLowerCase().compareTo(name(b).toLowerCase()));
+  return copy;
+}
+
 /// Parses a leaderboard `last_modified` value into a local [DateTime].
 ///
 /// The backend sends RFC 1123 dates (e.g. `"Wed, 01 Apr 2026 00:00:00 GMT"`)

--- a/lib/data/models/ranking_model.dart
+++ b/lib/data/models/ranking_model.dart
@@ -31,7 +31,7 @@ abstract class TripRankingEntry extends RankingEntry {
 ///
 /// Matches the `leaderboard_data` rows of `/getLeaderboardUsers/<type>`:
 /// ```json
-/// { "last_modified": "...", "length": 35377003.27, "trips": 196, "username": "mylou" }
+/// { "last_modified": "...", "length": 35377003.27, "trips": 196, "username": "John Doe" }
 /// ```
 class LeaderboardEntry extends TripRankingEntry {
   /// Total travelled distance in metres.
@@ -59,7 +59,7 @@ class LeaderboardEntry extends TripRankingEntry {
 /// Matches the carbon variant of `/getLeaderboardUsers/carbon`:
 /// ```json
 /// { "carbon_per_km": 0.177, "last_modified": "...", "total_carbon": 507375.78,
-///   "total_distance": 2856857682.75, "trips": 2202, "username": "nmartin4" }
+///   "total_distance": 2856857682.75, "trips": 2202, "username": "John Doe" }
 /// ```
 class CarbonLeaderboardEntry extends TripRankingEntry {
   /// Average carbon emitted per kilometre (kg CO2 / km).
@@ -95,7 +95,7 @@ class CarbonLeaderboardEntry extends TripRankingEntry {
 /// A leaderboard row for the countries-visited ranking
 /// (`/getLeaderboardUsers/country_count`):
 /// ```json
-/// { "countries_visited": ["US", "JP", ...], "country_count": 101, "username": "nmartin4" }
+/// { "countries_visited": ["US", "JP", ...], "country_count": 101, "username": "John Doe" }
 /// ```
 class CountryLeaderboardEntry extends RankingEntry {
   /// Number of distinct countries visited.
@@ -218,7 +218,7 @@ class RailCoverage {
 /// Rail-coverage stats for one country or subdivision, from
 /// `/getLeaderboardUsers/train_countries`:
 /// ```json
-/// { "cc": "AT", "data": [ { "percent": 99.0, "usernames": ["Wandering Pom"] }, ... ] }
+/// { "cc": "AT", "data": [ { "percent": 99.0, "usernames": ["John Doe"] }, ... ] }
 /// ```
 ///
 /// [code] is either a country code (`"AT"`) or an ISO 3166-2 subdivision code

--- a/lib/data/models/ranking_model.dart
+++ b/lib/data/models/ranking_model.dart
@@ -1,18 +1,27 @@
 import 'dart:io';
 
+import 'package:flutter/widgets.dart';
+import 'package:trainlog_app/data/models/country_detail.dart';
+
 /// Base class shared by every leaderboard entry.
 ///
-/// Every ranking row exposes a [username], the last time the user's data was
-/// modified ([lastModified], nullable — the backend sends `null` for users who
-/// never logged anything) and the number of [trips]. The concrete subclasses
-/// add the metric-specific fields (e.g. distance, carbon, …).
+/// The only field common to all ranking variants is the [username]; each
+/// concrete subclass adds the metric-specific fields.
 abstract class RankingEntry {
   final String username;
+
+  const RankingEntry({required this.username});
+}
+
+/// Intermediate class for the trip-based leaderboards (vehicle, `all`,
+/// carbon). These share a nullable [lastModified] (the backend sends `null`
+/// for users who never logged anything) and a number of [trips].
+abstract class TripRankingEntry extends RankingEntry {
   final DateTime? lastModified;
   final int trips;
 
-  const RankingEntry({
-    required this.username,
+  const TripRankingEntry({
+    required super.username,
     required this.lastModified,
     required this.trips,
   });
@@ -24,7 +33,7 @@ abstract class RankingEntry {
 /// ```json
 /// { "last_modified": "...", "length": 35377003.27, "trips": 196, "username": "mylou" }
 /// ```
-class LeaderboardEntry extends RankingEntry {
+class LeaderboardEntry extends TripRankingEntry {
   /// Total travelled distance in metres.
   final double length;
 
@@ -52,7 +61,7 @@ class LeaderboardEntry extends RankingEntry {
 /// { "carbon_per_km": 0.177, "last_modified": "...", "total_carbon": 507375.78,
 ///   "total_distance": 2856857682.75, "trips": 2202, "username": "nmartin4" }
 /// ```
-class CarbonLeaderboardEntry extends RankingEntry {
+class CarbonLeaderboardEntry extends TripRankingEntry {
   /// Average carbon emitted per kilometre (kg CO2 / km).
   final double carbonPerKm;
 
@@ -83,13 +92,62 @@ class CarbonLeaderboardEntry extends RankingEntry {
   }
 }
 
+/// A leaderboard row for the countries-visited ranking
+/// (`/getLeaderboardUsers/country_count`):
+/// ```json
+/// { "countries_visited": ["US", "JP", ...], "country_count": 101, "username": "nmartin4" }
+/// ```
+class CountryLeaderboardEntry extends RankingEntry {
+  /// Number of distinct countries visited.
+  final int countryCount;
+
+  /// ISO country codes the user has visited, kept in the backend order
+  /// (by trip count per country, most visited first).
+  final List<String> countriesVisited;
+
+  const CountryLeaderboardEntry({
+    required super.username,
+    required this.countryCount,
+    required this.countriesVisited,
+  });
+
+  factory CountryLeaderboardEntry.fromJson(Map<String, dynamic> json) {
+    final visited = (json['countries_visited'] as List<dynamic>? ?? [])
+        .map((e) => e.toString())
+        .toList();
+    return CountryLeaderboardEntry(
+      username: json['username']?.toString() ?? '',
+      countryCount: _toInt(json['country_count']),
+      countriesVisited: visited,
+    );
+  }
+
+  /// Resolves [countriesVisited] to [CountryDetail]s (code, localized name and
+  /// emoji), preserving the backend order — by trip count, most visited first.
+  List<CountryDetail> countryDetails(BuildContext context) {
+    return countriesVisited
+        .map((code) => CountryDetail.fromCode(code, context))
+        .toList();
+  }
+
+  /// Same as [countryDetails] but sorted alphabetically by localized country
+  /// name (according to the user's locale).
+  List<CountryDetail> countryDetailsSortedByName(BuildContext context) {
+    final details = countryDetails(context);
+    details.sort(
+      (a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()),
+    );
+    return details;
+  }
+}
+
 /// The result of a leaderboard request: the public entries only (users listed
-/// in `non_public_users` are already filtered out by [RankingApi]).
+/// in `non_public_users` are already filtered out by `RankingApi`).
 ///
 /// Sorting is intentionally not baked in — the same data is shown sorted by
 /// length, trips, carbon, … depending on the screen. Use [sortedBy] with a
-/// field selector, or the convenience helpers ([sortedByTrips] here, plus the
-/// metric-specific helpers in the extensions below).
+/// field selector, or one of the metric-specific helpers in the extensions
+/// below.
 class RankingResult<T extends RankingEntry> {
   final List<T> entries;
 
@@ -109,8 +167,12 @@ class RankingResult<T extends RankingEntry> {
     });
     return copy;
   }
+}
 
-  /// Sorted by number of trips (available on every entry type).
+/// Trip-count sorting, shared by every trip-based leaderboard.
+extension TripRankingResultSorting<T extends TripRankingEntry>
+    on RankingResult<T> {
+  /// Sorted by number of trips.
   List<T> sortedByTrips({bool descending = true}) =>
       sortedBy((e) => e.trips, descending: descending);
 }
@@ -135,6 +197,13 @@ extension CarbonResultSorting on RankingResult<CarbonLeaderboardEntry> {
   /// Sorted by total travelled distance.
   List<CarbonLeaderboardEntry> sortedByTotalDistance({bool descending = true}) =>
       sortedBy((e) => e.totalDistance, descending: descending);
+}
+
+/// Country-count sorting for the countries-visited leaderboard.
+extension CountryResultSorting on RankingResult<CountryLeaderboardEntry> {
+  /// Sorted by the number of distinct countries visited.
+  List<CountryLeaderboardEntry> sortedByCountryCount({bool descending = true}) =>
+      sortedBy((e) => e.countryCount, descending: descending);
 }
 
 /// Parses a leaderboard `last_modified` value into a local [DateTime].

--- a/lib/data/models/ranking_model.dart
+++ b/lib/data/models/ranking_model.dart
@@ -1,0 +1,169 @@
+import 'dart:io';
+
+/// Base class shared by every leaderboard entry.
+///
+/// Every ranking row exposes a [username], the last time the user's data was
+/// modified ([lastModified], nullable — the backend sends `null` for users who
+/// never logged anything) and the number of [trips]. The concrete subclasses
+/// add the metric-specific fields (e.g. distance, carbon, …).
+abstract class RankingEntry {
+  final String username;
+  final DateTime? lastModified;
+  final int trips;
+
+  const RankingEntry({
+    required this.username,
+    required this.lastModified,
+    required this.trips,
+  });
+}
+
+/// A leaderboard row for a single vehicle type (or for `all` combined).
+///
+/// Matches the `leaderboard_data` rows of `/getLeaderboardUsers/<type>`:
+/// ```json
+/// { "last_modified": "...", "length": 35377003.27, "trips": 196, "username": "mylou" }
+/// ```
+class LeaderboardEntry extends RankingEntry {
+  /// Total travelled distance in metres.
+  final double length;
+
+  const LeaderboardEntry({
+    required super.username,
+    required super.lastModified,
+    required super.trips,
+    required this.length,
+  });
+
+  factory LeaderboardEntry.fromJson(Map<String, dynamic> json) {
+    return LeaderboardEntry(
+      username: json['username']?.toString() ?? '',
+      lastModified: parseLeaderboardDate(json['last_modified']),
+      trips: _toInt(json['trips']),
+      length: _toDouble(json['length']),
+    );
+  }
+}
+
+/// A leaderboard row for the carbon-footprint ranking.
+///
+/// Matches the carbon variant of `/getLeaderboardUsers/carbon`:
+/// ```json
+/// { "carbon_per_km": 0.177, "last_modified": "...", "total_carbon": 507375.78,
+///   "total_distance": 2856857682.75, "trips": 2202, "username": "nmartin4" }
+/// ```
+class CarbonLeaderboardEntry extends RankingEntry {
+  /// Average carbon emitted per kilometre (kg CO2 / km).
+  final double carbonPerKm;
+
+  /// Total carbon emitted (kg CO2).
+  final double totalCarbon;
+
+  /// Total travelled distance in metres.
+  final double totalDistance;
+
+  const CarbonLeaderboardEntry({
+    required super.username,
+    required super.lastModified,
+    required super.trips,
+    required this.carbonPerKm,
+    required this.totalCarbon,
+    required this.totalDistance,
+  });
+
+  factory CarbonLeaderboardEntry.fromJson(Map<String, dynamic> json) {
+    return CarbonLeaderboardEntry(
+      username: json['username']?.toString() ?? '',
+      lastModified: parseLeaderboardDate(json['last_modified']),
+      trips: _toInt(json['trips']),
+      carbonPerKm: _toDouble(json['carbon_per_km']),
+      totalCarbon: _toDouble(json['total_carbon']),
+      totalDistance: _toDouble(json['total_distance']),
+    );
+  }
+}
+
+/// The result of a leaderboard request: the public entries only (users listed
+/// in `non_public_users` are already filtered out by [RankingApi]).
+///
+/// Sorting is intentionally not baked in — the same data is shown sorted by
+/// length, trips, carbon, … depending on the screen. Use [sortedBy] with a
+/// field selector, or the convenience helpers ([sortedByTrips] here, plus the
+/// metric-specific helpers in the extensions below).
+class RankingResult<T extends RankingEntry> {
+  final List<T> entries;
+
+  const RankingResult(this.entries);
+
+  bool get isEmpty => entries.isEmpty;
+  bool get isNotEmpty => entries.isNotEmpty;
+  int get length => entries.length;
+
+  /// Returns a new list sorted by [selector]. Descending (highest first) by
+  /// default, which is what a leaderboard usually wants.
+  List<T> sortedBy(num Function(T entry) selector, {bool descending = true}) {
+    final copy = List<T>.from(entries);
+    copy.sort((a, b) {
+      final cmp = selector(a).compareTo(selector(b));
+      return descending ? -cmp : cmp;
+    });
+    return copy;
+  }
+
+  /// Sorted by number of trips (available on every entry type).
+  List<T> sortedByTrips({bool descending = true}) =>
+      sortedBy((e) => e.trips, descending: descending);
+}
+
+/// Distance-based sorting for the vehicle / `all` leaderboards.
+extension LeaderboardResultSorting on RankingResult<LeaderboardEntry> {
+  /// Sorted by total travelled distance.
+  List<LeaderboardEntry> sortedByLength({bool descending = true}) =>
+      sortedBy((e) => e.length, descending: descending);
+}
+
+/// Carbon-based sorting for the carbon-footprint leaderboard.
+extension CarbonResultSorting on RankingResult<CarbonLeaderboardEntry> {
+  /// Sorted by total carbon emitted.
+  List<CarbonLeaderboardEntry> sortedByTotalCarbon({bool descending = true}) =>
+      sortedBy((e) => e.totalCarbon, descending: descending);
+
+  /// Sorted by carbon emitted per kilometre.
+  List<CarbonLeaderboardEntry> sortedByCarbonPerKm({bool descending = true}) =>
+      sortedBy((e) => e.carbonPerKm, descending: descending);
+
+  /// Sorted by total travelled distance.
+  List<CarbonLeaderboardEntry> sortedByTotalDistance({bool descending = true}) =>
+      sortedBy((e) => e.totalDistance, descending: descending);
+}
+
+/// Parses a leaderboard `last_modified` value into a local [DateTime].
+///
+/// The backend sends RFC 1123 dates (e.g. `"Wed, 01 Apr 2026 00:00:00 GMT"`)
+/// or `null` for users with no activity. Returns `null` when the value is
+/// missing or unparseable rather than throwing.
+DateTime? parseLeaderboardDate(dynamic value) {
+  if (value == null) return null;
+  final str = value.toString().trim();
+  if (str.isEmpty || str.toLowerCase() == 'null') return null;
+  try {
+    return HttpDate.parse(str).toLocal();
+  } on FormatException {
+    return DateTime.tryParse(str)?.toLocal();
+  } on HttpException {
+    return DateTime.tryParse(str)?.toLocal();
+  }
+}
+
+double _toDouble(dynamic v) {
+  if (v is num) return v.toDouble();
+  if (v is String) return double.tryParse(v) ?? 0.0;
+  return 0.0;
+}
+
+int _toInt(dynamic v) {
+  if (v is int) return v;
+  if (v is num) return v.toInt();
+  if (v is String) return int.tryParse(v) ?? 0;
+  return 0;
+}

--- a/lib/data/models/ranking_model.dart
+++ b/lib/data/models/ranking_model.dart
@@ -213,6 +213,20 @@ class RailCoverage {
   final List<String> usernames;
 
   const RailCoverage({required this.percent, required this.usernames});
+
+  /// Parses one `{ "percent": .., "usernames": [..] }` tier, dropping users in
+  /// [nonPublic]. Returns `null` when no public users remain.
+  static RailCoverage? fromJson(
+    Map<String, dynamic> json, {
+    Set<String> nonPublic = const {},
+  }) {
+    final users = (json['usernames'] as List<dynamic>? ?? [])
+        .map((e) => e.toString())
+        .where((u) => !nonPublic.contains(u))
+        .toList();
+    if (users.isEmpty) return null;
+    return RailCoverage(percent: _toDouble(json['percent']), usernames: users);
+  }
 }
 
 /// Rail-coverage stats for one country or subdivision, from
@@ -266,13 +280,8 @@ class RailPercentageEntry {
     final coverages = <RailCoverage>[];
     for (final d in (json['data'] as List<dynamic>? ?? [])
         .whereType<Map<String, dynamic>>()) {
-      final users = (d['usernames'] as List<dynamic>? ?? [])
-          .map((e) => e.toString())
-          .where((u) => !nonPublic.contains(u))
-          .toList();
-      if (users.isEmpty) continue;
-      coverages
-          .add(RailCoverage(percent: _toDouble(d['percent']), usernames: users));
+      final coverage = RailCoverage.fromJson(d, nonPublic: nonPublic);
+      if (coverage != null) coverages.add(coverage);
     }
 
     if (coverages.isEmpty) return null;
@@ -346,6 +355,43 @@ List<RailPercentageEntry> _sortByName(
   final copy = List<RailPercentageEntry>.of(list);
   copy.sort((a, b) => name(a).toLowerCase().compareTo(name(b).toLowerCase()));
   return copy;
+}
+
+/// The result of the world-squares leaderboard
+/// (`/getLeaderboardUsers/world_squares`): coverage tiers (each listing the
+/// users who reached it), ordered by world-coverage percentage (highest
+/// first). Public users only.
+///
+/// The backend sends a single `{ "cc": "world_squares", "data": [...] }` block:
+/// ```json
+/// { "percent": 2.27, "usernames": ["John Doe"] }
+/// ```
+class WorldSquaresResult {
+  final List<RailCoverage> coverages;
+
+  const WorldSquaresResult(this.coverages);
+
+  bool get isEmpty => coverages.isEmpty;
+  bool get isNotEmpty => coverages.isNotEmpty;
+
+  /// Builds the result from the raw `leaderboard_data` rows, dropping users in
+  /// [nonPublic]. The tiers come back ordered by coverage percentage; this
+  /// re-sorts defensively to guarantee highest-first.
+  factory WorldSquaresResult.fromLeaderboard(
+    List<Map<String, dynamic>> rows,
+    Set<String> nonPublic,
+  ) {
+    final coverages = <RailCoverage>[];
+    for (final row in rows) {
+      for (final d in (row['data'] as List<dynamic>? ?? [])
+          .whereType<Map<String, dynamic>>()) {
+        final coverage = RailCoverage.fromJson(d, nonPublic: nonPublic);
+        if (coverage != null) coverages.add(coverage);
+      }
+    }
+    coverages.sort((a, b) => b.percent.compareTo(a.percent));
+    return WorldSquaresResult(coverages);
+  }
 }
 
 /// Parses a leaderboard `last_modified` value into a local [DateTime].

--- a/lib/data/models/trips.dart
+++ b/lib/data/models/trips.dart
@@ -9,6 +9,7 @@ import 'package:trainlog_app/utils/date_utils.dart';
 import 'package:trainlog_app/utils/text_utils.dart';
 import 'package:trainlog_app/widgets/trip_visibility_selector.dart';
 import 'package:trainlog_app/data/models/polyline_entry.dart';
+import 'package:trainlog_app/data/models/country_detail.dart';
 
 class Trips {
   final String uid;
@@ -173,16 +174,12 @@ class Trips {
     }
   }
 
-  /// The trip's countries as `(code, emoji, localized name)` records, resolving
-  /// names through the active [CountryLocalizations]. Returns an empty list
-  /// when the trip carries no country data.
-  List<({String code, String emoji, String name})> countryDetails(BuildContext context) {
+  /// The trip's countries as [CountryDetail]s (code, flag emoji and localized
+  /// name), resolving names through the active [CountryLocalizations]. Returns
+  /// an empty list when the trip carries no country data.
+  List<CountryDetail> countryDetails(BuildContext context) {
     return countryList
-        .map((code) => (
-              code: code,
-              emoji: countryCodeToEmoji(code),
-              name: countryCodeToName(code, context),
-            ))
+        .map((code) => CountryDetail.fromCode(code, context))
         .toList();
   }
 

--- a/lib/features/trips/detail_sheet/trip_details_metadata.dart
+++ b/lib/features/trips/detail_sheet/trip_details_metadata.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:trainlog_app/data/models/country_detail.dart';
 import 'package:trainlog_app/data/models/trips.dart';
 import 'package:trainlog_app/features/trips/detail_sheet/trip_details_common.dart';
 import 'package:trainlog_app/l10n/app_localizations.dart';
@@ -93,7 +94,7 @@ class TripDetailsMetadata extends StatelessWidget {
 /// out in two responsive columns like the details grid (collapsing to one
 /// column on narrow widths).
 class _Countries extends StatelessWidget {
-  final List<({String code, String emoji, String name})> countries;
+  final List<CountryDetail> countries;
 
   const _Countries({required this.countries});
 

--- a/lib/providers/trainlog_provider.dart
+++ b/lib/providers/trainlog_provider.dart
@@ -338,7 +338,8 @@ class TrainlogProvider extends ChangeNotifier {
   Future<RankingResult<CarbonLeaderboardEntry>> fetchRankingForCarbonFootprint() =>
       _ranking.fetchRankingForCarbonFootprint();
 
-  Future<void> fetchRankingForCountry() => _ranking.fetchRankingForCountry();
+  Future<RankingResult<CountryLeaderboardEntry>> fetchRankingForCountry() =>
+      _ranking.fetchRankingForCountry();
 
   Future<void> fetchRankingForRailPercentage() =>
       _ranking.fetchRankingForRailPercentage();

--- a/lib/providers/trainlog_provider.dart
+++ b/lib/providers/trainlog_provider.dart
@@ -344,7 +344,7 @@ class TrainlogProvider extends ChangeNotifier {
   Future<RailPercentageResult> fetchRankingForRailPercentage() =>
       _ranking.fetchRankingForRailPercentage();
 
-  Future<void> fetchRankingForWorldSquares() =>
+  Future<WorldSquaresResult> fetchRankingForWorldSquares() =>
       _ranking.fetchRankingForWorldSquares();
 
   /// Return up to [limit] operators that match [query] by

--- a/lib/providers/trainlog_provider.dart
+++ b/lib/providers/trainlog_provider.dart
@@ -341,7 +341,7 @@ class TrainlogProvider extends ChangeNotifier {
   Future<RankingResult<CountryLeaderboardEntry>> fetchRankingForCountry() =>
       _ranking.fetchRankingForCountry();
 
-  Future<void> fetchRankingForRailPercentage() =>
+  Future<RailPercentageResult> fetchRankingForRailPercentage() =>
       _ranking.fetchRankingForRailPercentage();
 
   Future<void> fetchRankingForWorldSquares() =>

--- a/lib/providers/trainlog_provider.dart
+++ b/lib/providers/trainlog_provider.dart
@@ -3,6 +3,7 @@ import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:trainlog_app/data/models/news_model.dart';
 import 'package:trainlog_app/data/models/pre_record_model.dart';
+import 'package:trainlog_app/data/models/ranking_model.dart';
 import 'package:trainlog_app/data/models/trips.dart';
 import 'package:trainlog_app/providers/settings_provider.dart';
 import 'package:trainlog_app/providers/trips_provider.dart';
@@ -29,6 +30,7 @@ class TrainlogProvider extends ChangeNotifier {
   late StationsApi _stations;
   late AccountApi _account;
   late MiscApi _misc;
+  late RankingApi _ranking;
 
   bool _loading = false;
   bool _isAuthenticated = false;
@@ -53,6 +55,7 @@ class TrainlogProvider extends ChangeNotifier {
     _stations = StationsApi(_client);
     _account = AccountApi(_client);
     _misc = MiscApi(_client);
+    _ranking = RankingApi(_client);
   }
 
   bool get loading => _loading;
@@ -63,6 +66,9 @@ class TrainlogProvider extends ChangeNotifier {
 
   /// The trips data API, handed to [TripsProvider] so it shares this session.
   TripsApi get tripsApi => _tripsApi;
+
+  /// The leaderboard / ranking API.
+  RankingApi get rankingApi => _ranking;
 
   Map<String, String> get listOperators => _listOperators;
   List<String> get availableCurrencies => _availableCurrencies;
@@ -318,6 +324,27 @@ class TrainlogProvider extends ChangeNotifier {
     if (_username == null) return {};
     return await _misc.fetchStatsByVehicle(_username ?? "", type, year);
   }
+
+  // ----------------------------
+  // Leaderboards / rankings
+  // ----------------------------
+
+  Future<RankingResult<LeaderboardEntry>> fetchRankingForVehicle(VehicleType type) =>
+      _ranking.fetchRankingForVehicle(type);
+
+  Future<RankingResult<LeaderboardEntry>> fetchRankingAll() =>
+      _ranking.fetchRankingAll();
+
+  Future<RankingResult<CarbonLeaderboardEntry>> fetchRankingForCarbonFootprint() =>
+      _ranking.fetchRankingForCarbonFootprint();
+
+  Future<void> fetchRankingForCountry() => _ranking.fetchRankingForCountry();
+
+  Future<void> fetchRankingForRailPercentage() =>
+      _ranking.fetchRankingForRailPercentage();
+
+  Future<void> fetchRankingForWorldSquares() =>
+      _ranking.fetchRankingForWorldSquares();
 
   /// Return up to [limit] operators that match [query] by
   /// substring match first, then fuzzy Levenshtein distance.

--- a/lib/services/api/api_import.dart
+++ b/lib/services/api/api_import.dart
@@ -4,3 +4,4 @@ export "misc_api.dart";
 export "trips_api.dart";
 export "trainlog_http_client.dart";
 export "stations_api.dart";
+export "ranking_api.dart";

--- a/lib/services/api/ranking_api.dart
+++ b/lib/services/api/ranking_api.dart
@@ -37,14 +37,9 @@ class RankingApi {
     return _fetchCarbonLeaderboard('carbon');
   }
 
-  /// Ranking by country (`<type>` = `country`).
-  ///
-  /// Placeholder: the backend returns a different shape than the distance
-  /// leaderboards and needs its own result model. To be implemented.
-  Future<void> fetchRankingForCountry() {
-    throw UnimplementedError(
-      'fetchRankingForCountry (/getLeaderboardUsers/country) is not implemented yet',
-    );
+  /// Ranking by number of countries visited (`<type>` = `country_count`).
+  Future<RankingResult<CountryLeaderboardEntry>> fetchRankingForCountry() {
+    return _fetchCountryLeaderboard('country_count');
   }
 
   /// Ranking by share of rail travel (`<type>` = `train_countries`).
@@ -87,6 +82,18 @@ class RankingApi {
     final entries = rows
         .where((r) => !nonPublic.contains(r['username']?.toString()))
         .map(CarbonLeaderboardEntry.fromJson)
+        .toList();
+    return RankingResult(entries);
+  }
+
+  /// The countries-visited leaderboard: a list of country codes plus a count.
+  Future<RankingResult<CountryLeaderboardEntry>> _fetchCountryLeaderboard(
+    String type,
+  ) async {
+    final (rows, nonPublic) = await _fetchRaw(type);
+    final entries = rows
+        .where((r) => !nonPublic.contains(r['username']?.toString()))
+        .map(CountryLeaderboardEntry.fromJson)
         .toList();
     return RankingResult(entries);
   }

--- a/lib/services/api/ranking_api.dart
+++ b/lib/services/api/ranking_api.dart
@@ -42,13 +42,10 @@ class RankingApi {
     return _fetchCountryLeaderboard('country_count');
   }
 
-  /// Ranking by share of rail travel (`<type>` = `train_countries`).
-  ///
-  /// Placeholder: dedicated result model still to be defined.
-  Future<void> fetchRankingForRailPercentage() {
-    throw UnimplementedError(
-      'fetchRankingForRailPercentage (/getLeaderboardUsers/train_countries) is not implemented yet',
-    );
+  /// Ranking by share of rail travel per country / subdivision
+  /// (`<type>` = `train_countries`).
+  Future<RailPercentageResult> fetchRankingForRailPercentage() {
+    return _fetchRailPercentageLeaderboard('train_countries');
   }
 
   /// Ranking by world squares covered (`<type>` = `world_squares`).
@@ -96,6 +93,32 @@ class RankingApi {
         .map(CountryLeaderboardEntry.fromJson)
         .toList();
     return RankingResult(entries);
+  }
+
+  /// The rail-percentage leaderboard: rows keyed by country / subdivision
+  /// rather than by user. Public users are filtered out per coverage tier and
+  /// country- and subdivision-level rows are kept apart.
+  Future<RailPercentageResult> _fetchRailPercentageLeaderboard(
+    String type,
+  ) async {
+    final (rows, nonPublic) = await _fetchRaw(type);
+    final countries = <RailPercentageEntry>[];
+    final subdivisions = <RailPercentageEntry>[];
+
+    for (final row in rows) {
+      final entry = RailPercentageEntry.fromJson(row, nonPublic: nonPublic);
+      if (entry == null) continue; // no public users left for this area
+      if (entry.isSubdivision) {
+        subdivisions.add(entry);
+      } else {
+        countries.add(entry);
+      }
+    }
+
+    return RailPercentageResult(
+      countries: countries,
+      subdivisions: subdivisions,
+    );
   }
 
   /// Fetches and splits a `/getLeaderboardUsers/<type>` response into its

--- a/lib/services/api/ranking_api.dart
+++ b/lib/services/api/ranking_api.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/foundation.dart';
+import 'package:trainlog_app/data/models/ranking_model.dart';
+import 'package:trainlog_app/data/models/trips.dart';
+import 'package:trainlog_app/services/api/trainlog_http_client.dart';
+
+/// Leaderboard / ranking domain.
+///
+/// Calls the backend `/getLeaderboardUsers/<type>` endpoint, where `<type>` is
+/// one of a vehicle short string (`train`, `air`, …), `all`, `carbon`,
+/// `country`, `train_countries` or `world_squares`.
+///
+/// Every response carries a `non_public_users` list; those usernames are
+/// filtered out of the returned entries so the UI never exposes private users.
+class RankingApi {
+  final TrainlogHttpClient _client;
+
+  RankingApi(this._client);
+
+  // ----------------------------
+  // Public API
+  // ----------------------------
+
+  /// Ranking for a single [VehicleType]; `<type>` is its short string.
+  Future<RankingResult<LeaderboardEntry>> fetchRankingForVehicle(
+    VehicleType type,
+  ) {
+    return _fetchLeaderboard(type.toShortString());
+  }
+
+  /// Ranking across all vehicle types combined (`<type>` = `all`).
+  Future<RankingResult<LeaderboardEntry>> fetchRankingAll() {
+    return _fetchLeaderboard('all');
+  }
+
+  /// Carbon-footprint ranking (`<type>` = `carbon`).
+  Future<RankingResult<CarbonLeaderboardEntry>> fetchRankingForCarbonFootprint() {
+    return _fetchCarbonLeaderboard('carbon');
+  }
+
+  /// Ranking by country (`<type>` = `country`).
+  ///
+  /// Placeholder: the backend returns a different shape than the distance
+  /// leaderboards and needs its own result model. To be implemented.
+  Future<void> fetchRankingForCountry() {
+    throw UnimplementedError(
+      'fetchRankingForCountry (/getLeaderboardUsers/country) is not implemented yet',
+    );
+  }
+
+  /// Ranking by share of rail travel (`<type>` = `train_countries`).
+  ///
+  /// Placeholder: dedicated result model still to be defined.
+  Future<void> fetchRankingForRailPercentage() {
+    throw UnimplementedError(
+      'fetchRankingForRailPercentage (/getLeaderboardUsers/train_countries) is not implemented yet',
+    );
+  }
+
+  /// Ranking by world squares covered (`<type>` = `world_squares`).
+  ///
+  /// Placeholder: dedicated result model still to be defined.
+  Future<void> fetchRankingForWorldSquares() {
+    throw UnimplementedError(
+      'fetchRankingForWorldSquares (/getLeaderboardUsers/world_squares) is not implemented yet',
+    );
+  }
+
+  // ----------------------------
+  // Shared private fetchers
+  // ----------------------------
+
+  /// Distance leaderboards (vehicle types and `all`) share the same shape.
+  Future<RankingResult<LeaderboardEntry>> _fetchLeaderboard(String type) async {
+    final (rows, nonPublic) = await _fetchRaw(type);
+    final entries = rows
+        .where((r) => !nonPublic.contains(r['username']?.toString()))
+        .map(LeaderboardEntry.fromJson)
+        .toList();
+    return RankingResult(entries);
+  }
+
+  /// The carbon leaderboard has extra fields but the same overall logic.
+  Future<RankingResult<CarbonLeaderboardEntry>> _fetchCarbonLeaderboard(
+    String type,
+  ) async {
+    final (rows, nonPublic) = await _fetchRaw(type);
+    final entries = rows
+        .where((r) => !nonPublic.contains(r['username']?.toString()))
+        .map(CarbonLeaderboardEntry.fromJson)
+        .toList();
+    return RankingResult(entries);
+  }
+
+  /// Fetches and splits a `/getLeaderboardUsers/<type>` response into its
+  /// `leaderboard_data` rows and the set of `non_public_users`.
+  Future<(List<Map<String, dynamic>>, Set<String>)> _fetchRaw(
+    String type,
+  ) async {
+    final path = '/getLeaderboardUsers/$type';
+
+    try {
+      final res = await _client.safeGet<Map<String, dynamic>>(path);
+      final data = res.data;
+      if (data == null) return (const [], const {});
+
+      final rows = (data['leaderboard_data'] as List<dynamic>? ?? [])
+          .whereType<Map<String, dynamic>>()
+          .toList();
+      final nonPublic = (data['non_public_users'] as List<dynamic>? ?? [])
+          .map((e) => e.toString())
+          .toSet();
+
+      return (rows, nonPublic);
+    } catch (e) {
+      debugPrint('🛑 fetchLeaderboard($type) failed: $e');
+      return (const [], const {});
+    }
+  }
+}

--- a/lib/services/api/ranking_api.dart
+++ b/lib/services/api/ranking_api.dart
@@ -131,7 +131,7 @@ class RankingApi {
     try {
       final res = await _client.safeGet<Map<String, dynamic>>(path);
       final data = res.data;
-      if (data == null) return (const [], const {});
+      if (data == null) return (const <Map<String, dynamic>>[], const <String>{});
 
       final rows = (data['leaderboard_data'] as List<dynamic>? ?? [])
           .whereType<Map<String, dynamic>>()
@@ -143,7 +143,7 @@ class RankingApi {
       return (rows, nonPublic);
     } catch (e) {
       debugPrint('🛑 fetchLeaderboard($type) failed: $e');
-      return (const [], const {});
+      return (const <Map<String, dynamic>>[], const <String>{});
     }
   }
 }

--- a/lib/services/api/ranking_api.dart
+++ b/lib/services/api/ranking_api.dart
@@ -48,13 +48,10 @@ class RankingApi {
     return _fetchRailPercentageLeaderboard('train_countries');
   }
 
-  /// Ranking by world squares covered (`<type>` = `world_squares`).
-  ///
-  /// Placeholder: dedicated result model still to be defined.
-  Future<void> fetchRankingForWorldSquares() {
-    throw UnimplementedError(
-      'fetchRankingForWorldSquares (/getLeaderboardUsers/world_squares) is not implemented yet',
-    );
+  /// Ranking by share of the world's squares covered
+  /// (`<type>` = `world_squares`).
+  Future<WorldSquaresResult> fetchRankingForWorldSquares() {
+    return _fetchWorldSquaresLeaderboard('world_squares');
   }
 
   // ----------------------------
@@ -119,6 +116,13 @@ class RankingApi {
       countries: countries,
       subdivisions: subdivisions,
     );
+  }
+
+  /// The world-squares leaderboard: a single `world_squares` block of coverage
+  /// tiers, with public users only.
+  Future<WorldSquaresResult> _fetchWorldSquaresLeaderboard(String type) async {
+    final (rows, nonPublic) = await _fetchRaw(type);
+    return WorldSquaresResult.fromLeaderboard(rows, nonPublic);
   }
 
   /// Fetches and splits a `/getLeaderboardUsers/<type>` response into its

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: trainlog_app
 description: "Your online travel diary"
 publish_to: 'none'
-version: 0.2.1+16
+version: 0.2.2+17
 
 environment:
   sdk: ^3.8.0


### PR DESCRIPTION
## Summary
Introduces comprehensive leaderboard and ranking functionality to the app, including API integration, data models, and provider integration for displaying user rankings across multiple metrics.

## Key Changes

- **New Ranking Models** (`lib/data/models/ranking_model.dart`):
  - Base `RankingEntry` class and specialized subclasses for different leaderboard types
  - `LeaderboardEntry` for distance-based rankings (vehicle types and combined)
  - `CarbonLeaderboardEntry` for carbon footprint metrics
  - `CountryLeaderboardEntry` for countries visited rankings
  - `RailPercentageEntry` and `RailPercentageResult` for rail coverage by country/subdivision
  - `WorldSquaresResult` for world grid coverage rankings
  - Generic `RankingResult<T>` container with metric-specific sorting extensions
  - Utility functions for parsing leaderboard dates and type conversions

- **New Ranking API** (`lib/services/api/ranking_api.dart`):
  - `RankingApi` class handling `/getLeaderboardUsers/<type>` endpoint calls
  - Public methods for fetching rankings: vehicle-specific, combined, carbon, country, rail percentage, and world squares
  - Automatic filtering of non-public users from all responses
  - Robust error handling with fallback to empty results

- **Provider Integration** (`lib/providers/trainlog_provider.dart`):
  - Added `RankingApi` instance initialization
  - Exposed `rankingApi` getter for direct API access
  - Added convenience methods delegating to ranking API for all leaderboard types

- **Country Detail Model** (`lib/data/models/country_detail.dart`):
  - New `CountryDetail` class encapsulating country code, localized name, and flag emoji
  - Factory constructor for resolving details from ISO country codes

- **Refactoring**:
  - Updated `Trips.countryDetails()` to return `List<CountryDetail>` instead of tuples
  - Updated trip details metadata to use new `CountryDetail` model
  - Added `ranking_api.dart` to API exports

- **Version Bump**: 0.2.1+16 → 0.2.2+17

## Notable Implementation Details

- Leaderboard entries are filtered at the API layer to prevent private users from reaching the UI
- Sorting is intentionally flexible—the same data can be sorted by different metrics depending on context
- Rail percentage and world squares results use specialized structures to handle their unique data shapes
- Date parsing handles both RFC 1123 format (backend standard) and ISO 8601 with graceful fallback
- Type conversions (`_toDouble`, `_toInt`) are defensive, returning sensible defaults for malformed data

https://claude.ai/code/session_01DwgrixsY5LR9XQQdmoWNpS