### PR TITLE
Keep non-public users in leaderboards, tag them instead of filtering

### DIFF
--- a/lib/data/models/ranking_model.dart
+++ b/lib/data/models/ranking_model.dart
@@ -5,12 +5,17 @@ import 'package:trainlog_app/data/models/country_detail.dart';
 
 /// Base class shared by every leaderboard entry.
 ///
-/// The only field common to all ranking variants is the [username]; each
-/// concrete subclass adds the metric-specific fields.
+/// The fields common to all ranking variants are the [username] and the
+/// [isNonPublic] flag; each concrete subclass adds the metric-specific fields.
 abstract class RankingEntry {
   final String username;
 
-  const RankingEntry({required this.username});
+  /// Whether the user opted out of being public. Non-public users are still
+  /// included in the leaderboards; this flag is reserved for a later feature
+  /// (e.g. anonymising their row in the UI).
+  final bool isNonPublic;
+
+  const RankingEntry({required this.username, this.isNonPublic = false});
 }
 
 /// Intermediate class for the trip-based leaderboards (vehicle, `all`,
@@ -22,6 +27,7 @@ abstract class TripRankingEntry extends RankingEntry {
 
   const TripRankingEntry({
     required super.username,
+    super.isNonPublic,
     required this.lastModified,
     required this.trips,
   });
@@ -39,14 +45,19 @@ class LeaderboardEntry extends TripRankingEntry {
 
   const LeaderboardEntry({
     required super.username,
+    super.isNonPublic,
     required super.lastModified,
     required super.trips,
     required this.length,
   });
 
-  factory LeaderboardEntry.fromJson(Map<String, dynamic> json) {
+  factory LeaderboardEntry.fromJson(
+    Map<String, dynamic> json, {
+    bool isNonPublic = false,
+  }) {
     return LeaderboardEntry(
       username: json['username']?.toString() ?? '',
+      isNonPublic: isNonPublic,
       lastModified: parseLeaderboardDate(json['last_modified']),
       trips: _toInt(json['trips']),
       length: _toDouble(json['length']),
@@ -73,6 +84,7 @@ class CarbonLeaderboardEntry extends TripRankingEntry {
 
   const CarbonLeaderboardEntry({
     required super.username,
+    super.isNonPublic,
     required super.lastModified,
     required super.trips,
     required this.carbonPerKm,
@@ -80,9 +92,13 @@ class CarbonLeaderboardEntry extends TripRankingEntry {
     required this.totalDistance,
   });
 
-  factory CarbonLeaderboardEntry.fromJson(Map<String, dynamic> json) {
+  factory CarbonLeaderboardEntry.fromJson(
+    Map<String, dynamic> json, {
+    bool isNonPublic = false,
+  }) {
     return CarbonLeaderboardEntry(
       username: json['username']?.toString() ?? '',
+      isNonPublic: isNonPublic,
       lastModified: parseLeaderboardDate(json['last_modified']),
       trips: _toInt(json['trips']),
       carbonPerKm: _toDouble(json['carbon_per_km']),
@@ -107,16 +123,21 @@ class CountryLeaderboardEntry extends RankingEntry {
 
   const CountryLeaderboardEntry({
     required super.username,
+    super.isNonPublic,
     required this.countryCount,
     required this.countriesVisited,
   });
 
-  factory CountryLeaderboardEntry.fromJson(Map<String, dynamic> json) {
+  factory CountryLeaderboardEntry.fromJson(
+    Map<String, dynamic> json, {
+    bool isNonPublic = false,
+  }) {
     final visited = (json['countries_visited'] as List<dynamic>? ?? [])
         .map((e) => e.toString())
         .toList();
     return CountryLeaderboardEntry(
       username: json['username']?.toString() ?? '',
+      isNonPublic: isNonPublic,
       countryCount: _toInt(json['country_count']),
       countriesVisited: visited,
     );
@@ -141,8 +162,9 @@ class CountryLeaderboardEntry extends RankingEntry {
   }
 }
 
-/// The result of a leaderboard request: the public entries only (users listed
-/// in `non_public_users` are already filtered out by `RankingApi`).
+/// The result of a leaderboard request: every entry, including users listed in
+/// `non_public_users` (tagged via [RankingEntry.isNonPublic] by `RankingApi`
+/// rather than dropped).
 ///
 /// Sorting is intentionally not baked in — the same data is shown sorted by
 /// length, trips, carbon, … depending on the screen. Use [sortedBy] with a
@@ -206,26 +228,37 @@ extension CountryResultSorting on RankingResult<CountryLeaderboardEntry> {
       sortedBy((e) => e.countryCount, descending: descending);
 }
 
+/// A username appearing in a leaderboard, tagged with whether the user opted
+/// out of being public. Non-public users are still listed; [isNonPublic] is
+/// reserved for a later feature (e.g. anonymising their row in the UI).
+class RankedUser {
+  final String username;
+  final bool isNonPublic;
+
+  const RankedUser({required this.username, this.isNonPublic = false});
+}
+
 /// A single coverage tier within a country/subdivision: the [percent] of the
-/// rail network covered and the [usernames] of the users who reached it.
+/// rail network covered and the [users] who reached it.
 class RailCoverage {
   final double percent;
-  final List<String> usernames;
+  final List<RankedUser> users;
 
-  const RailCoverage({required this.percent, required this.usernames});
+  const RailCoverage({required this.percent, required this.users});
 
-  /// Parses one `{ "percent": .., "usernames": [..] }` tier, dropping users in
-  /// [nonPublic]. Returns `null` when no public users remain.
+  /// Parses one `{ "percent": .., "usernames": [..] }` tier, tagging users in
+  /// [nonPublic] via [RankedUser.isNonPublic] (they are kept, not dropped).
+  /// Returns `null` only when the tier lists no users at all.
   static RailCoverage? fromJson(
     Map<String, dynamic> json, {
     Set<String> nonPublic = const {},
   }) {
     final users = (json['usernames'] as List<dynamic>? ?? [])
         .map((e) => e.toString())
-        .where((u) => !nonPublic.contains(u))
+        .map((u) => RankedUser(username: u, isNonPublic: nonPublic.contains(u)))
         .toList();
     if (users.isEmpty) return null;
-    return RailCoverage(percent: _toDouble(json['percent']), usernames: users);
+    return RailCoverage(percent: _toDouble(json['percent']), users: users);
   }
 }
 
@@ -267,9 +300,8 @@ class RailPercentageEntry {
   CountryDetail country(BuildContext context) =>
       CountryDetail.fromCode(countryCode, context);
 
-  /// Parses one `leaderboard_data` row, dropping users in [nonPublic] (and any
-  /// tier or whole entry left empty as a result). Returns `null` when no public
-  /// users remain.
+  /// Parses one `leaderboard_data` row, tagging users in [nonPublic] (they are
+  /// kept, not dropped). Returns `null` only when the row lists no users at all.
   static RailPercentageEntry? fromJson(
     Map<String, dynamic> json, {
     Set<String> nonPublic = const {},
@@ -290,7 +322,8 @@ class RailPercentageEntry {
 }
 
 /// The result of the rail-percentage leaderboard, with country-level and
-/// subdivision-level entries kept apart (public users only).
+/// subdivision-level entries kept apart. Non-public users are included, tagged
+/// via [RankedUser.isNonPublic].
 class RailPercentageResult {
   /// Country-level entries (`cc` without a hyphen).
   final List<RailPercentageEntry> countries;
@@ -360,7 +393,7 @@ List<RailPercentageEntry> _sortByName(
 /// The result of the world-squares leaderboard
 /// (`/getLeaderboardUsers/world_squares`): coverage tiers (each listing the
 /// users who reached it), ordered by world-coverage percentage (highest
-/// first). Public users only.
+/// first). Non-public users are included, tagged via [RankedUser.isNonPublic].
 ///
 /// The backend sends a single `{ "cc": "world_squares", "data": [...] }` block:
 /// ```json
@@ -374,9 +407,9 @@ class WorldSquaresResult {
   bool get isEmpty => coverages.isEmpty;
   bool get isNotEmpty => coverages.isNotEmpty;
 
-  /// Builds the result from the raw `leaderboard_data` rows, dropping users in
-  /// [nonPublic]. The tiers come back ordered by coverage percentage; this
-  /// re-sorts defensively to guarantee highest-first.
+  /// Builds the result from the raw `leaderboard_data` rows, tagging users in
+  /// [nonPublic] via [RankedUser.isNonPublic]. The tiers come back ordered by
+  /// coverage percentage; this re-sorts defensively to guarantee highest-first.
   factory WorldSquaresResult.fromLeaderboard(
     List<Map<String, dynamic>> rows,
     Set<String> nonPublic,

--- a/lib/features/ranking/ranking_type.dart
+++ b/lib/features/ranking/ranking_type.dart
@@ -220,6 +220,10 @@ class RankingDisplayEntry {
   final int rank;
   final String username;
 
+  /// Whether the user opted out of being public. Such users are still shown in
+  /// the leaderboard; this flag is reserved for a later feature.
+  final bool isNonPublic;
+
   /// Total distance in kilometres (0 when not applicable).
   final double distanceKm;
 
@@ -241,6 +245,7 @@ class RankingDisplayEntry {
   const RankingDisplayEntry({
     required this.rank,
     required this.username,
+    this.isNonPublic = false,
     this.distanceKm = 0,
     this.trips = 0,
     this.percent,
@@ -252,6 +257,7 @@ class RankingDisplayEntry {
   RankingDisplayEntry copyWithRank(int newRank) => RankingDisplayEntry(
         rank: newRank,
         username: username,
+        isNonPublic: isNonPublic,
         distanceKm: distanceKm,
         trips: trips,
         percent: percent,

--- a/lib/features/ranking/widgets/ranking_list_view.dart
+++ b/lib/features/ranking/widgets/ranking_list_view.dart
@@ -93,15 +93,37 @@ class RankingListView extends StatelessWidget {
       separatorBuilder: (_, __) => const SizedBox(height: 4),
       itemBuilder: (context, i) {
         final e = rows[i];
+        // A tie shows its rank only on the first of the equal-valued rows that
+        // are displayed next to each other; the rest leave the rank blank. This
+        // works for every order (value/reversed/alphabetical) and unit because
+        // it compares the value actually shown to adjacent displayed rows.
+        final showRank = i == 0 ||
+            _primaryKey(context, provider, rows[i - 1]) !=
+                _primaryKey(context, provider, e);
         return RankingRow(
           entry: e,
           selection: provider.selection,
           sortUnit: provider.sortUnit,
           isCurrentUser: me != null && e.username.toLowerCase() == me,
+          showRank: showRank,
         );
       },
     );
   }
+
+  /// The displayed primary value (value + unit) for [entry], used to detect
+  /// consecutive rows that share the same value.
+  String _primaryKey(
+    BuildContext context,
+    RankingProvider provider,
+    RankingDisplayEntry entry,
+  ) =>
+      RankingMetrics.primaryInline(
+        context,
+        entry,
+        provider.selection,
+        provider.sortUnit,
+      );
 }
 
 /// A single leaderboard row.
@@ -111,12 +133,17 @@ class RankingRow extends StatelessWidget {
   final RankingSortUnit sortUnit;
   final bool isCurrentUser;
 
+  /// Whether to show the rank indicator. Tied rows displayed next to each other
+  /// only show the rank on the first one (see [RankingListView]).
+  final bool showRank;
+
   const RankingRow({
     super.key,
     required this.entry,
     required this.selection,
     required this.sortUnit,
     required this.isCurrentUser,
+    this.showRank = true,
   });
 
   @override
@@ -136,7 +163,7 @@ class RankingRow extends StatelessWidget {
       ),
       child: Row(
         children: [
-          _RankIndicator(rank: entry.rank),
+          _RankIndicator(rank: entry.rank, showRank: showRank),
           const SizedBox(width: 10),
           _Monogram(username: entry.username, highlight: isCurrentUser),
           const SizedBox(width: 12),
@@ -217,12 +244,19 @@ class RankingRow extends StatelessWidget {
 /// Medal for the top three, plain number otherwise.
 class _RankIndicator extends StatelessWidget {
   final int rank;
+  final bool showRank;
 
-  const _RankIndicator({required this.rank});
+  const _RankIndicator({required this.rank, this.showRank = true});
 
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
+
+    // Tied row that follows another with the same value: leave the rank slot
+    // blank but preserve its width so the rows stay aligned.
+    if (!showRank) {
+      return const SizedBox(width: 34);
+    }
 
     if (RankingMedal.isMedal(rank)) {
       return Container(

--- a/lib/features/ranking/widgets/ranking_list_view.dart
+++ b/lib/features/ranking/widgets/ranking_list_view.dart
@@ -96,10 +96,11 @@ class RankingListView extends StatelessWidget {
         // A tie shows its rank only on the first of the equal-valued rows that
         // are displayed next to each other; the rest leave the rank blank. This
         // works for every order (value/reversed/alphabetical) and unit because
-        // it compares the value actually shown to adjacent displayed rows.
+        // it compares the raw ranking value of adjacent displayed rows — rows
+        // are tied only when that value is exactly equal, not merely rounded
+        // to the same displayed number.
         final showRank = i == 0 ||
-            _primaryKey(context, provider, rows[i - 1]) !=
-                _primaryKey(context, provider, e);
+            provider.metricOf(rows[i - 1]) != provider.metricOf(e);
         return RankingRow(
           entry: e,
           selection: provider.selection,
@@ -110,20 +111,6 @@ class RankingListView extends StatelessWidget {
       },
     );
   }
-
-  /// The displayed primary value (value + unit) for [entry], used to detect
-  /// consecutive rows that share the same value.
-  String _primaryKey(
-    BuildContext context,
-    RankingProvider provider,
-    RankingDisplayEntry entry,
-  ) =>
-      RankingMetrics.primaryInline(
-        context,
-        entry,
-        provider.selection,
-        provider.sortUnit,
-      );
 }
 
 /// A single leaderboard row.

--- a/lib/providers/ranking_provider.dart
+++ b/lib/providers/ranking_provider.dart
@@ -247,9 +247,13 @@ class RankingProvider extends ChangeNotifier {
     return rows;
   }
 
+  /// The raw value used for ranking under the active selection/unit. Two rows
+  /// are tied only when this is exactly equal (regardless of how it is rounded
+  /// for display).
+  double metricOf(RankingDisplayEntry e) => _metric(e);
+
   /// The value used both for ranking and for the natural (value) display order.
-  double _metric(RankingDisplayEntry e) {
-    if (_selection.isWorldSquares) return e.percent ?? 0;
+  double _metric(RankingDisplayEntry e) {    if (_selection.isWorldSquares) return e.percent ?? 0;
     switch (_sortUnit) {
       case RankingSortUnit.distance:
         return e.distanceKm;

--- a/lib/providers/ranking_provider.dart
+++ b/lib/providers/ranking_provider.dart
@@ -277,11 +277,22 @@ class RankingProvider extends ChangeNotifier {
     return a.username.toLowerCase().compareTo(b.username.toLowerCase());
   }
 
-  /// (Re)assigns competitive ranks by the active metric, best first.
+  /// (Re)assigns competitive ranks by the active metric, best first, using
+  /// standard competition ranking ("1224"): rows with the exact same metric
+  /// value share one rank, and the next distinct value resumes at its absolute
+  /// position. This keeps the rank stable across the alphabetical and direction
+  /// toggles — tied users always carry the same number wherever they appear.
   void _assignRanks() {
     final sorted = List<RankingDisplayEntry>.of(_ranked)..sort(_compareBest);
+    var rank = 0;
+    double? previous;
     for (var i = 0; i < sorted.length; i++) {
-      sorted[i] = sorted[i].copyWithRank(i + 1);
+      final value = _metric(sorted[i]);
+      if (i == 0 || value != previous) {
+        rank = i + 1;
+        previous = value;
+      }
+      sorted[i] = sorted[i].copyWithRank(rank);
     }
     _ranked = sorted;
   }

--- a/lib/providers/ranking_provider.dart
+++ b/lib/providers/ranking_provider.dart
@@ -69,7 +69,7 @@ class RankingProvider extends ChangeNotifier {
   /// All rows with their competitive rank assigned.
   List<RankingDisplayEntry> get entries => _ranked;
 
-  /// The current user's row, if they appear in the public leaderboard.
+  /// The current user's row, if they appear in the leaderboard.
   RankingDisplayEntry? get currentUserEntry {
     final me = _trainlog.username;
     if (me == null) return null;
@@ -202,6 +202,7 @@ class RankingProvider extends ChangeNotifier {
           (e) => RankingDisplayEntry(
             rank: 0,
             username: e.username,
+            isNonPublic: e.isNonPublic,
             distanceKm: e.totalDistance / 1000.0,
             trips: e.trips,
             totalCarbonKg: e.totalCarbon,
@@ -221,6 +222,7 @@ class RankingProvider extends ChangeNotifier {
           (e) => RankingDisplayEntry(
             rank: 0,
             username: e.username,
+            isNonPublic: e.isNonPublic,
             distanceKm: e.length / 1000.0,
             trips: e.trips,
             lastModified: e.lastModified,
@@ -234,11 +236,12 @@ class RankingProvider extends ChangeNotifier {
     // to one row per user.
     final rows = <RankingDisplayEntry>[];
     for (final tier in res.coverages) {
-      for (final user in tier.usernames) {
+      for (final user in tier.users) {
         rows.add(
           RankingDisplayEntry(
             rank: 0,
-            username: user,
+            username: user.username,
+            isNonPublic: user.isNonPublic,
             percent: tier.percent,
           ),
         );

--- a/lib/services/api/ranking_api.dart
+++ b/lib/services/api/ranking_api.dart
@@ -9,8 +9,9 @@ import 'package:trainlog_app/services/api/trainlog_http_client.dart';
 /// one of a vehicle short string (`train`, `air`, …), `all`, `carbon`,
 /// `country`, `train_countries` or `world_squares`.
 ///
-/// Every response carries a `non_public_users` list; those usernames are
-/// filtered out of the returned entries so the UI never exposes private users.
+/// Every response carries a `non_public_users` list; those usernames are kept
+/// in the returned entries but tagged as non-public (via `isNonPublic` /
+/// `RankedUser.isNonPublic`) for a later feature, rather than filtered out.
 class RankingApi {
   final TrainlogHttpClient _client;
 
@@ -62,8 +63,10 @@ class RankingApi {
   Future<RankingResult<LeaderboardEntry>> _fetchLeaderboard(String type) async {
     final (rows, nonPublic) = await _fetchRaw(type);
     final entries = rows
-        .where((r) => !nonPublic.contains(r['username']?.toString()))
-        .map(LeaderboardEntry.fromJson)
+        .map((r) => LeaderboardEntry.fromJson(
+              r,
+              isNonPublic: nonPublic.contains(r['username']?.toString()),
+            ))
         .toList();
     return RankingResult(entries);
   }
@@ -74,8 +77,10 @@ class RankingApi {
   ) async {
     final (rows, nonPublic) = await _fetchRaw(type);
     final entries = rows
-        .where((r) => !nonPublic.contains(r['username']?.toString()))
-        .map(CarbonLeaderboardEntry.fromJson)
+        .map((r) => CarbonLeaderboardEntry.fromJson(
+              r,
+              isNonPublic: nonPublic.contains(r['username']?.toString()),
+            ))
         .toList();
     return RankingResult(entries);
   }
@@ -86,15 +91,17 @@ class RankingApi {
   ) async {
     final (rows, nonPublic) = await _fetchRaw(type);
     final entries = rows
-        .where((r) => !nonPublic.contains(r['username']?.toString()))
-        .map(CountryLeaderboardEntry.fromJson)
+        .map((r) => CountryLeaderboardEntry.fromJson(
+              r,
+              isNonPublic: nonPublic.contains(r['username']?.toString()),
+            ))
         .toList();
     return RankingResult(entries);
   }
 
   /// The rail-percentage leaderboard: rows keyed by country / subdivision
-  /// rather than by user. Public users are filtered out per coverage tier and
-  /// country- and subdivision-level rows are kept apart.
+  /// rather than by user. Non-public users are tagged per coverage tier (not
+  /// filtered out) and country- and subdivision-level rows are kept apart.
   Future<RailPercentageResult> _fetchRailPercentageLeaderboard(
     String type,
   ) async {
@@ -104,7 +111,7 @@ class RankingApi {
 
     for (final row in rows) {
       final entry = RailPercentageEntry.fromJson(row, nonPublic: nonPublic);
-      if (entry == null) continue; // no public users left for this area
+      if (entry == null) continue; // no users listed for this area
       if (entry.isSubdivision) {
         subdivisions.add(entry);
       } else {
@@ -119,7 +126,7 @@ class RankingApi {
   }
 
   /// The world-squares leaderboard: a single `world_squares` block of coverage
-  /// tiers, with public users only.
+  /// tiers; non-public users are tagged, not filtered out.
   Future<WorldSquaresResult> _fetchWorldSquaresLeaderboard(String type) async {
     final (rows, nonPublic) = await _fetchRaw(type);
     return WorldSquaresResult.fromLeaderboard(rows, nonPublic);


### PR DESCRIPTION
## Summary
This change modifies the leaderboard system to include non-public users in all ranking displays while tagging them with an `isNonPublic` flag for future UI features (e.g., anonymization). Previously, non-public users were filtered out entirely from the API responses.

## Key Changes

- **RankingEntry hierarchy**: Added `isNonPublic` field to the base `RankingEntry` class and all subclasses (`LeaderboardEntry`, `CarbonLeaderboardEntry`, `CountryLeaderboardEntry`). Updated factory methods to accept and pass through the flag.

- **RankedUser model**: Introduced new `RankedUser` class to represent users in rail-coverage and world-squares leaderboards, carrying both username and `isNonPublic` status.

- **RailCoverage and RailPercentageEntry**: Changed from filtering out non-public users to tagging them via `RankedUser.isNonPublic`. Updated field names (`usernames` → `users`) and parsing logic.

- **RankingApi**: Removed `.where()` filters that excluded non-public users; instead, pass the `isNonPublic` flag to factory methods based on membership in the `non_public_users` set.

- **Ranking display logic**: 
  - Added `isNonPublic` field to `RankingDisplayEntry`
  - Implemented proper competition ranking ("1224" style) where tied users share the same rank
  - Added `metricOf()` public method to expose the raw ranking metric for tie detection
  - Updated `RankingListView` to show rank indicators only on the first row of tied entries, keeping others blank for visual clarity

- **Documentation**: Updated comments throughout to reflect that non-public users are now included and tagged rather than filtered out.

## Notable Implementation Details

- Competition ranking now correctly handles ties by comparing exact metric values rather than rounded display values, ensuring stable ranks across different sort orders
- Tied rows displayed consecutively only show the rank on the first entry, with subsequent tied entries leaving the rank slot blank but preserving width for alignment
- The `isNonPublic` flag is preserved through the entire data pipeline from API response to UI display

https://claude.ai/code/session_01GSxt1fULzBxvCjWJyVH7pR