### PR TITLE
Hide zero delays in trip details and cards

### DIFF
--- a/lib/features/trips/detail_sheet/trip_details_timeline.dart
+++ b/lib/features/trips/detail_sheet/trip_details_timeline.dart
@@ -52,7 +52,7 @@ class TripDetailsTimeline extends StatelessWidget {
               children: [
                 _TimeBlock(
                   main: _time(context, trip.realStartDate),
-                  scheduled: trip.hasDepartureDelay
+                  scheduled: trip.hasDepartureDelay && trip.departureDelayInMinutes != 0
                       ? _time(context, trip.startDatetime)
                       : null,
                   delta: trip.departureDelayFormatted,
@@ -60,7 +60,7 @@ class TripDetailsTimeline extends StatelessWidget {
                 ),
                 _TimeBlock(
                   main: _time(context, trip.realEndDate),
-                  scheduled: trip.hasArrivalDelay
+                  scheduled: trip.hasArrivalDelay && trip.arrivalDelayInMinutes != 0
                       ? _time(context, trip.endDatetime)
                       : null,
                   delta: trip.arrivalDelayFormatted,

--- a/lib/features/trips/widgets/trip_card_view.dart
+++ b/lib/features/trips/widgets/trip_card_view.dart
@@ -452,7 +452,7 @@ class _TimeLabel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (delay != null && delayText != null) {
+    if (delay != null && delayText != null && delay != 0) {
       return Text.rich(
         TextSpan(children: [
           TextSpan(text: time, style: style),

--- a/lib/features/trips/widgets/trip_table_view.dart
+++ b/lib/features/trips/widgets/trip_table_view.dart
@@ -234,7 +234,7 @@ class _TripsDataSource extends DataTableSource {
           Row(
             children: [
               Text(time),
-              if (delay != null && delayFormatted != null)
+              if (delay != null && delayFormatted != null && delay != 0)
                 Text(
                   ' ($delayFormatted)',
                   style: TextStyle(


### PR DESCRIPTION
## Summary
This PR fixes the display of trip delay information by hiding zero-value delays across the trip UI components. Previously, delays of 0 minutes were being displayed, which provided no useful information to users.

## Key Changes
- **Trip Details Timeline**: Added checks to ensure scheduled times are only shown when there's an actual non-zero delay for both departure and arrival
- **Trip Card View**: Added validation to prevent displaying delay text when the delay value is 0
- **Trip Table View**: Added validation to prevent displaying formatted delay text when the delay value is 0

## Implementation Details
The fix involves adding `&& delay != 0` conditions to existing delay display logic across three components:
- `trip_details_timeline.dart`: Checks `departureDelayInMinutes != 0` and `arrivalDelayInMinutes != 0`
- `trip_card_view.dart`: Checks `delay != 0` in the `_TimeLabel` widget
- `trip_table_view.dart`: Checks `delay != 0` in the `_TripsDataSource` widget

This ensures that only meaningful delays (non-zero values) are presented to users in the UI.

https://claude.ai/code/session_01U44VxxwnhmzByFxz6A8D1w