### PR TITLE
Add landing page preference to settings

### DIFF
--- a/lib/features/settings/settings_page.dart
+++ b/lib/features/settings/settings_page.dart
@@ -283,6 +283,18 @@ class _SettingsPageState extends State<SettingsPage> {
         )
         .label;
 
+    final landingPageOptions = [
+      (label: l10n.menuMapTitle, value: LandingPage.map),
+      (label: l10n.menuTripsTitle, value: LandingPage.trips),
+    ];
+
+    final landingPageName = landingPageOptions
+        .firstWhere(
+          (o) => o.value == settings.landingPage,
+          orElse: () => landingPageOptions.first,
+        )
+        .label;
+
     return SettingsGroup(children: [
       _ThemeRow(
         icon: AdaptiveIcons.theme,
@@ -357,6 +369,18 @@ class _SettingsPageState extends State<SettingsPage> {
           options: radiusOptions,
           selected: settings.sprRadius,
           onChanged: settings.setSprRadius,
+        ),
+      ),
+      SettingsTile(
+        icon: AdaptiveIcons.landingPage,
+        title: l10n.settingsLandingPage,
+        trailing: _chevronTrailing(ctx, landingPageName),
+        onTap: () => _showPicker<LandingPage>(
+          context: ctx,
+          title: l10n.settingsLandingPage,
+          options: landingPageOptions,
+          selected: settings.landingPage,
+          onChanged: settings.setLandingPage,
         ),
       ),
     ]);

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -130,6 +130,7 @@
   "settingsExampleShort": "Ex:",
   "settingsCurrency": "Default Currency",
   "settingsSprRadius": "Maximum radius for station search in Geolog",
+  "settingsLandingPage": "Landing page",
   "settingsSystem": "System",
   "settingsMapPathDisplayOrder": "Order of trip paths on the map",
   "settingMapPathDisplayOrderByCreation": "By creation date",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -99,6 +99,7 @@
   "settingsExampleShort": "Ex :",
   "settingsCurrency": "Devise par défaut",
   "settingsSprRadius": "Rayon maximum pour la recherche de gare dans Géomémo",
+  "settingsLandingPage": "Page de démarrage",
   "settingsSystem": "Système",
   "settingsMapPathDisplayOrder": "Ordre des trajets sur la carte",
   "settingMapPathDisplayOrderByCreation": "Par date de création",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -99,6 +99,7 @@
   "settingsExampleShort": "例:",
   "settingsCurrency": "デフォルト通貨",
   "settingsSprRadius": "ジオログの駅検索の最大半径",
+  "settingsLandingPage": "起動時のページ",
   "settingsSystem": "システム",
   "settingsMapPathDisplayOrder": "地図上の経路の表示順",
   "settingMapPathDisplayOrderByCreation": "作成日順",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -696,6 +696,12 @@ abstract class AppLocalizations {
   /// **'Maximum radius for station search in Geolog'**
   String get settingsSprRadius;
 
+  /// No description provided for @settingsLandingPage.
+  ///
+  /// In en, this message translates to:
+  /// **'Landing page'**
+  String get settingsLandingPage;
+
   /// No description provided for @settingsSystem.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -317,6 +317,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settingsSprRadius => 'Maximum radius for station search in Geolog';
 
   @override
+  String get settingsLandingPage => 'Landing page';
+
+  @override
   String get settingsSystem => 'System';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -319,6 +319,9 @@ class AppLocalizationsFr extends AppLocalizations {
       'Rayon maximum pour la recherche de gare dans Géomémo';
 
   @override
+  String get settingsLandingPage => 'Page de démarrage';
+
+  @override
   String get settingsSystem => 'Système';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -310,6 +310,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settingsSprRadius => 'ジオログの駅検索の最大半径';
 
   @override
+  String get settingsLandingPage => '起動時のページ';
+
+  @override
   String get settingsSystem => 'システム';
 
   @override

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -312,6 +312,9 @@ class AppLocalizationsTl extends AppLocalizations {
       'Pinakamalaking radius para sa paghahanap ng istasyon sa Geolog';
 
   @override
+  String get settingsLandingPage => 'Panimulang pahina';
+
+  @override
   String get settingsSystem => 'Sistema';
 
   @override

--- a/lib/l10n/app_tl.arb
+++ b/lib/l10n/app_tl.arb
@@ -101,6 +101,7 @@
   "settingsExampleShort": "Hal:",
   "settingsCurrency": "Default currency",
   "settingsSprRadius": "Pinakamalaking radius para sa paghahanap ng istasyon sa Geolog",
+  "settingsLandingPage": "Panimulang pahina",
   "settingsSystem": "Sistema",
   "settingsMapPathDisplayOrder": "Ayos ng mga ruta ng biyahe sa mapa",
   "settingMapPathDisplayOrderByCreation": "Ayusin ayon sa petsa ng paglikha",

--- a/lib/navigation/cupertino_shell.dart
+++ b/lib/navigation/cupertino_shell.dart
@@ -1,12 +1,14 @@
 // cupertino_shell.dart
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart' show Icon, PageRouteBuilder, Scaffold, Theme;
+import 'package:provider/provider.dart';
 import 'package:trainlog_app/l10n/app_localizations.dart';
 import 'package:trainlog_app/navigation/nav_models.dart';
 import 'package:trainlog_app/platform/adaptive_app_bar.dart';
 import 'package:trainlog_app/platform/adaptive_bottom_navbar.dart'
     show AdaptiveBottomNavBar, kNavBarClearance;
 import 'package:trainlog_app/platform/cupertino_fab.dart';
+import 'package:trainlog_app/providers/settings_provider.dart';
 import 'package:trainlog_app/utils/platform_utils.dart';
 
 import 'package:trainlog_app/features/about/about_page.dart';
@@ -43,6 +45,15 @@ class _CupertinoShellState extends State<CupertinoShell> {
     GlobalKey<NavigatorState>(),
     GlobalKey<NavigatorState>(),
   ];
+
+  @override
+  void initState() {
+    super.initState();
+    _currentIndex =
+        context.read<SettingsProvider>().landingPage == LandingPage.trips
+            ? 1
+            : 0;
+  }
 
   void _onTabTapped(int index) {
     if (index == _currentIndex) {

--- a/lib/navigation/material_shell.dart
+++ b/lib/navigation/material_shell.dart
@@ -1,8 +1,10 @@
 // material_shell.dart
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:provider/provider.dart';
 import 'package:trainlog_app/l10n/app_localizations.dart';
 import 'package:trainlog_app/navigation/nav_models.dart';
+import 'package:trainlog_app/providers/settings_provider.dart';
 import 'package:trainlog_app/features/settings/settings_page.dart';
 import 'package:trainlog_app/platform/adaptive_app_bar.dart';
 import 'package:trainlog_app/platform/adaptive_bottom_navbar.dart';
@@ -129,6 +131,11 @@ class _MaterialShellState extends State<MaterialShell> {
   @override
   void initState() {
     super.initState();
+    _selectedIndex =
+        context.read<SettingsProvider>().landingPage == LandingPage.trips
+            ? 1
+            : 0;
+    _previousBottomIndex = _selectedIndex;
     _pageController = PageController(initialPage: _selectedIndex);
 
     _pages = [

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -17,6 +17,11 @@ enum PathDisplayOrder {
   tripDatePlaneOver,
 }
 
+enum LandingPage {
+  map,
+  trips,
+}
+
 class SettingsProvider with ChangeNotifier {
   ThemeMode _themeMode = ThemeMode.system;
   Locale _locale = const Locale('en');
@@ -29,6 +34,7 @@ class SettingsProvider with ChangeNotifier {
   bool _hideWarningMessage = false;
   String _currency = "EUR";
   int _sprRadius = 500;
+  LandingPage _landingPage = LandingPage.map;
   String _userInstanceUrl = ""; // Cannot be changed in settings, only on login page before login, and only if not authenticated yet.
 
   // _SP members are stored in the Shared Preferences only, they cannot be modified by the user in settings
@@ -71,6 +77,7 @@ class SettingsProvider with ChangeNotifier {
   bool get hideWarningMessage => _hideWarningMessage;
   String get currency => _currency;
   int get sprRadius => _sprRadius;
+  LandingPage get landingPage => _landingPage;
   String get userInstanceUrl => _userInstanceUrl;
 
   bool get onboardingCompleted => _SP_onboardingCompleted;
@@ -127,6 +134,7 @@ class SettingsProvider with ChangeNotifier {
       _loadHideWarningMessage,
       _loadCurrency,
       _loadSprRadius,
+      _loadLandingPage,
       _loadUserInstanceUrl,
 
       // Shared Preference only (_SP) i.e. internal to the app
@@ -356,6 +364,28 @@ class SettingsProvider with ChangeNotifier {
     _sprRadius = sprRadius;
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt('spr_radius', sprRadius);
+    notifyListeners();
+  }
+
+  // ------------------------------------------------------------------------------
+
+  void _loadLandingPage(SharedPreferences prefs) {
+    final page = prefs.getString('landing_page');
+    if (page != null) {
+      _landingPage = LandingPage.values.firstWhere(
+        (e) => e.name == page,
+        orElse: () => LandingPage.map,
+      );
+    } else {
+      _landingPage = LandingPage.map;
+    }
+  }
+
+  void setLandingPage(LandingPage page) async {
+    if (_landingPage == page) return;
+    _landingPage = page;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('landing_page', page.name);
     notifyListeners();
   }
 

--- a/lib/utils/platform_utils.dart
+++ b/lib/utils/platform_utils.dart
@@ -75,6 +75,7 @@ class AdaptiveIcons {
   static final IconData hour =        isA ? CupertinoIcons.clock : Icons.watch;
   static final IconData currency =    isA ? CupertinoIcons.money_dollar_circle : Icons.currency_exchange;
   static final IconData radar =       isA ? CupertinoIcons.location_circle : Icons.radar;
+  static final IconData landingPage = isA ? CupertinoIcons.house : Icons.home;
   static final IconData warningMsg =  isA ? CupertinoIcons.exclamationmark_triangle : Icons.warning;
   static final IconData layers =      isA ? CupertinoIcons.layers : Icons.layers;
   static final IconData palette =     isA ? CupertinoIcons.paintbrush : Icons.palette;


### PR DESCRIPTION
## Summary
This PR adds a new user preference to allow users to choose which page (Map or Trips) loads when the app starts, instead of always defaulting to the Map page.

## Key Changes
- **New enum `LandingPage`**: Added to `settings_provider.dart` with two options: `map` and `trips`
- **Settings persistence**: 
  - Added `_landingPage` field to `SettingsProvider` with default value of `LandingPage.map`
  - Implemented `_loadLandingPage()` to load preference from SharedPreferences
  - Implemented `setLandingPage()` to persist user selection
- **Settings UI**: Added new settings tile in `settings_page.dart` with a picker to select the landing page
- **Navigation initialization**: Updated both `material_shell.dart` and `cupertino_shell.dart` to read the landing page preference in `initState()` and set the initial tab/page accordingly
- **Localization**: Added `settingsLandingPage` translation key across all supported languages (English, French, Japanese, Tagalog)
- **Icon**: Added `landingPage` icon to `AdaptiveIcons` using platform-appropriate icons (house for Cupertino, home for Material)

## Implementation Details
- The landing page preference is stored in SharedPreferences with key `'landing_page'`
- Default behavior remains unchanged (Map page) for users who haven't set a preference
- The preference is applied at app startup by initializing the correct tab index in the shell navigation widgets
- All localization strings have been added to the `.arb` files and generated into the localization classes

https://claude.ai/code/session_01MPuRrnDWgjBTfibH48mQjT