### PR TITLE
Display participant count in ranking position badge

### DIFF
--- a/lib/features/ranking/widgets/ranking_user_position_block.dart
+++ b/lib/features/ranking/widgets/ranking_user_position_block.dart
@@ -185,9 +185,9 @@ class _RankBadge extends StatelessWidget {
                   fontWeight: FontWeight.w800,
                 ),
                 children: [
-                  if (provider.maxRank > 0)
+                  if (provider.participantCount > 0)
                     TextSpan(
-                      text: '/${provider.maxRank}',
+                      text: '/${provider.participantCount}',
                       style: AppTheme.monoFont.copyWith(
                         color: cs.onInverseSurface.withValues(alpha: 0.6),
                         fontSize: 16,

--- a/lib/features/ranking/widgets/ranking_user_position_block.dart
+++ b/lib/features/ranking/widgets/ranking_user_position_block.dart
@@ -176,12 +176,25 @@ class _RankBadge extends StatelessWidget {
               RankingMedal(rank: entry.rank, size: 22),
               const SizedBox(width: 4),
             ],
-            Text(
-              loc.rankingPositionValue(entry.rank),
-              style: AppTheme.monoFont.copyWith(
-                color: cs.onInverseSurface,
-                fontSize: 28,
-                fontWeight: FontWeight.w800,
+            Text.rich(
+              TextSpan(
+                text: loc.rankingPositionValue(entry.rank),
+                style: AppTheme.monoFont.copyWith(
+                  color: cs.onInverseSurface,
+                  fontSize: 28,
+                  fontWeight: FontWeight.w800,
+                ),
+                children: [
+                  if (provider.maxRank > 0)
+                    TextSpan(
+                      text: '/${provider.maxRank}',
+                      style: AppTheme.monoFont.copyWith(
+                        color: cs.onInverseSurface.withValues(alpha: 0.6),
+                        fontSize: 16,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                ],
               ),
             ),
           ],

--- a/lib/providers/ranking_provider.dart
+++ b/lib/providers/ranking_provider.dart
@@ -69,6 +69,9 @@ class RankingProvider extends ChangeNotifier {
   /// All rows with their competitive rank assigned.
   List<RankingDisplayEntry> get entries => _ranked;
 
+  /// The number of users on the current leaderboard.
+  int get participantCount => _ranked.length;
+
   /// The highest rank number on the current leaderboard. With competition
   /// ("1224") ranking, tied rows share a rank, so this can be lower than the
   /// number of ranked users.

--- a/lib/providers/ranking_provider.dart
+++ b/lib/providers/ranking_provider.dart
@@ -69,6 +69,17 @@ class RankingProvider extends ChangeNotifier {
   /// All rows with their competitive rank assigned.
   List<RankingDisplayEntry> get entries => _ranked;
 
+  /// The highest rank number on the current leaderboard. With competition
+  /// ("1224") ranking, tied rows share a rank, so this can be lower than the
+  /// number of ranked users.
+  int get maxRank {
+    var max = 0;
+    for (final e in _ranked) {
+      if (e.rank > max) max = e.rank;
+    }
+    return max;
+  }
+
   /// The current user's row, if they appear in the leaderboard.
   RankingDisplayEntry? get currentUserEntry {
     final me = _trainlog.username;


### PR DESCRIPTION
## Summary
Enhanced the ranking position display to show the user's rank relative to the total number of participants on the leaderboard.

## Key Changes
- **RankingProvider**: Added two new getter properties:
  - `participantCount`: Returns the total number of users on the current leaderboard
  - `maxRank`: Returns the highest rank number (accounts for tied ranks in competition-style ranking)

- **RankingUserPositionBlock**: Updated the rank display widget to show participant count:
  - Converted the rank `Text` widget to `Text.rich` to support multiple text spans
  - Added a secondary text span displaying `/{participantCount}` with reduced opacity (60% alpha)
  - Styled the participant count with smaller font size (16px vs 28px) and lighter weight (w600 vs w800)
  - Only displays the participant count when `participantCount > 0`

## Implementation Details
The participant count is displayed inline with the user's rank (e.g., "42/1224"), providing immediate context about the leaderboard size without requiring additional UI elements.

https://claude.ai/code/session_018qrFSND1BuwuG97Kqff2yv