### PR TITLE
Replace DefaultTabController with custom TabController in AboutPage

### DIFF
--- a/lib/features/about/about_page.dart
+++ b/lib/features/about/about_page.dart
@@ -6,11 +6,35 @@ import 'package:trainlog_app/features/about/privacy_tab.dart';
 import 'package:trainlog_app/platform/adaptive_button.dart';
 import 'package:trainlog_app/providers/trainlog_provider.dart';
 import 'package:trainlog_app/utils/platform_utils.dart';
+import 'package:trainlog_app/widgets/app_steps_tab_bar.dart';
 import 'package:trainlog_app/widgets/localised_markdown.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-class AboutPage extends StatelessWidget {
+class AboutPage extends StatefulWidget {
   const AboutPage({super.key});
+
+  @override
+  State<AboutPage> createState() => _AboutPageState();
+}
+
+class _AboutPageState extends State<AboutPage>
+    with SingleTickerProviderStateMixin {
+  late final TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 3, vsync: this);
+    _tabController.addListener(() {
+      if (mounted) setState(() {});
+    });
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -19,34 +43,36 @@ class AboutPage extends StatelessWidget {
     final languageCode = locale.languageCode;
     final trainlog = Provider.of<TrainlogProvider>(context, listen: false);
 
-    return DefaultTabController(
-      length: 3,
-      child: Column(
-        children: [
-          Material(
-            child: TabBar(
-              tabs: [
-                Tab(text: loc.aboutPageAboutSubPageTitle),
-                Tab(text: loc.aboutPageHowToSubPageTitle),
-                Tab(text: loc.aboutPagePrivacySubPageTitle),
-              ],
-            ),
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(8),
+          child: AppStepsTabBar(
+            fullWidth: true,
+            selectedIndex: _tabController.index,
+            onTabChanged: (i) => _tabController.animateTo(i),
+            tabs: [
+              AppStepsTab(label: loc.aboutPageAboutSubPageTitle),
+              AppStepsTab(label: loc.aboutPageHowToSubPageTitle),
+              AppStepsTab(label: loc.aboutPagePrivacySubPageTitle),
+            ],
           ),
-          Expanded(
-            child: TabBarView(
-              children: [
-                TrainlogProjectDescription(), // About Trainlog
-                SingleChildScrollView(
-                  padding: const EdgeInsets.all(16),
-                  child: LocalisedMarkdown(assetBaseName: 'howto', displayToc: false,),
-                ),
-                PrivacyHtmlTab(url: Uri.parse('${trainlog.instanceUrl}/privacy/$languageCode')),
-              ],
-            ),
+        ),
+        Expanded(
+          child: TabBarView(
+            controller: _tabController,
+            children: [
+              TrainlogProjectDescription(), // About Trainlog
+              SingleChildScrollView(
+                padding: const EdgeInsets.all(16),
+                child: LocalisedMarkdown(assetBaseName: 'howto', displayToc: false,),
+              ),
+              PrivacyHtmlTab(url: Uri.parse('${trainlog.instanceUrl}/privacy/$languageCode')),
+            ],
           ),
-          AppPlatform.bottomPadding(context),
-        ],
-      ),
+        ),
+        AppPlatform.bottomPadding(context),
+      ],
     );
   }
 }


### PR DESCRIPTION
## Summary
Refactored the AboutPage from a StatelessWidget to a StatefulWidget to use a manually managed TabController instead of DefaultTabController. Additionally, replaced the standard Material TabBar with a custom AppStepsTabBar component for improved UI consistency.

## Key Changes
- Converted `AboutPage` from `StatelessWidget` to `StatefulWidget` with `SingleTickerProviderStateMixin`
- Implemented manual `TabController` lifecycle management in `initState()` and `dispose()`
- Added state listener to `_tabController` to trigger UI updates on tab changes
- Replaced `DefaultTabController` wrapper with explicit `TabController` passed to `TabBarView`
- Replaced Material `TabBar` with custom `AppStepsTabBar` component
- Updated tab configuration to use `AppStepsTab` objects with label properties
- Removed `Material` wrapper around the tab bar
- Added padding wrapper around the new `AppStepsTabBar`
- Imported `AppStepsTabBar` widget

## Implementation Details
- The `TabController` is explicitly managed with proper disposal to prevent memory leaks
- Tab change listener calls `setState()` to keep the UI in sync with controller state
- The `AppStepsTabBar` receives `selectedIndex` and `onTabChanged` callback for two-way binding
- Layout structure remains functionally equivalent with improved visual presentation

https://claude.ai/code/session_01PhoLq9AsxkRnBo8QzuZjXw