### PR TITLE
Redesign station endpoint fields to match details step styling

### DIFF
--- a/lib/features/trips_add/steps/add_trip_route_step.dart
+++ b/lib/features/trips_add/steps/add_trip_route_step.dart
@@ -98,8 +98,9 @@ class AddTripRouteStep extends StatelessWidget {
   }
 }
 
-/// One departure/arrival block: header with timeline marker, label and mode
-/// tab bar; station fields; and the mini map underneath.
+/// One departure/arrival grouped card, in the style of the details step:
+/// a header row with timeline marker, label and mode tab bar, then the
+/// station line items and the mini map, separated by hairline dividers.
 class _EndpointBlock extends StatefulWidget {
   const _EndpointBlock({
     required this.isDeparture,
@@ -150,7 +151,6 @@ class _EndpointBlockState extends State<_EndpointBlock> {
     final label = isDeparture ? loc.addTripDeparture : loc.addTripArrival;
 
     return Container(
-      padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
         color: theme.cardColor,
         borderRadius: BorderRadius.circular(16),
@@ -160,41 +160,54 @@ class _EndpointBlockState extends State<_EndpointBlock> {
               : theme.colorScheme.outline,
         ),
       ),
+      clipBehavior: Clip.antiAlias,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Row(
-            children: [
-              _TimelineMarker(
-                  colour: widget.markerColour, filled: !isDeparture),
-              const SizedBox(width: 8),
-              Expanded(
-                child: Text(
-                  label.toUpperCase(),
-                  style: theme.textTheme.labelSmall?.copyWith(
-                    color: theme.colorScheme.onSurfaceVariant,
-                    fontWeight: FontWeight.w600,
-                    letterSpacing: 1.2,
+          // Title row: marker, DEPARTURE/ARRIVAL and the mode toggle.
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 12, 12, 12),
+            child: Row(
+              children: [
+                _TimelineMarker(
+                    colour: widget.markerColour, filled: !isDeparture),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    label.toUpperCase(),
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                      fontWeight: FontWeight.w600,
+                      letterSpacing: 1.2,
+                    ),
                   ),
                 ),
-              ),
-              const SizedBox(width: 8),
-              AppStepsTabBar(
-                tabs: [
-                  AppStepsTab(label: loc.addTripModeByName),
-                  AppStepsTab(label: loc.addTripModeManual),
-                ],
-                selectedIndex: _geoMode ? 1 : 0,
-                onTabChanged: (index) =>
-                    _fieldsKey.currentState?.setMode(index == 1),
-              ),
-            ],
+                const SizedBox(width: 8),
+                AppStepsTabBar(
+                  tabs: [
+                    AppStepsTab(label: loc.addTripModeByName),
+                    AppStepsTab(label: loc.addTripModeManual),
+                  ],
+                  selectedIndex: _geoMode ? 1 : 0,
+                  onTabChanged: (index) =>
+                      _fieldsKey.currentState?.setMode(index == 1),
+                ),
+              ],
+            ),
           ),
-          const SizedBox(height: 12),
+          Divider(height: 1, color: theme.dividerColor),
           _stationFields(context, loc),
-          const SizedBox(height: 12),
-          _miniMap(loc),
-          ..._miniMapHelper(loc, theme),
+          Divider(height: 1, color: theme.dividerColor),
+          Padding(
+            padding: const EdgeInsets.all(12),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _miniMap(loc),
+                ..._miniMapHelper(loc, theme),
+              ],
+            ),
+          ),
         ],
       ),
     );

--- a/lib/features/trips_add/widgets/station_endpoint_fields.dart
+++ b/lib/features/trips_add/widgets/station_endpoint_fields.dart
@@ -12,7 +12,11 @@ import 'package:trainlog_app/features/trips_add/widgets/full_screen_search_overl
 /// Renders either the by-name search field (read-only; tapping opens the
 /// full-screen suggestion overlay) with the resolved address underneath, or
 /// the manual fields (name with a label icon, then monospaced latitude /
-/// longitude inputs). Unlike the deprecated StationFieldsSwitcher, the mode
+/// longitude inputs). Each field carries the wizard's uppercase micro-label
+/// above it (matching the line items of the details / ticket / when steps)
+/// instead of a floating Material label; the leading icon is tinted with the
+/// primary colour once the field has a value, like everywhere else in the
+/// wizard. Unlike the deprecated StationFieldsSwitcher, the mode
 /// toggle UI lives in the parent (an AppStepsTabBar in the block header),
 /// which calls [StationEndpointFieldsState.setMode] through a [GlobalKey];
 /// the mode-switching behaviour itself is identical to the old widget.
@@ -80,15 +84,37 @@ class StationEndpointFieldsState extends State<StationEndpointFields> {
 
   Timer? _debounceTimer;
 
-  /// Compact field decoration following the app guidelines (dense fields with
-  /// the label inside the decoration).
-  InputDecoration _decoration(String label, {Widget? prefixIcon}) {
+  /// Compact field decoration following the app guidelines: dense fields
+  /// with a hint inside; the title is rendered above via [_fieldLabel].
+  InputDecoration _decoration({String? hint, Widget? prefixIcon}) {
     return InputDecoration(
-      labelText: label,
+      hintText: hint,
       prefixIcon: prefixIcon,
       isDense: true,
       contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
     );
+  }
+
+  /// Uppercase micro-label above a field, matching the line-item labels of
+  /// the other wizard steps.
+  Widget _fieldLabel(String text) {
+    final theme = Theme.of(context);
+    return Text(
+      text.toUpperCase(),
+      style: theme.textTheme.labelSmall?.copyWith(
+        color: theme.colorScheme.onSurfaceVariant,
+        fontWeight: FontWeight.w600,
+        letterSpacing: 1.2,
+      ),
+    );
+  }
+
+  /// Leading icon colour: primary once the field has a value, muted
+  /// otherwise — same behaviour as the detail and ticket line items.
+  Color _iconColour(ThemeData theme, bool hasValue) {
+    return hasValue
+        ? theme.colorScheme.primary
+        : theme.colorScheme.onSurfaceVariant;
   }
 
   // ------------------------------
@@ -361,6 +387,11 @@ class StationEndpointFieldsState extends State<StationEndpointFields> {
     final theme = Theme.of(context);
     final monoStyle = AppTheme.monoFont.copyWith(
       fontSize: 14,
+      fontWeight: FontWeight.w700,
+      color: theme.colorScheme.onSurface,
+    );
+    final valueStyle = theme.textTheme.bodyMedium?.copyWith(
+      fontWeight: FontWeight.w600,
       color: theme.colorScheme.onSurface,
     );
 
@@ -369,13 +400,19 @@ class StationEndpointFieldsState extends State<StationEndpointFields> {
       key: const ValueKey('name-mode'),
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
+        _fieldLabel(loc.nameField),
+        const SizedBox(height: 6),
         TextFormField(
           controller: _nameCtl,
           readOnly: true,
           onTap: _openOverlay,
+          style: valueStyle,
           decoration: _decoration(
-            loc.nameField,
-            prefixIcon: const Icon(Icons.search),
+            hint: loc.searchStationHint(widget.vehicleType.name),
+            prefixIcon: Icon(
+              Icons.search,
+              color: _iconColour(theme, _nameCtl.text.isNotEmpty),
+            ),
           ),
         ),
         const SizedBox(height: 8),
@@ -407,43 +444,70 @@ class StationEndpointFieldsState extends State<StationEndpointFields> {
     // ---------------- MANUAL MODE ------------------
     final geoMode = Column(
       key: const ValueKey('geo-mode'),
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
+        _fieldLabel(loc.nameField),
+        const SizedBox(height: 6),
         TextFormField(
           controller: _manualNameCtl,
+          style: valueStyle,
           decoration: _decoration(
-            widget.manualNameFieldHint,
-            prefixIcon: const Icon(Icons.label_outline),
+            hint: widget.manualNameFieldHint,
+            prefixIcon: Icon(
+              Icons.label_outline,
+              color: _iconColour(theme, _manualNameCtl.text.isNotEmpty),
+            ),
           ),
-          onChanged: (_) => _emitValues(),
+          onChanged: (_) {
+            setState(() {});
+            _emitValues();
+          },
         ),
         const SizedBox(height: 12),
         Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Expanded(
-              child: TextFormField(
-                controller: _latCtl,
-                style: monoStyle,
-                keyboardType:
-                    const TextInputType.numberWithOptions(decimal: true),
-                decoration: _decoration(loc.addTripLatitudeShort),
-                inputFormatters: [
-                  FilteringTextInputFormatter.allow(RegExp(r'^-?\d*\.?\d*$')),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _fieldLabel(loc.addTripLatitudeShort),
+                  const SizedBox(height: 6),
+                  TextFormField(
+                    controller: _latCtl,
+                    style: monoStyle,
+                    keyboardType:
+                        const TextInputType.numberWithOptions(decimal: true),
+                    decoration: _decoration(),
+                    inputFormatters: [
+                      FilteringTextInputFormatter.allow(
+                          RegExp(r'^-?\d*\.?\d*$')),
+                    ],
+                    onChanged: (_) => _emitValues(),
+                  ),
                 ],
-                onChanged: (_) => _emitValues(),
               ),
             ),
             const SizedBox(width: 12),
             Expanded(
-              child: TextFormField(
-                controller: _longCtl,
-                style: monoStyle,
-                keyboardType:
-                    const TextInputType.numberWithOptions(decimal: true),
-                decoration: _decoration(loc.addTripLongitudeShort),
-                inputFormatters: [
-                  FilteringTextInputFormatter.allow(RegExp(r'^-?\d*\.?\d*$')),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _fieldLabel(loc.addTripLongitudeShort),
+                  const SizedBox(height: 6),
+                  TextFormField(
+                    controller: _longCtl,
+                    style: monoStyle,
+                    keyboardType:
+                        const TextInputType.numberWithOptions(decimal: true),
+                    decoration: _decoration(),
+                    inputFormatters: [
+                      FilteringTextInputFormatter.allow(
+                          RegExp(r'^-?\d*\.?\d*$')),
+                    ],
+                    onChanged: (_) => _emitValues(),
+                  ),
                 ],
-                onChanged: (_) => _emitValues(),
               ),
             ),
           ],

--- a/lib/features/trips_add/widgets/station_endpoint_fields.dart
+++ b/lib/features/trips_add/widgets/station_endpoint_fields.dart
@@ -539,17 +539,26 @@ class StationEndpointFieldsState extends State<StationEndpointFields> {
           ),
         ),
         Divider(height: 1, color: theme.dividerColor),
-        // LAT/LONG double cell with a vertical separation. A fixed-height
-        // separator keeps the cells at their natural, compact height
-        // (IntrinsicHeight would let the text fields inflate the row).
-        Row(
+        // LAT/LONG double cell. The separator is layered behind the row so
+        // it always spans the row's natural height (IntrinsicHeight would
+        // let the text fields inflate the cells instead).
+        Stack(
           children: [
-            Expanded(
-              child: _coordCell(loc.addTripLatitudeShort, _latCtl),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(
+                  child: _coordCell(loc.addTripLatitudeShort, _latCtl),
+                ),
+                Expanded(
+                  child: _coordCell(loc.addTripLongitudeShort, _longCtl),
+                ),
+              ],
             ),
-            Container(width: 1, height: 44, color: theme.dividerColor),
-            Expanded(
-              child: _coordCell(loc.addTripLongitudeShort, _longCtl),
+            Positioned.fill(
+              child: Center(
+                child: Container(width: 1, color: theme.dividerColor),
+              ),
             ),
           ],
         ),

--- a/lib/features/trips_add/widgets/station_endpoint_fields.dart
+++ b/lib/features/trips_add/widgets/station_endpoint_fields.dart
@@ -9,14 +9,15 @@ import 'package:trainlog_app/features/trips_add/widgets/full_screen_search_overl
 
 /// Departure/arrival station fields of the "Add Trip" route step.
 ///
-/// Renders either the by-name search field (read-only; tapping opens the
-/// full-screen suggestion overlay) with the resolved address underneath, or
-/// the manual fields (name with a label icon, then monospaced latitude /
-/// longitude inputs). Each field carries the wizard's uppercase micro-label
-/// above it (matching the line items of the details / ticket / when steps)
-/// instead of a floating Material label; the leading icon is tinted with the
-/// primary colour once the field has a value, like everywhere else in the
-/// wizard. Unlike the deprecated StationFieldsSwitcher, the mode
+/// Renders the middle rows of an endpoint card as grouped-card line items in
+/// the style of the details step tiles: leading icon (tinted with the
+/// primary colour once the row has a value), uppercase micro-label and a
+/// borderless value underneath. In by-name mode that is a tappable row
+/// opening the full-screen suggestion overlay, with the resolved address as
+/// plain text below; in manual mode a free-text name row and a divided
+/// double cell with the monospaced latitude / longitude inputs. The parent
+/// card draws the hairline dividers around this widget. Unlike the
+/// deprecated StationFieldsSwitcher, the mode
 /// toggle UI lives in the parent (an AppStepsTabBar in the block header),
 /// which calls [StationEndpointFieldsState.setMode] through a [GlobalKey];
 /// the mode-switching behaviour itself is identical to the old widget.
@@ -84,18 +85,20 @@ class StationEndpointFieldsState extends State<StationEndpointFields> {
 
   Timer? _debounceTimer;
 
-  /// Compact field decoration following the app guidelines: dense fields
-  /// with a hint inside; the title is rendered above via [_fieldLabel].
-  InputDecoration _decoration({String? hint, Widget? prefixIcon}) {
+  /// Borderless collapsed decoration for inputs living inside a card line
+  /// item, matching the details step tiles.
+  InputDecoration _lineItemDecoration({String? hint}) {
     return InputDecoration(
+      isCollapsed: true,
+      filled: false,
+      border: InputBorder.none,
+      enabledBorder: InputBorder.none,
+      focusedBorder: InputBorder.none,
       hintText: hint,
-      prefixIcon: prefixIcon,
-      isDense: true,
-      contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
     );
   }
 
-  /// Uppercase micro-label above a field, matching the line-item labels of
+  /// Uppercase micro-label above a value, matching the line-item labels of
   /// the other wizard steps.
   Widget _fieldLabel(String text) {
     final theme = Theme.of(context);
@@ -379,64 +382,137 @@ class StationEndpointFieldsState extends State<StationEndpointFields> {
   }
 
   // ------------------------------
+  // Line-item building blocks (details step tile style)
+  // ------------------------------
+
+  /// One card line item: leading icon, uppercase label and the value widget
+  /// underneath. Optionally tappable across the whole row.
+  Widget _lineItem({
+    required IconData icon,
+    required bool hasValue,
+    required String label,
+    required Widget child,
+    VoidCallback? onTap,
+  }) {
+    final theme = Theme.of(context);
+
+    final content = Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      child: Row(
+        children: [
+          Icon(icon, size: 18, color: _iconColour(theme, hasValue)),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _fieldLabel(label),
+                const SizedBox(height: 4),
+                child,
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+
+    if (onTap == null) return content;
+    return InkWell(onTap: onTap, child: content);
+  }
+
+  /// One half of the LAT/LONG double cell: uppercase label above a
+  /// borderless monospaced coordinate input.
+  Widget _coordCell(String label, TextEditingController controller) {
+    final theme = Theme.of(context);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _fieldLabel(label),
+          const SizedBox(height: 4),
+          TextFormField(
+            controller: controller,
+            style: AppTheme.monoFont.copyWith(
+              fontSize: 16,
+              fontWeight: FontWeight.w700,
+              color: theme.colorScheme.onSurface,
+            ),
+            keyboardType: const TextInputType.numberWithOptions(decimal: true),
+            decoration: _lineItemDecoration(),
+            inputFormatters: [
+              FilteringTextInputFormatter.allow(RegExp(r'^-?\d*\.?\d*$')),
+            ],
+            onChanged: (_) => _emitValues(),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // ------------------------------
   // Build UI
   // ------------------------------
   @override
   Widget build(BuildContext context) {
     final loc = AppLocalizations.of(context)!;
     final theme = Theme.of(context);
-    final monoStyle = AppTheme.monoFont.copyWith(
-      fontSize: 14,
-      fontWeight: FontWeight.w700,
-      color: theme.colorScheme.onSurface,
-    );
-    final valueStyle = theme.textTheme.bodyMedium?.copyWith(
+    final valueStyle = theme.textTheme.titleMedium?.copyWith(
       fontWeight: FontWeight.w600,
-      color: theme.colorScheme.onSurface,
     );
 
     // ---------------- BY NAME MODE ------------------
+    final hasStation = _nameCtl.text.isNotEmpty;
     final nameMode = Column(
       key: const ValueKey('name-mode'),
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        _fieldLabel(loc.nameField),
-        const SizedBox(height: 6),
-        TextFormField(
-          controller: _nameCtl,
-          readOnly: true,
+        // Tappable station row opening the search overlay.
+        _lineItem(
+          icon: Icons.search,
+          hasValue: hasStation,
+          label: loc.nameField,
           onTap: _openOverlay,
-          style: valueStyle,
-          decoration: _decoration(
-            hint: loc.searchStationHint(widget.vehicleType.name),
-            prefixIcon: Icon(
-              Icons.search,
-              color: _iconColour(theme, _nameCtl.text.isNotEmpty),
+          child: Text(
+            hasStation
+                ? _nameCtl.text
+                : loc.searchStationHint(widget.vehicleType.name),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: valueStyle?.copyWith(
+              color: hasStation
+                  ? theme.colorScheme.onSurface
+                  : theme.colorScheme.onSurfaceVariant,
             ),
           ),
         ),
-        const SizedBox(height: 8),
-        // Space for the resolved address of the selected station.
-        Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Icon(
-              Icons.place_outlined,
-              size: 14,
-              color: theme.colorScheme.onSurfaceVariant,
-            ),
-            const SizedBox(width: 6),
-            Expanded(
-              child: Text(
-                _currentAddress.isEmpty
-                    ? widget.addressDefaultText
-                    : _currentAddress,
-                style: theme.textTheme.bodySmall?.copyWith(
-                  color: theme.colorScheme.onSurfaceVariant,
+        // Resolved address: plain annotation text, aligned with the value
+        // column, clearly not a field.
+        Padding(
+          padding: const EdgeInsets.fromLTRB(46, 0, 16, 12),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Icon(
+                Icons.place_outlined,
+                size: 14,
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+              const SizedBox(width: 6),
+              Expanded(
+                child: Text(
+                  _currentAddress.isEmpty
+                      ? widget.addressDefaultText
+                      : _currentAddress,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                    fontStyle: FontStyle.italic,
+                  ),
                 ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ],
     );
@@ -446,71 +522,35 @@ class StationEndpointFieldsState extends State<StationEndpointFields> {
       key: const ValueKey('geo-mode'),
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        _fieldLabel(loc.nameField),
-        const SizedBox(height: 6),
-        TextFormField(
-          controller: _manualNameCtl,
-          style: valueStyle,
-          decoration: _decoration(
-            hint: widget.manualNameFieldHint,
-            prefixIcon: Icon(
-              Icons.label_outline,
-              color: _iconColour(theme, _manualNameCtl.text.isNotEmpty),
-            ),
+        _lineItem(
+          icon: Icons.label_outline,
+          hasValue: _manualNameCtl.text.isNotEmpty,
+          label: loc.nameField,
+          child: TextFormField(
+            controller: _manualNameCtl,
+            style: valueStyle,
+            decoration: _lineItemDecoration(hint: widget.manualNameFieldHint),
+            onChanged: (_) {
+              setState(() {});
+              _emitValues();
+            },
           ),
-          onChanged: (_) {
-            setState(() {});
-            _emitValues();
-          },
         ),
-        const SizedBox(height: 12),
-        Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  _fieldLabel(loc.addTripLatitudeShort),
-                  const SizedBox(height: 6),
-                  TextFormField(
-                    controller: _latCtl,
-                    style: monoStyle,
-                    keyboardType:
-                        const TextInputType.numberWithOptions(decimal: true),
-                    decoration: _decoration(),
-                    inputFormatters: [
-                      FilteringTextInputFormatter.allow(
-                          RegExp(r'^-?\d*\.?\d*$')),
-                    ],
-                    onChanged: (_) => _emitValues(),
-                  ),
-                ],
+        Divider(height: 1, color: theme.dividerColor),
+        // LAT/LONG double cell with a vertical separation.
+        IntrinsicHeight(
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Expanded(
+                child: _coordCell(loc.addTripLatitudeShort, _latCtl),
               ),
-            ),
-            const SizedBox(width: 12),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  _fieldLabel(loc.addTripLongitudeShort),
-                  const SizedBox(height: 6),
-                  TextFormField(
-                    controller: _longCtl,
-                    style: monoStyle,
-                    keyboardType:
-                        const TextInputType.numberWithOptions(decimal: true),
-                    decoration: _decoration(),
-                    inputFormatters: [
-                      FilteringTextInputFormatter.allow(
-                          RegExp(r'^-?\d*\.?\d*$')),
-                    ],
-                    onChanged: (_) => _emitValues(),
-                  ),
-                ],
+              VerticalDivider(width: 1, color: theme.dividerColor),
+              Expanded(
+                child: _coordCell(loc.addTripLongitudeShort, _longCtl),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ],
     );

--- a/lib/features/trips_add/widgets/station_endpoint_fields.dart
+++ b/lib/features/trips_add/widgets/station_endpoint_fields.dart
@@ -404,6 +404,7 @@ class StationEndpointFieldsState extends State<StationEndpointFields> {
           const SizedBox(width: 12),
           Expanded(
             child: Column(
+              mainAxisSize: MainAxisSize.min,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 _fieldLabel(label),
@@ -428,6 +429,7 @@ class StationEndpointFieldsState extends State<StationEndpointFields> {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
       child: Column(
+        mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           _fieldLabel(label),
@@ -537,20 +539,19 @@ class StationEndpointFieldsState extends State<StationEndpointFields> {
           ),
         ),
         Divider(height: 1, color: theme.dividerColor),
-        // LAT/LONG double cell with a vertical separation.
-        IntrinsicHeight(
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              Expanded(
-                child: _coordCell(loc.addTripLatitudeShort, _latCtl),
-              ),
-              VerticalDivider(width: 1, color: theme.dividerColor),
-              Expanded(
-                child: _coordCell(loc.addTripLongitudeShort, _longCtl),
-              ),
-            ],
-          ),
+        // LAT/LONG double cell with a vertical separation. A fixed-height
+        // separator keeps the cells at their natural, compact height
+        // (IntrinsicHeight would let the text fields inflate the row).
+        Row(
+          children: [
+            Expanded(
+              child: _coordCell(loc.addTripLatitudeShort, _latCtl),
+            ),
+            Container(width: 1, height: 44, color: theme.dividerColor),
+            Expanded(
+              child: _coordCell(loc.addTripLongitudeShort, _longCtl),
+            ),
+          ],
         ),
       ],
     );


### PR DESCRIPTION
## Summary
Refactored the station endpoint fields UI in the "Add Trip" route step to adopt the grouped card line-item styling used in the details step, creating visual consistency across the wizard.

## Key Changes

- **Updated `StationEndpointFields` widget**:
  - Replaced compact field decorations with borderless `_lineItemDecoration()` for inputs inside card line items
  - Added `_fieldLabel()` helper to render uppercase micro-labels matching other wizard steps
  - Added `_iconColour()` helper to tint leading icons based on field value state (primary when filled, muted otherwise)
  - Introduced `_lineItem()` building block for consistent card line item layout with leading icon, label, and value widget
  - Introduced `_coordCell()` building block for latitude/longitude coordinate inputs with monospaced font

- **Refactored by-name mode**:
  - Converted search field to a tappable line item with icon and label
  - Moved resolved address display below as plain annotation text (italic, muted color)
  - Improved visual hierarchy and interaction affordance

- **Refactored manual mode**:
  - Wrapped manual name field in a line item with label icon
  - Redesigned LAT/LONG inputs as a divided double cell with shared vertical divider
  - Both cells now use the line-item styling with uppercase labels and borderless inputs

- **Updated `_EndpointBlock` container**:
  - Removed uniform padding in favor of per-section padding for better control
  - Added `clipBehavior: Clip.antiAlias` for proper border radius clipping
  - Replaced spacing with `Divider` widgets to create hairline separators between sections
  - Adjusted title row padding and wrapped mini map section in its own padded container
  - Maintained grouped card appearance with consistent border styling

## Implementation Details

- All field decorations now use `isCollapsed: true` and `InputBorder.none` for seamless integration into card line items
- Icon colors dynamically respond to field state, providing visual feedback without additional UI elements
- Coordinate inputs maintain monospaced font styling for better readability of numeric values
- The parent card now manages all visual separation through dividers, creating a cleaner, more modular structure

https://claude.ai/code/session_015bYDqUj2sHVYnnGo6HRYsb