### PR TITLE
Add optional content widget to adaptive dialogs

### DIFF
--- a/lib/features/settings/settings_page.dart
+++ b/lib/features/settings/settings_page.dart
@@ -146,16 +146,29 @@ class _SettingsPageState extends State<SettingsPage> {
     final settings = context.read<SettingsProvider>();
     final tripsProvider = context.read<TripsProvider>();
 
+    bool clearGeologs = true;
     final confirmed = await AdaptiveDialog.confirm(
       context: context,
       title: l10n.settingsCacheClearConfirmTitle,
       message: l10n.settingsCacheClearConfirmMessage,
+      content: StatefulBuilder(
+        builder: (ctx, setState) => SwitchListTile.adaptive(
+          contentPadding: EdgeInsets.zero,
+          title: Text(l10n.settingsCacheClearGeologsToggle),
+          value: clearGeologs,
+          onChanged: (value) => setState(() => clearGeologs = value),
+        ),
+      ),
       confirmLabel: l10n.settingsCacheClearButton,
       destructive: true,
     );
 
     if (confirmed) {
-      await _vm.clearCache(settings: settings, tripsProvider: tripsProvider);
+      await _vm.clearCache(
+        settings: settings,
+        tripsProvider: tripsProvider,
+        clearGeologs: clearGeologs,
+      );
       if (!mounted) return;
       AdaptiveInformationMessage.showInfo(l10n.settingsCacheClearedMessage);
     }

--- a/lib/features/settings/settings_vm.dart
+++ b/lib/features/settings/settings_vm.dart
@@ -162,6 +162,7 @@ class SettingsVm extends ChangeNotifier {
   Future<void> clearCache({
     required SettingsProvider settings,
     required TripsProvider tripsProvider,
+    bool clearGeologs = true,
   }) async {
     settings.setShouldReloadPolylines(true);
     settings.setLastFetchingTrips(forceRefreshDate.toUtc());
@@ -169,7 +170,9 @@ class SettingsVm extends ChangeNotifier {
     FlagCache.clearCache();
 
     await AppCacheFilePath.deleteFile(AppCacheFilePath.polylines);
-    await AppCacheFilePath.deleteFile(AppCacheFilePath.preRecord);
+    if (clearGeologs) {
+      await AppCacheFilePath.deleteFile(AppCacheFilePath.preRecord);
+    }
 
     refreshCacheSize();
     settings.setShouldReloadPolylines(true);

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -154,6 +154,7 @@
   "settingsCacheTitle" : "Cached data",
   "settingsCacheClearConfirmTitle": "Clear cache?",
   "settingsCacheClearConfirmMessage": "Are you sure you want to delete the cached data? This action is irreversible. The next loading of the app might take longer.",
+  "settingsCacheClearGeologsToggle": "Also clear all the Geologs",
   "settingsCacheClearedMessage": "Cache cleared successfully.",
   "settingsDisplayUserMarker": "Display current position",
   "settingsDeleteAccount": "Delete my account",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -117,6 +117,7 @@
   "settingsCacheClearButton" : "Vider",
   "settingsCacheClearConfirmTitle": "Vider le cache ?",
   "settingsCacheClearConfirmMessage": "Êtes-vous sûr de vouloir supprimer les données en cache ? Cette action est irréversible. Le prochain chargement de l'application pourra être plus long.",
+  "settingsCacheClearGeologsToggle": "Supprimer aussi tous les Géomémo",
   "settingsCacheClearedMessage": "Cache vidé avec succes.",
   "settingsDisplayUserMarker": "Afficher votre position",
   "settingsDeleteAccount": "Supprimer mon compte",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -116,6 +116,7 @@
   "settingsCacheClearButton" : "消す",
   "settingsCacheClearConfirmTitle": "キャッシュを消しますか?",
   "settingsCacheClearConfirmMessage": "キャッシュデータを削除してもよろしいですか？この操作は元に戻せません。次回のアプリの読み込みに時間がかかる可能性があります。",
+  "settingsCacheClearGeologsToggle": "すべてのジオログも削除する",
   "settingsCacheClearedMessage": "キャッシュが正常に消されました。",
   "settingsDisplayUserMarker": "現在の位置を表示する",
   "settingsDeleteAccount": "アカウントを削除する",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -804,6 +804,12 @@ abstract class AppLocalizations {
   /// **'Are you sure you want to delete the cached data? This action is irreversible. The next loading of the app might take longer.'**
   String get settingsCacheClearConfirmMessage;
 
+  /// No description provided for @settingsCacheClearGeologsToggle.
+  ///
+  /// In en, this message translates to:
+  /// **'Also clear all the Geologs'**
+  String get settingsCacheClearGeologsToggle;
+
   /// No description provided for @settingsCacheClearedMessage.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -376,6 +376,9 @@ class AppLocalizationsEn extends AppLocalizations {
       'Are you sure you want to delete the cached data? This action is irreversible. The next loading of the app might take longer.';
 
   @override
+  String get settingsCacheClearGeologsToggle => 'Also clear all the Geologs';
+
+  @override
   String get settingsCacheClearedMessage => 'Cache cleared successfully.';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -377,6 +377,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Êtes-vous sûr de vouloir supprimer les données en cache ? Cette action est irréversible. Le prochain chargement de l\'application pourra être plus long.';
 
   @override
+  String get settingsCacheClearGeologsToggle =>
+      'Supprimer aussi tous les Géomémo';
+
+  @override
   String get settingsCacheClearedMessage => 'Cache vidé avec succes.';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -367,6 +367,9 @@ class AppLocalizationsJa extends AppLocalizations {
       'キャッシュデータを削除してもよろしいですか？この操作は元に戻せません。次回のアプリの読み込みに時間がかかる可能性があります。';
 
   @override
+  String get settingsCacheClearGeologsToggle => 'すべてのジオログも削除する';
+
+  @override
   String get settingsCacheClearedMessage => 'キャッシュが正常に消されました。';
 
   @override

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -373,6 +373,10 @@ class AppLocalizationsTl extends AppLocalizations {
       'Sigurado ka bang gusto mong tanggalin ang naka-cache na data? Hindi na ito maibabalik. Maaaring mas matagal ang susunod na pag-load ng app.';
 
   @override
+  String get settingsCacheClearGeologsToggle =>
+      'Burahin din ang lahat ng Geologs';
+
+  @override
   String get settingsCacheClearedMessage => 'Nabura ang cache';
 
   @override

--- a/lib/l10n/app_tl.arb
+++ b/lib/l10n/app_tl.arb
@@ -124,6 +124,7 @@
   "settingsCacheClearButton": "Ibura",
   "settingsCacheClearConfirmTitle": "Ibura ang cache?",
   "settingsCacheClearConfirmMessage": "Sigurado ka bang gusto mong tanggalin ang naka-cache na data? Hindi na ito maibabalik. Maaaring mas matagal ang susunod na pag-load ng app.",
+  "settingsCacheClearGeologsToggle": "Burahin din ang lahat ng Geologs",
   "settingsCacheClearedMessage": "Nabura ang cache",
   "settingsDisplayUserMarker": "Ipakita ang kasalukurang lugar",
   "settingsDeleteAccount": "Ibura ang account",

--- a/lib/platform/adaptive_dialog.dart
+++ b/lib/platform/adaptive_dialog.dart
@@ -44,6 +44,9 @@ class AdaptiveDialog {
     String? title,
     required String message,
 
+    /// Optional widget displayed under the message (e.g. a toggle).
+    Widget? content,
+
     /// If null, uses loc.dialogueDefaultInfoTitle for title.
     /// If you want no title at all, pass title: "" (empty).
     List<AdaptiveDialogAction>? actions,
@@ -75,6 +78,7 @@ class AdaptiveDialog {
           context: context,
           title: resolvedTitle,
           message: message,
+          content: content,
           actions: resolvedActions,
           barrierDismissible: barrierDismissible,
         );
@@ -83,6 +87,7 @@ class AdaptiveDialog {
         context: context,
         title: resolvedTitle,
         message: message,
+        content: content,
         actions: resolvedActions,
       );
     }
@@ -91,8 +96,34 @@ class AdaptiveDialog {
       context: context,
       title: resolvedTitle,
       message: message,
+      content: content,
       actions: resolvedActions,
       barrierDismissible: barrierDismissible,
+    );
+  }
+
+  /// Message text, optionally followed by extra content underneath.
+  /// Cupertino surfaces have no Material ancestor, so the extra content is
+  /// wrapped in a transparent Material to support Material widgets (switches…).
+  static Widget _buildBody({
+    required String message,
+    required Widget? content,
+    bool wrapContentInMaterial = false,
+  }) {
+    if (content == null) return Text(message);
+
+    final extra = wrapContentInMaterial
+        ? Material(type: MaterialType.transparency, child: content)
+        : content;
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(message),
+        const SizedBox(height: 12),
+        extra,
+      ],
     );
   }
 
@@ -103,6 +134,7 @@ class AdaptiveDialog {
     required BuildContext context,
     required String title,
     required String message,
+    Widget? content,
     required List<AdaptiveDialogAction> actions,
     required bool barrierDismissible,
   }) async {
@@ -112,7 +144,7 @@ class AdaptiveDialog {
       builder: (_) {
         return AlertDialog(
           title: title.isEmpty ? null : Text(title),
-          content: Text(message),
+          content: _buildBody(message: message, content: content),
           actions: actions.map((a) {
             final isCancel = a.result == AdaptiveDialogResult.cancelled;
 
@@ -158,6 +190,7 @@ class AdaptiveDialog {
     required BuildContext context,
     required String title,
     required String message,
+    Widget? content,
     required List<AdaptiveDialogAction> actions,
   }) async {
     final result = await showCupertinoDialog<AdaptiveDialogResult>(
@@ -165,7 +198,11 @@ class AdaptiveDialog {
       builder: (_) {
         return CupertinoAlertDialog(
           title: title.isEmpty ? null : Text(title),
-          content: Text(message),
+          content: _buildBody(
+            message: message,
+            content: content,
+            wrapContentInMaterial: true,
+          ),
           actions: actions.map((a) {
             return CupertinoDialogAction(
               isDefaultAction: a.isDefault,
@@ -188,6 +225,7 @@ class AdaptiveDialog {
     required BuildContext context,
     required String title,
     required String message,
+    Widget? content,
     required List<AdaptiveDialogAction> actions,
     required bool barrierDismissible,
   }) async {
@@ -202,7 +240,11 @@ class AdaptiveDialog {
 
         return CupertinoActionSheet(
           title: title.isEmpty ? null : Text(title),
-          message: Text(message),
+          message: _buildBody(
+            message: message,
+            content: content,
+            wrapContentInMaterial: true,
+          ),
           actions: nonCancel.map((a) {
             return CupertinoActionSheetAction(
               isDestructiveAction: a.isDestructive,
@@ -229,6 +271,7 @@ class AdaptiveDialog {
     required BuildContext context,
     String? title,
     required String message,
+    Widget? content,
     String? confirmLabel,
     bool destructive = false,
     bool useActionSheetOnIOS = true,
@@ -237,6 +280,7 @@ class AdaptiveDialog {
       context: context,
       title: title,
       message: message,
+      content: content,
       useActionSheetOnIOS: useActionSheetOnIOS && destructive,
       actions: [
         AdaptiveDialogAction.cancel(context),


### PR DESCRIPTION
## Summary
This PR extends the `AdaptiveDialog` class to support optional custom content widgets displayed below the message text. This enables dialogs to include interactive elements like toggles, switches, or other Material widgets alongside the message.

## Key Changes

- **AdaptiveDialog Enhancement**: Added optional `content` parameter to `show()` and `confirm()` methods to allow custom widgets in dialog content area
- **Body Builder Method**: Introduced `_buildBody()` helper method that combines message text with optional content in a Column layout with proper spacing
- **Platform-Specific Handling**: 
  - Material dialogs use content directly
  - Cupertino dialogs wrap content in transparent Material to support Material widgets (e.g., switches) on iOS
- **Settings Cache Clear Dialog**: Implemented practical use case with a toggle switch to optionally clear Geologs data separately from other cache
- **Localization**: Added `settingsCacheClearGeologsToggle` string key with translations for English, French, Japanese, and Tagalog

## Implementation Details

- The `_buildBody()` method handles both simple message-only and message-with-content scenarios
- Cupertino surfaces receive `wrapContentInMaterial: true` to ensure Material widgets render correctly without a Material ancestor
- The settings view model's `clearCache()` method now accepts a `clearGeologs` parameter to conditionally delete the preRecord cache file
- All three dialog types (Material AlertDialog, Cupertino AlertDialog, and Cupertino ActionSheet) support the new content parameter

https://claude.ai/code/session_01MFYxc8urn7LaaKKLHRgKLm