### PR TITLE
Add tap-to-reveal tooltips for raw ranking metric values

### DIFF
--- a/lib/features/ranking/ranking_metrics.dart
+++ b/lib/features/ranking/ranking_metrics.dart
@@ -67,6 +67,46 @@ abstract final class RankingMetrics {
   static String inline(CompactNumber n) =>
       n.unit.isEmpty ? n.value : '${n.value} ${n.unit}';
 
+  /// The raw, full-precision value of [unit] for [entry], expressed in the base
+  /// unit (km, kg, g/km…), for a "tap to reveal" tooltip.
+  ///
+  /// Returns null for metrics that are already shown exactly — a plain trip
+  /// count is neither rounded nor SI-prefixed, so it needs no tooltip.
+  static String? rawTooltip(
+    BuildContext context,
+    RankingDisplayEntry entry,
+    RankingSortUnit unit,
+  ) {
+    final loc = AppLocalizations.of(context)!;
+    final locale = Localizations.localeOf(context);
+    switch (unit) {
+      case RankingSortUnit.distance:
+        return '${NumberFormatter.precise(entry.distanceKm, locale: locale)} '
+            '${MeasurementUnit.distance.baseUnit(loc)}';
+      case RankingSortUnit.totalCarbon:
+        return '${NumberFormatter.precise(entry.totalCarbonKg, locale: locale)} '
+            '${MeasurementUnit.co2.baseUnit(loc)}';
+      case RankingSortUnit.carbonPerKm:
+        return '${NumberFormatter.precise(entry.carbonPerKmG, locale: locale)} '
+            'g/km';
+      case RankingSortUnit.trips:
+        return null;
+    }
+  }
+
+  /// The raw-value tooltip for the primary metric, or null when the displayed
+  /// value is already exact. World-squares shows a percentage with no SI prefix,
+  /// so it needs no tooltip.
+  static String? primaryTooltip(
+    BuildContext context,
+    RankingDisplayEntry entry,
+    RankingSelection selection,
+    RankingSortUnit unit,
+  ) {
+    if (selection.isWorldSquares) return null;
+    return rawTooltip(context, entry, unit);
+  }
+
   /// The primary metric (the active [unit], or the percentage for
   /// world-squares) as a value + unit pair.
   static CompactNumber primary(
@@ -102,9 +142,9 @@ abstract final class RankingMetrics {
     return inline(format(context, entry, unit));
   }
 
-  /// The non-primary metrics, formatted inline, in display order. Empty for
-  /// world-squares.
-  static List<String> secondaries(
+  /// The non-primary metrics, each as its inline string plus the optional
+  /// raw-value tooltip, in display order. Empty for world-squares.
+  static List<RankingMetricText> secondaryMetrics(
     BuildContext context,
     RankingDisplayEntry entry,
     RankingSelection selection,
@@ -113,7 +153,28 @@ abstract final class RankingMetrics {
     if (selection.isWorldSquares) return const [];
     return [
       for (final u in unitsFor(selection.type))
-        if (u != unit) inline(format(context, entry, u)),
+        if (u != unit)
+          (
+            inline: inline(format(context, entry, u)),
+            tooltip: rawTooltip(context, entry, u),
+          ),
     ];
   }
+
+  /// The non-primary metrics, formatted inline, in display order. Empty for
+  /// world-squares.
+  static List<String> secondaries(
+    BuildContext context,
+    RankingDisplayEntry entry,
+    RankingSelection selection,
+    RankingSortUnit unit,
+  ) =>
+      [
+        for (final m in secondaryMetrics(context, entry, selection, unit))
+          m.inline,
+      ];
 }
+
+/// A formatted metric: the [inline] display string and, when the displayed value
+/// is rounded or SI-prefixed, the raw base-unit [tooltip] to reveal on tap.
+typedef RankingMetricText = ({String inline, String? tooltip});

--- a/lib/features/ranking/widgets/ranking_list_view.dart
+++ b/lib/features/ranking/widgets/ranking_list_view.dart
@@ -6,6 +6,7 @@ import 'package:trainlog_app/app/theme/app_theme.dart';
 import 'package:trainlog_app/features/ranking/ranking_metrics.dart';
 import 'package:trainlog_app/features/ranking/ranking_type.dart';
 import 'package:trainlog_app/features/ranking/widgets/ranking_medal.dart';
+import 'package:trainlog_app/features/ranking/widgets/raw_value_tooltip.dart';
 import 'package:trainlog_app/l10n/app_localizations.dart';
 import 'package:trainlog_app/providers/ranking_provider.dart';
 import 'package:trainlog_app/utils/number_formatter.dart';
@@ -166,36 +167,29 @@ class RankingRow extends StatelessWidget {
                       ),
                   overflow: TextOverflow.ellipsis,
                 ),
-                if (_secondaryMetric(context) != null)
-                  Text(
-                    _secondaryMetric(context)!,
-                    style: AppTheme.monoFont.copyWith(
-                      fontSize: 12,
-                      color: cs.onSurfaceVariant,
-                    ),
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                if (_lastConnection(context) != null)
-                  Text(
-                    _lastConnection(context)!,
-                    style: AppTheme.monoFont.copyWith(
-                      fontSize: 11,
-                      color: cs.onSurfaceVariant.withValues(alpha: 0.7),
-                    ),
-                    overflow: TextOverflow.ellipsis,
-                  ),
+                ..._supportingLines(context, cs),
               ],
             ),
           ),
           const SizedBox(width: 8),
           // CO2e/km is rendered as a coloured threshold pill; everything else
-          // as the large value + stacked unit.
+          // as the large value + stacked unit. Both reveal the raw base-unit
+          // value on tap (see [RawValueTooltip]).
           if (_isCarbon && sortUnit == RankingSortUnit.carbonPerKm)
-            _CarbonPill(gPerKm: entry.carbonPerKmG)
+            _CarbonPill(
+              gPerKm: entry.carbonPerKmG,
+              tooltip: RankingMetrics.rawTooltip(
+                  context, entry, RankingSortUnit.carbonPerKm),
+            )
           else
             Builder(builder: (context) {
               final primary = _primary(context);
-              return _PrimaryValue(value: primary.value, unit: primary.unit);
+              return _PrimaryValue(
+                value: primary.value,
+                unit: primary.unit,
+                tooltip: RankingMetrics.primaryTooltip(
+                    context, entry, selection, sortUnit),
+              );
             }),
         ],
       ),
@@ -208,23 +202,53 @@ class RankingRow extends StatelessWidget {
   CompactNumber _primary(BuildContext context) =>
       RankingMetrics.primary(context, entry, selection, sortUnit);
 
-  /// Secondary supporting metric (first non-primary value).
-  String? _secondaryMetric(BuildContext context) {
+  /// The supporting lines beneath the username: the first non-primary metric,
+  /// then either the second metric (carbon has two secondaries) or the last
+  /// activity date. Metric lines reveal their raw base-unit value on tap; the
+  /// date does not.
+  List<Widget> _supportingLines(BuildContext context, ColorScheme cs) {
     final secondaries =
-        RankingMetrics.secondaries(context, entry, selection, sortUnit);
-    return secondaries.isEmpty ? null : secondaries.first;
-  }
+        RankingMetrics.secondaryMetrics(context, entry, selection, sortUnit);
+    final lines = <Widget>[];
 
-  /// Third line: the second carbon metric for carbon (two secondaries),
-  /// otherwise the last connection (last activity).
-  String? _lastConnection(BuildContext context) {
-    final secondaries =
-        RankingMetrics.secondaries(context, entry, selection, sortUnit);
-    if (secondaries.length >= 2) return secondaries.last;
-    final date = entry.lastModified;
-    if (date == null) return null;
-    return DateFormat.yMMM(Localizations.localeOf(context).toString())
-        .format(date);
+    if (secondaries.isNotEmpty) {
+      final m = secondaries.first;
+      lines.add(RawValueTooltip(
+        message: m.tooltip,
+        child: Text(
+          m.inline,
+          style: AppTheme.monoFont.copyWith(
+            fontSize: 12,
+            color: cs.onSurfaceVariant,
+          ),
+          overflow: TextOverflow.ellipsis,
+        ),
+      ));
+    }
+
+    final lineStyle = AppTheme.monoFont.copyWith(
+      fontSize: 11,
+      color: cs.onSurfaceVariant.withValues(alpha: 0.7),
+    );
+    if (secondaries.length >= 2) {
+      final m = secondaries.last;
+      lines.add(RawValueTooltip(
+        message: m.tooltip,
+        child: Text(m.inline, style: lineStyle, overflow: TextOverflow.ellipsis),
+      ));
+    } else {
+      final date = entry.lastModified;
+      if (date != null) {
+        lines.add(Text(
+          DateFormat.yMMM(Localizations.localeOf(context).toString())
+              .format(date),
+          style: lineStyle,
+          overflow: TextOverflow.ellipsis,
+        ));
+      }
+    }
+
+    return lines;
   }
 }
 
@@ -324,7 +348,10 @@ class _Monogram extends StatelessWidget {
 class _CarbonPill extends StatelessWidget {
   final double gPerKm;
 
-  const _CarbonPill({required this.gPerKm});
+  /// Raw, full-precision `g/km` value revealed on tap (the pill itself rounds).
+  final String? tooltip;
+
+  const _CarbonPill({required this.gPerKm, this.tooltip});
 
   @override
   Widget build(BuildContext context) {
@@ -335,7 +362,9 @@ class _CarbonPill extends StatelessWidget {
       noDecimal: true,
     );
 
-    return Container(
+    return RawValueTooltip(
+      message: tooltip,
+      child: Container(
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
       decoration: BoxDecoration(
         color: color.withValues(alpha: 0.15),
@@ -365,6 +394,7 @@ class _CarbonPill extends StatelessWidget {
           ),
         ],
       ),
+      ),
     );
   }
 }
@@ -374,12 +404,18 @@ class _PrimaryValue extends StatelessWidget {
   final String value;
   final String unit;
 
-  const _PrimaryValue({required this.value, required this.unit});
+  /// Raw, full-precision base-unit value revealed on tap (null when the value
+  /// is shown exactly, e.g. a plain trip count).
+  final String? tooltip;
+
+  const _PrimaryValue({required this.value, required this.unit, this.tooltip});
 
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    return Column(
+    return RawValueTooltip(
+      message: tooltip,
+      child: Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.end,
       children: [
@@ -402,6 +438,7 @@ class _PrimaryValue extends StatelessWidget {
           ),
         ),
       ],
+      ),
     );
   }
 }

--- a/lib/features/ranking/widgets/ranking_user_position_block.dart
+++ b/lib/features/ranking/widgets/ranking_user_position_block.dart
@@ -8,6 +8,7 @@ import 'package:trainlog_app/data/models/trips.dart';
 import 'package:trainlog_app/features/ranking/ranking_metrics.dart';
 import 'package:trainlog_app/features/ranking/ranking_type.dart';
 import 'package:trainlog_app/features/ranking/widgets/ranking_medal.dart';
+import 'package:trainlog_app/features/ranking/widgets/raw_value_tooltip.dart';
 import 'package:trainlog_app/l10n/app_localizations.dart';
 import 'package:trainlog_app/providers/ranking_provider.dart';
 import 'package:trainlog_app/providers/settings_provider.dart';
@@ -200,12 +201,20 @@ class _RankBadge extends StatelessWidget {
           ],
         ),
         const SizedBox(height: 2),
-        Text(
-          _value(context),
-          style: AppTheme.monoFont.copyWith(
-            color: AppColors.amber,
-            fontSize: 14,
-            fontWeight: FontWeight.w700,
+        RawValueTooltip(
+          message: RankingMetrics.primaryTooltip(
+            context,
+            entry,
+            provider.selection,
+            provider.sortUnit,
+          ),
+          child: Text(
+            _value(context),
+            style: AppTheme.monoFont.copyWith(
+              color: AppColors.amber,
+              fontSize: 14,
+              fontWeight: FontWeight.w700,
+            ),
           ),
         ),
       ],

--- a/lib/features/ranking/widgets/raw_value_tooltip.dart
+++ b/lib/features/ranking/widgets/raw_value_tooltip.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+/// Wraps [child] so that tapping it reveals [message] — the raw, un-rounded
+/// value in its base unit — as a tooltip.
+///
+/// Ranking values are shown rounded (e.g. CO2e in g/km) or with SI prefixes
+/// (e.g. distance as `Mm`/`Gm`); this lets the user tap the number to read the
+/// exact base-unit value. The child's appearance is intentionally left
+/// untouched (no underline or other affordance) so the layout is unchanged.
+///
+/// When [message] is null the child is returned as-is (used for metrics that are
+/// already shown exactly, such as a plain trip count).
+class RawValueTooltip extends StatelessWidget {
+  final String? message;
+  final Widget child;
+
+  const RawValueTooltip({
+    super.key,
+    required this.message,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final message = this.message;
+    if (message == null) return child;
+
+    final cs = Theme.of(context).colorScheme;
+    return Tooltip(
+      message: message,
+      triggerMode: TooltipTriggerMode.tap,
+      preferBelow: false,
+      waitDuration: Duration.zero,
+      showDuration: const Duration(seconds: 4),
+      decoration: BoxDecoration(
+        color: cs.primaryContainer,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      textStyle: TextStyle(color: cs.onPrimaryContainer),
+      child: child,
+    );
+  }
+}

--- a/lib/utils/number_formatter.dart
+++ b/lib/utils/number_formatter.dart
@@ -108,6 +108,19 @@ abstract final class NumberFormatter {
     return NumberFormat(pattern, locale.toString()).format(value);
   }
 
+  /// Full-precision grouped number, used for "raw value" tooltips: keeps up to
+  /// [maxDecimals] fractional digits (trailing zeros stripped) so the underlying
+  /// value is shown without SI scaling or the display rounding applied by
+  /// [decimal] / [compactParts].
+  static String precise(
+    num value, {
+    required Locale locale,
+    int maxDecimals = 6,
+  }) {
+    final pattern = '#,##0.${'#' * maxDecimals}';
+    return NumberFormat(pattern, locale.toString()).format(value);
+  }
+
   /// Currency-style grouped number with an optional explicit sign.
   static String currency(
     num amount, {

--- a/lib/utils/number_formatter.dart
+++ b/lib/utils/number_formatter.dart
@@ -115,7 +115,7 @@ abstract final class NumberFormatter {
   static String precise(
     num value, {
     required Locale locale,
-    int maxDecimals = 6,
+    int maxDecimals = 3,
   }) {
     final pattern = '#,##0.${'#' * maxDecimals}';
     return NumberFormat(pattern, locale.toString()).format(value);


### PR DESCRIPTION
## Summary
Ranking metrics are displayed with SI prefixes and rounding for readability (e.g., distance as `Mm`, CO2e as `g/km`). This change adds tap-activated tooltips that reveal the exact base-unit values, allowing users to see the full precision when needed.

## Key Changes
- **New `RawValueTooltip` widget**: A reusable wrapper that displays a tap-activated tooltip with the raw, full-precision value. When the message is null (for metrics already shown exactly), the child is returned unchanged.
- **Enhanced `RankingMetrics`**: 
  - Added `rawTooltip()` to generate full-precision base-unit strings for each metric type
  - Added `primaryTooltip()` to determine if the primary metric needs a tooltip (null for world-squares percentages shown exactly)
  - Refactored `secondaries()` to return `RankingMetricText` tuples containing both the inline display string and optional tooltip
  - Added `secondaries()` helper to extract just the inline strings for backward compatibility
- **Updated ranking displays**:
  - `RankingListView`: Wrapped primary values and secondary metrics with `RawValueTooltip`
  - `RankingUserPositionBlock`: Added tooltip to the user's rank badge value
  - `_CarbonPill` and `_PrimaryValue` widgets now accept optional tooltip parameters
- **New `NumberFormatter.precise()`**: Formats numbers with up to 3 decimal places (trailing zeros stripped) for use in tooltips, showing the underlying value without SI scaling or display rounding.

## Implementation Details
- Tooltips use `TooltipTriggerMode.tap` with zero wait duration and 4-second display duration
- Styled with `primaryContainer` background and `onPrimaryContainer` text for consistency
- The refactored `_supportingLines()` method now returns a list of widgets, allowing metric lines to be wrapped with tooltips while keeping date lines unwrapped
- Backward compatible: existing code using `secondaries()` continues to work unchanged

https://claude.ai/code/session_01GpuiYmyLsU66hnpAwa6USR