### PR TITLE
Add unknown past/future trip filtering to year selector

### DIFF
--- a/lib/features/map/map_filter_widget.dart
+++ b/lib/features/map/map_filter_widget.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import 'package:trainlog_app/l10n/app_localizations.dart';
 import 'package:trainlog_app/platform/adaptive_vehicle_type_filter_chips.dart';
 import 'package:trainlog_app/providers/polyline_provider.dart';
+import 'package:trainlog_app/utils/date_utils.dart';
 import 'package:trainlog_app/widgets/app_steps_tab_bar.dart';
 
 /// Map filter bottom sheet.
@@ -240,15 +241,26 @@ class _MapFilterWidgetState extends State<MapFilterWidget> {
     PolylineProvider poly,
   ) {
     final years = poly.availableYears; // already sorted descending
-    final pageCount = math.max(1, (years.length / _yearsPerPage).ceil());
+
+    // The grid lays out a single ordered list of "slots": the unknown-future
+    // button first (rendered in the future/dashed style), then the real years
+    // (descending), then the unknown-past button last. The unknown buttons only
+    // appear when the user actually has such trips.
+    final items = <int>[
+      if (poly.hasUnknownFuture) unknownFuture.year,
+      ...years,
+      if (poly.hasUnknownPast) unknownPast.year,
+    ];
+
+    final pageCount = math.max(1, (items.length / _yearsPerPage).ceil());
     final page = _yearPage.clamp(0, pageCount - 1);
     final start = page * _yearsPerPage;
-    final end = math.min(start + _yearsPerPage, years.length);
-    final pageYears = years.sublist(start, end);
+    final end = math.min(start + _yearsPerPage, items.length);
+    final pageItems = items.sublist(start, end);
 
     // When paginated, every page reserves the full 4×3 footprint so the sheet
     // height stays constant when flipping to a shorter last page.
-    final grid = _yearGrid(context, poly, pageYears, fill: pageCount > 1);
+    final grid = _yearGrid(context, l10n, poly, pageItems, fill: pageCount > 1);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -292,14 +304,15 @@ class _MapFilterWidgetState extends State<MapFilterWidget> {
 
   Widget _yearGrid(
     BuildContext context,
+    AppLocalizations l10n,
     PolylineProvider poly,
-    List<int> years, {
+    List<int> items, {
     required bool fill,
   }) {
     final currentYear = DateTime.now().year;
     // When [fill] is set, always lay out a full 4×3 grid (12 slots); otherwise
-    // size to the available years only.
-    final slotCount = fill ? _yearsPerPage : years.length;
+    // size to the available items only.
+    final slotCount = fill ? _yearsPerPage : items.length;
     final rows = <Widget>[];
     for (int rowStart = 0; rowStart < slotCount; rowStart += 4) {
       if (rows.isNotEmpty) rows.add(const SizedBox(height: 8));
@@ -307,30 +320,29 @@ class _MapFilterWidgetState extends State<MapFilterWidget> {
       for (int col = 0; col < 4; col++) {
         if (col > 0) cells.add(const SizedBox(width: 8));
         final idx = rowStart + col;
-        if (idx >= years.length) {
+        if (idx >= items.length) {
           // Empty placeholder keeps the 4×3 footprint (and row height) stable.
           cells.add(const Expanded(child: SizedBox(height: _kYearChipHeight)));
           continue;
         }
-        final year = years[idx];
+        final year = items[idx];
+        final isUnknownFuture = year == unknownFuture.year;
+        final isUnknownPast = year == unknownPast.year;
+        final isUnknown = isUnknownFuture || isUnknownPast;
         cells.add(
           Expanded(
             child: _YearChip(
-              year: year,
+              label: isUnknownFuture
+                  ? l10n.mapFilterUnknownFuture
+                  : isUnknownPast
+                      ? l10n.mapFilterUnknownPast
+                      : year.toString(),
+              // Unknown labels are longer than a year number, so let them
+              // shrink/wrap to keep the shared year-chip footprint.
+              fitLabel: isUnknown,
               selected: poly.selectedYears.contains(year),
-              isFuture: year > currentYear,
-              onTap: () {
-                final allYears = poly.availableYears;
-                final newSub = allYears
-                    .map((y) =>
-                        y == year ? !poly.selectedYears.contains(y) : poly.selectedYears.contains(y))
-                    .toList();
-                context.read<PolylineProvider>().updateYearFilter(
-                      topIndex: _yearsOptionIndex,
-                      years: allYears,
-                      subSelection: newSub,
-                    );
-              },
+              isFuture: isUnknownFuture || (!isUnknown && year > currentYear),
+              onTap: () => context.read<PolylineProvider>().toggleYear(year),
             ),
           ),
         );
@@ -404,18 +416,22 @@ const double _kYearChipHeight = 44;
 // ─── Year chip ────────────────────────────────────────────────────────────────
 
 /// A single year cell. Past/current years get a solid border; future years a
-/// dashed border to distinguish planned excursions from completed trips.
+/// dashed border to distinguish planned excursions from completed trips. The
+/// same chip renders the "unknown past/future" buttons — with [fitLabel] set so
+/// their longer text shrinks/wraps into the shared footprint.
 class _YearChip extends StatelessWidget {
-  final int year;
+  final String label;
   final bool selected;
   final bool isFuture;
+  final bool fitLabel;
   final VoidCallback onTap;
 
   const _YearChip({
-    required this.year,
+    required this.label,
     required this.selected,
     required this.isFuture,
     required this.onTap,
+    this.fitLabel = false,
   });
 
   @override
@@ -427,19 +443,40 @@ class _YearChip extends StatelessWidget {
     final fg = selected ? cs.onPrimary : cs.onSurface;
     final borderColor = selected ? cs.primary : cs.outline;
 
+    Widget child = Text(
+      label,
+      textAlign: TextAlign.center,
+      maxLines: fitLabel ? 2 : 1,
+      style: TextStyle(
+        color: fg,
+        fontWeight: FontWeight.w600,
+        fontSize: fitLabel ? 12 : null,
+        height: fitLabel ? 1.05 : null,
+      ),
+    );
+    if (fitLabel) {
+      // Wrap to (at most) two lines within the cell, then scale down if the
+      // word itself is still too wide — guarantees the text always fits.
+      child = FittedBox(
+        fit: BoxFit.scaleDown,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 76),
+          child: child,
+        ),
+      );
+    }
+
     Widget content = Container(
       height: _kYearChipHeight,
       alignment: Alignment.center,
+      padding: const EdgeInsets.symmetric(horizontal: 4),
       decoration: BoxDecoration(
         color: bg,
         borderRadius: BorderRadius.circular(radius),
         // Future years draw their (dashed) border via the painter below.
         border: isFuture ? null : Border.all(color: borderColor, width: 1.2),
       ),
-      child: Text(
-        year.toString(),
-        style: TextStyle(color: fg, fontWeight: FontWeight.w600),
-      ),
+      child: child,
     );
 
     if (isFuture) {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -201,6 +201,14 @@
   "mapFilterReset": "Reset",
   "mapFilterTimeRange": "Time range",
   "mapFilterSelectYears": "Select years",
+  "mapFilterUnknownFuture": "Unknown future",
+  "@mapFilterUnknownFuture": {
+    "description": "Button in the year filter grid that toggles trips with an unknown future date"
+  },
+  "mapFilterUnknownPast": "Unknown past",
+  "@mapFilterUnknownPast": {
+    "description": "Button in the year filter grid that toggles trips with an unknown past date"
+  },
   "mapFilterShowTrips": "{count, plural, =0 {Show no trips} =1 {Show 1 trip} other {Show {count} trips}}",
   "@mapFilterShowTrips": {
     "description": "Primary action button in the map filter sheet showing how many trips match the current filters",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -167,6 +167,8 @@
   "mapFilterReset": "Réinitialiser",
   "mapFilterTimeRange": "Période",
   "mapFilterSelectYears": "Choisir les années",
+  "mapFilterUnknownFuture": "Futur inconnu",
+  "mapFilterUnknownPast": "Passé inconnu",
   "mapFilterShowTrips": "{count, plural, =0 {Aucun trajet} =1 {Afficher 1 trajet} other {Afficher {count} trajets}}",
   "@mapFilterShowTrips": {
     "description": "Primary action button in the map filter sheet showing how many trips match the current filters",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -166,6 +166,8 @@
   "mapFilterReset": "リセット",
   "mapFilterTimeRange": "期間",
   "mapFilterSelectYears": "年を選択",
+  "mapFilterUnknownFuture": "不明な未来",
+  "mapFilterUnknownPast": "不明な過去",
   "mapFilterShowTrips": "{count, plural, =0 {旅行なし} other {{count} 件の旅行を表示}}",
   "@mapFilterShowTrips": {
     "description": "Primary action button in the map filter sheet showing how many trips match the current filters",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1050,6 +1050,18 @@ abstract class AppLocalizations {
   /// **'Select years'**
   String get mapFilterSelectYears;
 
+  /// Button in the year filter grid that toggles trips with an unknown future date
+  ///
+  /// In en, this message translates to:
+  /// **'Unknown future'**
+  String get mapFilterUnknownFuture;
+
+  /// Button in the year filter grid that toggles trips with an unknown past date
+  ///
+  /// In en, this message translates to:
+  /// **'Unknown past'**
+  String get mapFilterUnknownPast;
+
   /// Primary action button in the map filter sheet showing how many trips match the current filters
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -525,6 +525,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get mapFilterSelectYears => 'Select years';
 
   @override
+  String get mapFilterUnknownFuture => 'Unknown future';
+
+  @override
+  String get mapFilterUnknownPast => 'Unknown past';
+
+  @override
   String mapFilterShowTrips(num count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -531,6 +531,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get mapFilterSelectYears => 'Choisir les années';
 
   @override
+  String get mapFilterUnknownFuture => 'Futur inconnu';
+
+  @override
+  String get mapFilterUnknownPast => 'Passé inconnu';
+
+  @override
   String mapFilterShowTrips(num count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -514,6 +514,12 @@ class AppLocalizationsJa extends AppLocalizations {
   String get mapFilterSelectYears => '年を選択';
 
   @override
+  String get mapFilterUnknownFuture => '不明な未来';
+
+  @override
+  String get mapFilterUnknownPast => '不明な過去';
+
+  @override
   String mapFilterShowTrips(num count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -521,6 +521,12 @@ class AppLocalizationsTl extends AppLocalizations {
   String get mapFilterSelectYears => 'Pumili ng mga taon';
 
   @override
+  String get mapFilterUnknownFuture => 'Hindi alam na hinaharap';
+
+  @override
+  String get mapFilterUnknownPast => 'Hindi alam na nakaraan';
+
+  @override
   String mapFilterShowTrips(num count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/app_tl.arb
+++ b/lib/l10n/app_tl.arb
@@ -185,6 +185,8 @@
   "mapFilterReset": "I-reset",
   "mapFilterTimeRange": "Saklaw ng panahon",
   "mapFilterSelectYears": "Pumili ng mga taon",
+  "mapFilterUnknownFuture": "Hindi alam na hinaharap",
+  "mapFilterUnknownPast": "Hindi alam na nakaraan",
   "mapFilterShowTrips": "{count, plural, =0 {Walang byahe} other {Ipakita ang {count} byahe}}",
   "@mapFilterShowTrips": {
     "description": "Primary action button in the map filter sheet showing how many trips match the current filters",

--- a/lib/providers/polyline_provider.dart
+++ b/lib/providers/polyline_provider.dart
@@ -11,6 +11,7 @@ import 'package:trainlog_app/data/polyline_cache.dart';
 import 'package:trainlog_app/data/polyline_loader.dart';
 import 'package:trainlog_app/providers/settings_provider.dart';
 import 'package:trainlog_app/providers/trips_provider.dart';
+import 'package:trainlog_app/utils/date_utils.dart';
 import 'package:trainlog_app/utils/map_color_palette.dart';
 import 'package:trainlog_app/utils/polyline_styling.dart';
 
@@ -65,6 +66,12 @@ class PolylineProvider extends ChangeNotifier {
   PolylineYearFilter _selectedYearFilter = PolylineYearFilter.all;
   int _selectedYearFilterOption = 0;
 
+  // Whether the loaded trips include any "unknown past" / "unknown future"
+  // entries (sentinel years 0 / 9999). Drives the dedicated toggle buttons in
+  // the year filter grid, which are only shown when such trips exist.
+  bool _hasUnknownPast = false;
+  bool _hasUnknownFuture = false;
+
   Set<VehicleType> _selectedTypes = {};
   Set<VehicleType> _userDeselectedTypes = {};
   Set<VehicleType> _lastAvailableTypes = {};
@@ -93,6 +100,12 @@ class PolylineProvider extends ChangeNotifier {
   Set<int> get selectedYears => Set.unmodifiable(_selectedYears);
   PolylineYearFilter get selectedYearFilter => _selectedYearFilter;
   int get selectedYearFilterOption => _selectedYearFilterOption;
+
+  /// Whether any loaded trip has an unknown (undated) past start.
+  bool get hasUnknownPast => _hasUnknownPast;
+
+  /// Whether any loaded trip has an unknown (undated) future start.
+  bool get hasUnknownFuture => _hasUnknownFuture;
 
   Set<VehicleType> get selectedTypes => Set.unmodifiable(_selectedTypes);
   Set<VehicleType> get userDeselectedTypes => Set.unmodifiable(_userDeselectedTypes);
@@ -198,8 +211,14 @@ class PolylineProvider extends ChangeNotifier {
       _selectedYearFilterOption = 0;
     } else if (_selectedYearFilter == PolylineYearFilter.years) {
       // Stay in explicit "years" mode, even if nothing is selected.
-      // Only remove years that no longer exist.
-      _selectedYears = _selectedYears.intersection(availableYears);
+      // Only remove years that no longer exist. The unknown-past/future
+      // sentinel years are valid selections too, so keep them around.
+      final allowedYears = {
+        ...availableYears,
+        unknownPast.year,
+        unknownFuture.year,
+      };
+      _selectedYears = _selectedYears.intersection(allowedYears);
     }
 
     // ---- Types
@@ -258,6 +277,10 @@ class PolylineProvider extends ChangeNotifier {
             .where((e) => e.value)
             .map((e) => years[e.key])
             .toSet();
+        // Entering explicit "years" mode starts with every available range
+        // selected, so include the unknown past/future ranges when present.
+        if (_hasUnknownPast) _selectedYears.add(unknownPast.year);
+        if (_hasUnknownFuture) _selectedYears.add(unknownFuture.year);
         break;
     }
 
@@ -270,7 +293,27 @@ class PolylineProvider extends ChangeNotifier {
   Future<void> selectAllYears(List<int> years) async {
     _selectedYearFilter = PolylineYearFilter.years;
     _selectedYearFilterOption = 3;
-    _selectedYears = years.toSet();
+    _selectedYears = {
+      ...years,
+      if (_hasUnknownPast) unknownPast.year,
+      if (_hasUnknownFuture) unknownFuture.year,
+    };
+
+    await _persistFilters();
+    _rebuildRenderedPolylines(notify: true);
+  }
+
+  /// Toggles a single year (or unknown-past/future sentinel year) in the
+  /// explicit "years" filter, leaving every other selection untouched. Used by
+  /// both the year chips and the unknown past/future buttons in the grid.
+  Future<void> toggleYear(int year) async {
+    _selectedYearFilter = PolylineYearFilter.years;
+    _selectedYearFilterOption = 3;
+    if (_selectedYears.contains(year)) {
+      _selectedYears.remove(year);
+    } else {
+      _selectedYears.add(year);
+    }
 
     await _persistFilters();
     _rebuildRenderedPolylines(notify: true);
@@ -597,6 +640,14 @@ class PolylineProvider extends ChangeNotifier {
     if (settings == null) return;
 
     final now = _nowUtc;
+
+    // Refresh whether unknown past/future trips exist so the filter UI can
+    // show/hide their dedicated buttons in step with the loaded data.
+    _hasUnknownPast =
+        _polylines.any((e) => e.startDate?.year == unknownPast.year);
+    _hasUnknownFuture =
+        _polylines.any((e) => e.startDate?.year == unknownFuture.year);
+
     final filtered = PolylineStyling.filterBySelection(
       _polylines,
       yearFilter: _selectedYearFilter,

--- a/lib/utils/polyline_styling.dart
+++ b/lib/utils/polyline_styling.dart
@@ -158,9 +158,11 @@ class PolylineStyling {
         }).toList();
 
       case PolylineYearFilter.years:
-        final allowedYears = {...selectedYears, unknownPast.year, unknownFuture.year};
+        // Unknown past/future trips (sentinel years 0 / 9999) are only included
+        // when their dedicated buttons are selected, i.e. present in
+        // [selectedYears] — they are no longer forced in.
         return polylines.where((e) {
-          return allowedYears.contains(e.startDate?.year) &&
+          return selectedYears.contains(e.startDate?.year) &&
               selectedTypes.contains(e.type);
         }).toList();
     }


### PR DESCRIPTION
## Summary
This change adds dedicated filter buttons for trips with unknown (undated) past and future dates in the map's year filter grid. Previously, these sentinel-year trips (years 0 and 9999) were always included when filtering by years. Now they can be toggled independently via dedicated UI buttons that only appear when such trips exist.

## Key Changes

- **Year filter grid UI**: Modified `_yearGrid()` to display "Unknown past" and "Unknown future" buttons alongside regular year chips. These buttons:
  - Only appear when trips with those sentinel years actually exist
  - Use the same chip styling as year buttons but with longer text that wraps/shrinks to fit
  - Are positioned at the start (unknown future) and end (unknown past) of the year list

- **PolylineProvider state management**:
  - Added `_hasUnknownPast` and `_hasUnknownFuture` flags to track whether such trips exist
  - Added `toggleYear()` method to toggle individual years (including sentinel years) in explicit "years" filter mode
  - Updated `selectAllYears()` to include unknown past/future when entering explicit years mode
  - Refresh unknown flags whenever polylines are loaded

- **Filter logic**: Modified `PolylineStyling.filterBySelection()` to only include unknown past/future trips when their sentinel years are explicitly selected, rather than always forcing them in

- **Localization**: Added new strings for "Unknown future" and "Unknown past" buttons in English, French, Japanese, and Tagalog

- **UI refinements**: Enhanced `_YearChip` to support variable-length labels with optional text wrapping and scaling via the new `fitLabel` parameter

## Implementation Details

The unknown past/future buttons are rendered as part of a unified "items" list that includes:
1. Unknown future button (if trips exist) — rendered with dashed border style
2. Regular years in descending order
3. Unknown past button (if trips exist) — rendered with solid border style

This maintains the existing pagination and grid layout while seamlessly integrating the new filter options.

https://claude.ai/code/session_01ExJ7RHjMA3ENuvrUcvGBhe