### PR TITLE
Implement countries-visited leaderboard with drill-down view

### DIFF
--- a/lib/features/ranking/ranking_metrics.dart
+++ b/lib/features/ranking/ranking_metrics.dart
@@ -95,20 +95,20 @@ abstract final class RankingMetrics {
   }
 
   /// The raw-value tooltip for the primary metric, or null when the displayed
-  /// value is already exact. World-squares shows a percentage with no SI prefix,
-  /// so it needs no tooltip.
+  /// value is already exact. World-squares shows a percentage with no SI prefix
+  /// and the country view a plain count, so neither needs a tooltip.
   static String? primaryTooltip(
     BuildContext context,
     RankingDisplayEntry entry,
     RankingSelection selection,
     RankingSortUnit unit,
   ) {
-    if (selection.isWorldSquares) return null;
+    if (selection.isWorldSquares || selection.isCountry) return null;
     return rawTooltip(context, entry, unit);
   }
 
-  /// The primary metric (the active [unit], or the percentage for
-  /// world-squares) as a value + unit pair.
+  /// The primary metric (the active [unit], the percentage for world-squares,
+  /// or the country count for the country view) as a value + unit pair.
   static CompactNumber primary(
     BuildContext context,
     RankingDisplayEntry entry,
@@ -120,6 +120,14 @@ abstract final class RankingMetrics {
         value: NumberFormatter.decimal(entry.percent ?? 0,
             locale: Localizations.localeOf(context)),
         unit: '%',
+      );
+    }
+    if (selection.isCountry) {
+      final loc = AppLocalizations.of(context)!;
+      return (
+        value: NumberFormatter.decimal(entry.countryCount,
+            locale: Localizations.localeOf(context)),
+        unit: loc.rankingCountryCountLabel(entry.countryCount),
       );
     }
     return format(context, entry, unit);
@@ -139,18 +147,19 @@ abstract final class RankingMetrics {
         locale: Localizations.localeOf(context),
       );
     }
-    return inline(format(context, entry, unit));
+    return inline(primary(context, entry, selection, unit));
   }
 
   /// The non-primary metrics, each as its inline string plus the optional
-  /// raw-value tooltip, in display order. Empty for world-squares.
+  /// raw-value tooltip, in display order. Empty for world-squares and the
+  /// country view (both are single-metric).
   static List<RankingMetricText> secondaryMetrics(
     BuildContext context,
     RankingDisplayEntry entry,
     RankingSelection selection,
     RankingSortUnit unit,
   ) {
-    if (selection.isWorldSquares) return const [];
+    if (selection.isWorldSquares || selection.isCountry) return const [];
     return [
       for (final u in unitsFor(selection.type))
         if (u != unit)

--- a/lib/features/ranking/ranking_page.dart
+++ b/lib/features/ranking/ranking_page.dart
@@ -5,17 +5,20 @@ import 'package:provider/provider.dart';
 
 import 'package:trainlog_app/features/ranking/ranking_metrics.dart';
 import 'package:trainlog_app/features/ranking/ranking_type.dart';
+import 'package:trainlog_app/features/ranking/user_countries_page.dart';
 import 'package:trainlog_app/features/ranking/widgets/railway_coverage_view.dart';
 import 'package:trainlog_app/features/ranking/widgets/ranking_filter_controls.dart';
 import 'package:trainlog_app/features/ranking/widgets/ranking_list_view.dart';
 import 'package:trainlog_app/features/ranking/widgets/ranking_selector_bar.dart';
 import 'package:trainlog_app/features/ranking/widgets/ranking_user_position_block.dart';
 import 'package:trainlog_app/l10n/app_localizations.dart';
+import 'package:trainlog_app/platform/adaptive_page_route.dart';
 import 'package:trainlog_app/platform/adaptive_widget.dart';
 import 'package:trainlog_app/providers/ranking_provider.dart';
 import 'package:trainlog_app/providers/settings_provider.dart';
 import 'package:trainlog_app/providers/trainlog_provider.dart';
 import 'package:trainlog_app/utils/map_color_palette.dart';
+import 'package:trainlog_app/utils/text_utils.dart';
 
 /// Native, adaptive leaderboard entry point.
 ///
@@ -77,6 +80,28 @@ class _RankingPageState extends State<RankingPage> {
       ).join(' · ');
     }
 
+    // Extra content beneath the row: the carbon info banner, or the visited
+    // country flags (tappable, drilling into the full country list).
+    final Object? details;
+    if (selection.type == RankingType.carbon) {
+      details = loc.rankingCarbonExplanation;
+    } else if (selection.isCountry &&
+        entry != null &&
+        entry.countriesVisited.isNotEmpty) {
+      details = _VisitedCountryFlags(
+        countryCodes: entry.countriesVisited,
+        onTap: () => AdaptivePageRoute.push(
+          context,
+          (_) => UserCountriesPage(
+            username: entry.username,
+            countryCodes: entry.countriesVisited,
+          ),
+        ),
+      );
+    } else {
+      details = null;
+    }
+
     return RankingUserPositionBlock(
       icon: RankingPositionIcon(
         icon: selection.icon,
@@ -94,9 +119,7 @@ class _RankingPageState extends State<RankingPage> {
           ? null
           : RankingMetrics.primaryTooltip(
               context, entry, selection, provider.sortUnit),
-      carbonExplanation: selection.type == RankingType.carbon
-          ? loc.rankingCarbonExplanation
-          : null,
+      details: details,
     );
   }
 
@@ -194,6 +217,58 @@ class _RankingPageState extends State<RankingPage> {
           ],
         );
       },
+    );
+  }
+}
+
+/// The country-ranking details of [RankingUserPositionBlock]: the flags of the
+/// countries the user has visited (backend order — most visited first), capped
+/// at two lines with an ellipsis, plus a trailing chevron. Tapping it opens the
+/// user's full [UserCountriesPage].
+class _VisitedCountryFlags extends StatelessWidget {
+  /// ISO country codes in the backend order (by trip count, most visited
+  /// first).
+  final List<String> countryCodes;
+
+  final VoidCallback onTap;
+
+  const _VisitedCountryFlags({
+    required this.countryCodes,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(10),
+      child: Padding(
+        padding: const EdgeInsets.only(top: 14),
+        child: Row(
+          children: [
+            Expanded(
+              child: Text(
+                countryCodes.map(countryCodeToEmoji).join(' '),
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  fontSize: 18,
+                  height: 1.5,
+                  letterSpacing: 2,
+                  color: cs.onInverseSurface,
+                ),
+              ),
+            ),
+            const SizedBox(width: 8),
+            Icon(
+              Icons.chevron_right,
+              color: cs.onInverseSurface.withValues(alpha: 0.7),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/features/ranking/ranking_page.dart
+++ b/lib/features/ranking/ranking_page.dart
@@ -65,6 +65,8 @@ class _RankingPageState extends State<RankingPage> {
       subtitle = loc.rankingNotRanked;
     } else if (selection.isWorldSquares) {
       subtitle = loc.rankingWorldCovered;
+    } else if (selection.isCountry) {
+      subtitle = loc.rankingCountriesVisited;
     } else {
       // The complementary metric(s) not used as the primary value.
       subtitle = RankingMetrics.secondaries(

--- a/lib/features/ranking/ranking_type.dart
+++ b/lib/features/ranking/ranking_type.dart
@@ -22,7 +22,7 @@ enum RankingType {
   /// Share of the world's squares covered.
   worldSquares,
 
-  /// Number of distinct countries visited. (Built later.)
+  /// Number of distinct countries visited.
   country,
 
   /// Carbon-footprint leaderboard. (Built later.)
@@ -30,14 +30,8 @@ enum RankingType {
 
   /// Whether a functional view exists for this category in the current batch.
   ///
-  /// [all], [vehicles], [worldSquares], [railwayCoverage] and [carbon] are
-  /// implemented; the remaining ones are rendered as disabled pills.
-  bool get isImplemented =>
-      this == RankingType.all ||
-      this == RankingType.vehicles ||
-      this == RankingType.worldSquares ||
-      this == RankingType.railwayCoverage ||
-      this == RankingType.carbon;
+  /// Every category is implemented.
+  bool get isImplemented => true;
 
   /// Localized label for the category pill (vehicle pills use the vehicle name).
   String label(BuildContext context) {
@@ -176,6 +170,7 @@ class RankingSelection {
   const RankingSelection.category(RankingType type) : this._(type, null);
 
   bool get isWorldSquares => type == RankingType.worldSquares;
+  bool get isCountry => type == RankingType.country;
   bool get isVehicle => type == RankingType.vehicles && vehicle != null;
 
   /// Pill label: the vehicle name for vehicle selections, the type label
@@ -248,6 +243,13 @@ class RankingDisplayEntry {
   /// CO2e intensity, in grams per kilometre (0 outside the carbon view).
   final double carbonPerKmG;
 
+  /// Number of distinct countries visited (0 outside the country view).
+  final int countryCount;
+
+  /// ISO country codes visited, in the backend order (by trip count, most
+  /// visited first). Empty outside the country view.
+  final List<String> countriesVisited;
+
   /// Last activity, when known (drives the "· Jun 2026" subtitle).
   final DateTime? lastModified;
 
@@ -260,6 +262,8 @@ class RankingDisplayEntry {
     this.percent,
     this.totalCarbonKg = 0,
     this.carbonPerKmG = 0,
+    this.countryCount = 0,
+    this.countriesVisited = const [],
     this.lastModified,
   });
 
@@ -272,6 +276,8 @@ class RankingDisplayEntry {
         percent: percent,
         totalCarbonKg: totalCarbonKg,
         carbonPerKmG: carbonPerKmG,
+        countryCount: countryCount,
+        countriesVisited: countriesVisited,
         lastModified: lastModified,
       );
 }

--- a/lib/features/ranking/user_countries_page.dart
+++ b/lib/features/ranking/user_countries_page.dart
@@ -57,32 +57,30 @@ class _UserCountriesPageState extends State<UserCountriesPage> {
     final loc = AppLocalizations.of(context)!;
     final countries = _displayCountries(context);
 
+    final sortingButtons = Padding(
+      padding: const EdgeInsets.only(right: 16),
+      child: RankingSortButtons(
+        alphabetical: _alphabetical,
+        descending: _descending,
+        onToggleAlphabetical: () =>
+            setState(() => _alphabetical = !_alphabetical),
+        onToggleDirection: () =>
+            setState(() => _descending = !_descending),
+      ),
+    );
+
     return Scaffold(
       appBar: AdaptiveAppBar(
         title: widget.username,
         onBack: () => Navigator.of(context).pop(),
+        materialActions: [sortingButtons],
+        cupertinoTrailing: sortingButtons,
       ),
       body: SafeArea(
         top: false,
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Padding(
-              padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
-              child: Row(
-                children: [
-                  const Spacer(),
-                  RankingSortButtons(
-                    alphabetical: _alphabetical,
-                    descending: _descending,
-                    onToggleAlphabetical: () =>
-                        setState(() => _alphabetical = !_alphabetical),
-                    onToggleDirection: () =>
-                        setState(() => _descending = !_descending),
-                  ),
-                ],
-              ),
-            ),
             const SizedBox(height: 12),
             Expanded(
               child: countries.isEmpty

--- a/lib/features/ranking/user_countries_page.dart
+++ b/lib/features/ranking/user_countries_page.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/material.dart';
+
+import 'package:trainlog_app/data/models/country_detail.dart';
+import 'package:trainlog_app/features/ranking/widgets/coverage_list_card.dart';
+import 'package:trainlog_app/features/ranking/widgets/ranking_filter_controls.dart';
+import 'package:trainlog_app/l10n/app_localizations.dart';
+import 'package:trainlog_app/platform/adaptive_app_bar.dart';
+
+/// Drill-down sub-page for the countries-visited leaderboard: the full list of
+/// countries a single user has visited, with their flag and localized name.
+/// Pushed onto the stack (hiding the bottom navigation) when a row of the
+/// country ranking is tapped; the app-bar title is the user's name.
+///
+/// The default order is the backend order (by trip count, most visited first);
+/// the two sort toggles switch to/from alphabetical order and reverse the
+/// direction — display only, the data is never refetched.
+class UserCountriesPage extends StatefulWidget {
+  /// The user whose countries are listed (shown as the app-bar title).
+  final String username;
+
+  /// ISO country codes in the backend order (by trip count per country, most
+  /// visited first).
+  final List<String> countryCodes;
+
+  const UserCountriesPage({
+    super.key,
+    required this.username,
+    required this.countryCodes,
+  });
+
+  @override
+  State<UserCountriesPage> createState() => _UserCountriesPageState();
+}
+
+class _UserCountriesPageState extends State<UserCountriesPage> {
+  bool _alphabetical = false;
+  bool _descending = true;
+
+  /// Countries in display order: the backend order by default (the "value"
+  /// order), or sorted by localized name when the alphabetical toggle is on;
+  /// the direction toggle reverses either order.
+  List<CountryDetail> _displayCountries(BuildContext context) {
+    final details = [
+      for (final code in widget.countryCodes)
+        CountryDetail.fromCode(code, context),
+    ];
+    if (_alphabetical) {
+      details.sort(
+        (a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()),
+      );
+    }
+    return _descending ? details : details.reversed.toList();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
+    final countries = _displayCountries(context);
+
+    return Scaffold(
+      appBar: AdaptiveAppBar(
+        title: widget.username,
+        onBack: () => Navigator.of(context).pop(),
+      ),
+      body: SafeArea(
+        top: false,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+              child: Row(
+                children: [
+                  const Spacer(),
+                  RankingSortButtons(
+                    alphabetical: _alphabetical,
+                    descending: _descending,
+                    onToggleAlphabetical: () =>
+                        setState(() => _alphabetical = !_alphabetical),
+                    onToggleDirection: () =>
+                        setState(() => _descending = !_descending),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 12),
+            Expanded(
+              child: countries.isEmpty
+                  ? Center(child: Text(loc.rankingNoData))
+                  : CoverageListCard(
+                      child: ListView.separated(
+                        padding: EdgeInsets.zero,
+                        itemCount: countries.length,
+                        separatorBuilder: (_, __) => Divider(
+                          height: 1,
+                          thickness: 1,
+                          indent: 16,
+                          endIndent: 16,
+                          color: Theme.of(context)
+                              .colorScheme
+                              .outlineVariant
+                              .withValues(alpha: 0.4),
+                        ),
+                        itemBuilder: (context, i) =>
+                            _CountryRow(country: countries[i]),
+                      ),
+                    ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// A single visited-country row: flag emoji + localized name.
+class _CountryRow extends StatelessWidget {
+  final CountryDetail country;
+
+  const _CountryRow({required this.country});
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      child: Row(
+        children: [
+          Text(country.emoji, style: const TextStyle(fontSize: 22)),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              country.name,
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                    color: cs.onSurface,
+                  ),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/ranking/widgets/ranking_list_view.dart
+++ b/lib/features/ranking/widgets/ranking_list_view.dart
@@ -5,9 +5,11 @@ import 'package:trainlog_app/app/theme/app_colors.dart';
 import 'package:trainlog_app/app/theme/app_theme.dart';
 import 'package:trainlog_app/features/ranking/ranking_metrics.dart';
 import 'package:trainlog_app/features/ranking/ranking_type.dart';
+import 'package:trainlog_app/features/ranking/user_countries_page.dart';
 import 'package:trainlog_app/features/ranking/widgets/ranking_medal.dart';
 import 'package:trainlog_app/features/ranking/widgets/raw_value_tooltip.dart';
 import 'package:trainlog_app/l10n/app_localizations.dart';
+import 'package:trainlog_app/platform/adaptive_page_route.dart';
 import 'package:trainlog_app/providers/ranking_provider.dart';
 import 'package:trainlog_app/utils/number_formatter.dart';
 import 'package:trainlog_app/widgets/monogram.dart';
@@ -109,6 +111,16 @@ class RankingListView extends StatelessWidget {
           sortUnit: provider.sortUnit,
           isCurrentUser: me != null && e.username.toLowerCase() == me,
           showRank: showRank,
+          // Country rows drill into the user's full visited-country list.
+          onTap: provider.selection.isCountry
+              ? () => AdaptivePageRoute.push(
+                    context,
+                    (_) => UserCountriesPage(
+                      username: e.username,
+                      countryCodes: e.countriesVisited,
+                    ),
+                  )
+              : null,
         );
       },
     );
@@ -126,6 +138,10 @@ class RankingRow extends StatelessWidget {
   /// only show the rank on the first one (see [RankingListView]).
   final bool showRank;
 
+  /// When set, the row is tappable and shows a trailing navigation chevron
+  /// (used by the country ranking to drill into the visited-country list).
+  final VoidCallback? onTap;
+
   const RankingRow({
     super.key,
     required this.entry,
@@ -133,13 +149,14 @@ class RankingRow extends StatelessWidget {
     required this.sortUnit,
     required this.isCurrentUser,
     this.showRank = true,
+    this.onTap,
   });
 
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
 
-    return Container(
+    final row = Container(
       padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 10),
       decoration: BoxDecoration(
         color: isCurrentUser
@@ -192,8 +209,19 @@ class RankingRow extends StatelessWidget {
                     context, entry, selection, sortUnit),
               );
             }),
+          if (onTap != null) ...[
+            const SizedBox(width: 6),
+            Icon(Icons.chevron_right, color: cs.onSurfaceVariant),
+          ],
         ],
       ),
+    );
+
+    if (onTap == null) return row;
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(14),
+      child: row,
     );
   }
 

--- a/lib/features/ranking/widgets/ranking_user_position_block.dart
+++ b/lib/features/ranking/widgets/ranking_user_position_block.dart
@@ -35,9 +35,11 @@ class RankingUserPositionBlock extends StatelessWidget {
   /// Optional raw-value tooltip revealed on tapping [valueText].
   final String? valueTooltip;
 
-  /// When set, an info banner with this text is shown beneath the row (used by
-  /// the carbon leaderboard to explain that lower g/km ranks better).
-  final String? carbonExplanation;
+  /// Extra content shown beneath the row. A [String] is rendered as an
+  /// [ExplanationDetails] info banner (used by the carbon leaderboard to
+  /// explain that lower g/km ranks better); a [Widget] is rendered as-is
+  /// (used by the country ranking for the visited-flags list).
+  final Object? details;
 
   const RankingUserPositionBlock({
     super.key,
@@ -48,8 +50,9 @@ class RankingUserPositionBlock extends StatelessWidget {
     this.participantCount = 0,
     this.valueText,
     this.valueTooltip,
-    this.carbonExplanation,
-  });
+    this.details,
+  })  : assert(details == null || details is String || details is Widget,
+            'details must be a String or a Widget');
 
   @override
   Widget build(BuildContext context) {
@@ -116,19 +119,26 @@ class RankingUserPositionBlock extends StatelessWidget {
               ),
             ],
           ),
-          if (carbonExplanation != null)
-            _CarbonExplanation(text: carbonExplanation!),
+          if (details != null) _detailsChild(details!),
         ],
       ),
     );
   }
+
+  /// Resolves [details] to its widget: a plain string becomes the
+  /// [ExplanationDetails] banner, a widget is rendered as-is.
+  Widget _detailsChild(Object details) {
+    if (details is String) return ExplanationDetails(text: details);
+    return details as Widget;
+  }
 }
 
-/// Info banner explaining that lower CO2e/km ranks better.
-class _CarbonExplanation extends StatelessWidget {
+/// Info banner shown beneath the position row (e.g. explaining that lower
+/// CO2e/km ranks better on the carbon leaderboard).
+class ExplanationDetails extends StatelessWidget {
   final String text;
 
-  const _CarbonExplanation({required this.text});
+  const ExplanationDetails({super.key, required this.text});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -188,6 +188,17 @@
   "rankingOrderDescending": "Descending",
   "rankingAllVehicles": "all vehicles",
   "rankingWorldCovered": "World squares covered",
+  "rankingCountriesVisited": "Countries visited",
+  "@rankingCountriesVisited": {
+    "description": "Subtitle of the user position block in the countries ranking"
+  },
+  "rankingCountryCountLabel": "{count, plural, =1 {country} other {countries}}",
+  "@rankingCountryCountLabel": {
+    "description": "Unit label shown under the number of countries visited in the ranking list",
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
   "rankingNoData": "No data",
   "rankingNotRanked": "Not ranked",
   "rankingSearchHint": "Search users…",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -154,6 +154,8 @@
   "rankingOrderDescending": "Décroissant",
   "rankingAllVehicles": "tous les véhicules",
   "rankingWorldCovered": "Cases du monde couvertes",
+  "rankingCountriesVisited": "Pays visités",
+  "rankingCountryCountLabel": "{count, plural, =1 {pays} other {pays}}",
   "rankingNoData": "Aucune donnée",
   "rankingNotRanked": "Non classé",
   "rankingSearchHint": "Rechercher des utilisateurs…",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -153,6 +153,8 @@
   "rankingOrderDescending": "降順",
   "rankingAllVehicles": "すべての乗り物",
   "rankingWorldCovered": "世界マスの網羅率",
+  "rankingCountriesVisited": "訪問した国",
+  "rankingCountryCountLabel": "{count, plural, other {か国}}",
   "rankingNoData": "データなし",
   "rankingNotRanked": "ランク外",
   "rankingSearchHint": "ユーザーを検索…",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1020,6 +1020,18 @@ abstract class AppLocalizations {
   /// **'World squares covered'**
   String get rankingWorldCovered;
 
+  /// Subtitle of the user position block in the countries ranking
+  ///
+  /// In en, this message translates to:
+  /// **'Countries visited'**
+  String get rankingCountriesVisited;
+
+  /// Unit label shown under the number of countries visited in the ranking list
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1 {country} other {countries}}'**
+  String rankingCountryCountLabel(int count);
+
   /// No description provided for @rankingNoData.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -500,6 +500,20 @@ class AppLocalizationsEn extends AppLocalizations {
   String get rankingWorldCovered => 'World squares covered';
 
   @override
+  String get rankingCountriesVisited => 'Countries visited';
+
+  @override
+  String rankingCountryCountLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'countries',
+      one: 'country',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get rankingNoData => 'No data';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -507,6 +507,20 @@ class AppLocalizationsFr extends AppLocalizations {
   String get rankingWorldCovered => 'Cases du monde couvertes';
 
   @override
+  String get rankingCountriesVisited => 'Pays visités';
+
+  @override
+  String rankingCountryCountLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'pays',
+      one: 'pays',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get rankingNoData => 'Aucune donnée';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -490,6 +490,19 @@ class AppLocalizationsJa extends AppLocalizations {
   String get rankingWorldCovered => '世界マスの網羅率';
 
   @override
+  String get rankingCountriesVisited => '訪問した国';
+
+  @override
+  String rankingCountryCountLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'か国',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get rankingNoData => 'データなし';
 
   @override

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -499,6 +499,20 @@ class AppLocalizationsTl extends AppLocalizations {
   String get rankingWorldCovered => 'Na-cover na mga squares sa mundo';
 
   @override
+  String get rankingCountriesVisited => 'Mga bansang nabisita';
+
+  @override
+  String rankingCountryCountLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'mga bansa',
+      one: 'bansa',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get rankingNoData => 'Walang datos';
 
   @override

--- a/lib/l10n/app_tl.arb
+++ b/lib/l10n/app_tl.arb
@@ -173,6 +173,8 @@
   "rankingOrderDescending": "Pababa",
   "rankingAllVehicles": "lahat ng sasakyan",
   "rankingWorldCovered": "Na-cover na mga squares sa mundo",
+  "rankingCountriesVisited": "Mga bansang nabisita",
+  "rankingCountryCountLabel": "{count, plural, =1 {bansa} other {mga bansa}}",
   "rankingNoData": "Walang datos",
   "rankingNotRanked": "Hindi naka-ranggo",
   "rankingSearchHint": "Maghanap ng user…",

--- a/lib/providers/ranking_provider.dart
+++ b/lib/providers/ranking_provider.dart
@@ -37,8 +37,8 @@ class RankingProvider extends ChangeNotifier {
 
   /// The sort units offered for the current selection.
   ///
-  /// Carbon exposes three (CO2e/km, total CO2e, distance); world-squares none
-  /// (percentage only); everything else distance/trips.
+  /// Carbon exposes three (CO2e/km, total CO2e, distance); world-squares and
+  /// country none (single metric); everything else distance/trips.
   List<RankingSortUnit> get availableUnits {
     switch (_selection.type) {
       case RankingType.carbon:
@@ -48,6 +48,7 @@ class RankingProvider extends ChangeNotifier {
           RankingSortUnit.distance,
         ];
       case RankingType.worldSquares:
+      case RankingType.country:
         return const [];
       default:
         return const [RankingSortUnit.distance, RankingSortUnit.trips];
@@ -200,11 +201,29 @@ class RankingProvider extends ChangeNotifier {
       case RankingType.carbon:
         final res = await _trainlog.fetchRankingForCarbonFootprint();
         return _fromCarbon(res);
-      case RankingType.railwayCoverage:
       case RankingType.country:
-        // Not implemented in this batch; rendered as disabled pills.
+        final res = await _trainlog.fetchRankingForCountry();
+        return _fromCountry(res);
+      case RankingType.railwayCoverage:
+        // Railway Coverage has its own view and provider.
         return const [];
     }
+  }
+
+  List<RankingDisplayEntry> _fromCountry(
+    RankingResult<CountryLeaderboardEntry> res,
+  ) {
+    return res.entries
+        .map(
+          (e) => RankingDisplayEntry(
+            rank: 0,
+            username: e.username,
+            isNonPublic: e.isNonPublic,
+            countryCount: e.countryCount,
+            countriesVisited: e.countriesVisited,
+          ),
+        )
+        .toList();
   }
 
   List<RankingDisplayEntry> _fromCarbon(
@@ -270,7 +289,9 @@ class RankingProvider extends ChangeNotifier {
   double metricOf(RankingDisplayEntry e) => _metric(e);
 
   /// The value used both for ranking and for the natural (value) display order.
-  double _metric(RankingDisplayEntry e) {    if (_selection.isWorldSquares) return e.percent ?? 0;
+  double _metric(RankingDisplayEntry e) {
+    if (_selection.isWorldSquares) return e.percent ?? 0;
+    if (_selection.isCountry) return e.countryCount.toDouble();
     switch (_sortUnit) {
       case RankingSortUnit.distance:
         return e.distanceKm;
@@ -288,7 +309,9 @@ class RankingProvider extends ChangeNotifier {
   /// username so the competitive rank and the displayed order stay in sync
   /// (otherwise equal values — e.g. many 0 g/km rows — would sort arbitrarily).
   int _compareBest(RankingDisplayEntry a, RankingDisplayEntry b) {
-    final lowerBetter = _sortUnit.lowerIsBetter && !_selection.isWorldSquares;
+    final lowerBetter = _sortUnit.lowerIsBetter &&
+        !_selection.isWorldSquares &&
+        !_selection.isCountry;
     final cmp = _metric(a).compareTo(_metric(b));
     if (cmp != 0) return lowerBetter ? cmp : -cmp;
     return a.username.toLowerCase().compareTo(b.username.toLowerCase());

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: trainlog_app
 description: "Your online travel diary"
 publish_to: 'none'
-version: 0.2.2+17
+version: 0.3.0+19
 
 environment:
   sdk: ^3.8.0


### PR DESCRIPTION
## Summary
Implements the countries-visited leaderboard category, allowing users to see rankings of how many distinct countries they've visited, with the ability to drill down into a detailed view of each user's visited countries.

## Key Changes

- **New `UserCountriesPage`**: A dedicated page showing a user's visited countries with flag emojis and localized names, supporting sorting by visit count (default) or alphabetically, with reverse-direction toggle
- **Country ranking integration**: 
  - Enabled `RankingType.country` as a fully implemented category (previously disabled)
  - Added `fetchRankingForCountry()` support in `RankingProvider` with `_fromCountry()` conversion method
  - Updated `RankingDisplayEntry` to include `countryCount` and `countriesVisited` fields
- **Drill-down navigation**: 
  - Country ranking rows are now tappable, navigating to the full `UserCountriesPage`
  - User position block shows visited country flags (capped at 2 lines) with a chevron indicator
  - Implemented `_VisitedCountryFlags` widget for the position block details
- **Metrics and sorting**:
  - Country view uses a single metric (country count) with no secondary metrics
  - Updated `RankingMetrics` to handle country-specific formatting and tooltips
  - Added `rankingCountryCountLabel()` pluralization for localized unit labels
- **Localization**: Added translations for "Countries visited" subtitle and country count unit labels in English, French, Japanese, and Tagalog
- **UI refinements**:
  - Renamed `carbonExplanation` to generic `details` parameter in `RankingUserPositionBlock` to support both string banners and custom widgets
  - Renamed `_CarbonExplanation` to `ExplanationDetails` for reusability
  - Added chevron icons to tappable ranking rows

## Notable Implementation Details

- Country codes are maintained in backend order (by trip count, most visited first) and only reordered client-side for display
- The `UserCountriesPage` uses `CountryDetail.fromCode()` to resolve ISO codes to localized names and flag emojis
- Sorting state is local to the drill-down page; data is never refetched
- The country ranking follows the same single-metric pattern as world-squares (no sort unit selection)

https://claude.ai/code/session_01NNVhgfePKfy18uPozthgMZ