### PR TITLE
Add changelog dialog to display release notes on app updates

### DIFF
--- a/assets/changelog/changelog_en.yaml
+++ b/assets/changelog/changelog_en.yaml
@@ -1,0 +1,8 @@
+changelog_en:
+  - version: 0.4.1
+    date: 2026-07-21
+    changes:
+      - type: feature
+        text: Option to change the landing page in the settings.
+      - type: feature
+        text: Changelog feature to display the last change from the previous update.

--- a/assets/changelog/changelog_fr.yaml
+++ b/assets/changelog/changelog_fr.yaml
@@ -1,0 +1,8 @@
+changelog_fr:
+  - version: 0.4.1
+    date: 2026-07-21
+    changes:
+      - type: feature
+        text: Option pour changer la page d'accueil dans les paramètres.
+      - type: feature
+        text: Journal des modifications affichant les derniers changements après une mise à jour.

--- a/assets/changelog/changelog_ja.yaml
+++ b/assets/changelog/changelog_ja.yaml
@@ -1,0 +1,8 @@
+changelog_ja:
+  - version: 0.4.1
+    date: 2026-07-21
+    changes:
+      - type: feature
+        text: 設定で起動時に表示するページを変更できるオプションを追加。
+      - type: feature
+        text: アップデート後に前回からの変更点を表示する変更履歴機能を追加。

--- a/assets/changelog/changelog_tl.yaml
+++ b/assets/changelog/changelog_tl.yaml
@@ -1,0 +1,8 @@
+changelog_tl:
+  - version: 0.4.1
+    date: 2026-07-21
+    changes:
+      - type: feature
+        text: Opsyon para palitan ang landing page sa mga setting.
+      - type: feature
+        text: Changelog feature para ipakita ang mga pagbabago mula sa nakaraang update.

--- a/lib/app/home_gate.dart
+++ b/lib/app/home_gate.dart
@@ -8,6 +8,7 @@ import 'package:trainlog_app/providers/settings_provider.dart';
 import 'package:trainlog_app/providers/trainlog_provider.dart';
 import 'package:trainlog_app/services/changelog_service.dart';
 import 'package:trainlog_app/services/flag_cache.dart';
+import 'package:trainlog_app/utils/platform_utils.dart';
 import 'package:trainlog_app/widgets/changelog_dialog.dart';
 import 'package:trainlog_app/widgets/trips_loader.dart';
 
@@ -41,6 +42,10 @@ class _HomeGateState extends State<HomeGate> {
   ///   that predates this feature): show only the latest entry.
   /// - Regular update: show every entry newer than the stored version.
   /// - Newer entries without any change item are recorded silently.
+  ///
+  /// Only changes relevant to the current platform are displayed: items
+  /// tagged os "ios" on Apple devices, "android" on Material ones, and
+  /// "all" (the default) everywhere.
   Future<void> _checkChangelog() async {
     final settings = context.read<SettingsProvider>();
     await settings.ready;
@@ -73,7 +78,12 @@ class _HomeGateState extends State<HomeGate> {
       date: latest.date,
     );
 
-    final entriesToShow = newEntries.where((e) => e.hasChanges).toList();
+    final platformOs =
+        AppPlatform.isApple ? ChangelogOs.ios : ChangelogOs.android;
+    final entriesToShow = newEntries
+        .map((e) => e.forOs(platformOs))
+        .where((e) => e.hasChanges)
+        .toList();
     if (entriesToShow.isEmpty || !mounted) return;
 
     await ChangelogDialog.show(

--- a/lib/app/home_gate.dart
+++ b/lib/app/home_gate.dart
@@ -1,20 +1,87 @@
 import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
 
+import 'package:trainlog_app/data/models/changelog.dart';
 import 'package:trainlog_app/features/onboarding/onboarding_screen.dart';
 import 'package:trainlog_app/features/user/login_page.dart';
 import 'package:trainlog_app/providers/settings_provider.dart';
 import 'package:trainlog_app/providers/trainlog_provider.dart';
+import 'package:trainlog_app/services/changelog_service.dart';
 import 'package:trainlog_app/services/flag_cache.dart';
+import 'package:trainlog_app/widgets/changelog_dialog.dart';
 import 'package:trainlog_app/widgets/trips_loader.dart';
 
-class HomeGate extends StatelessWidget {
+class HomeGate extends StatefulWidget {
   final WidgetBuilder signedInBuilder;
 
   const HomeGate({
     super.key,
     required this.signedInBuilder,
   });
+
+  @override
+  State<HomeGate> createState() => _HomeGateState();
+}
+
+class _HomeGateState extends State<HomeGate> {
+  @override
+  void initState() {
+    super.initState();
+    // Deferred to after the first frame so a Navigator and the localizations
+    // are available when the changelog dialogue needs to be shown.
+    WidgetsBinding.instance.addPostFrameCallback((_) => _checkChangelog());
+  }
+
+  /// Runs once per launch and decides whether the changelog modal must be
+  /// shown, then records the newest changelog version so it never re-triggers.
+  ///
+  /// - Fresh install (onboarding not completed yet): never show historical
+  ///   changes, just remember the current version.
+  /// - Existing user without a stored version (updated from an app version
+  ///   that predates this feature): show only the latest entry.
+  /// - Regular update: show every entry newer than the stored version.
+  /// - Newer entries without any change item are recorded silently.
+  Future<void> _checkChangelog() async {
+    final settings = context.read<SettingsProvider>();
+    await settings.ready;
+    if (!mounted) return;
+
+    final doc = await ChangelogService.load(settings.locale.languageCode);
+    final latest = doc.latest;
+    if (latest == null) return;
+
+    if (!settings.onboardingCompleted) {
+      await settings.setLastSeenChangelog(
+        version: latest.version,
+        date: latest.date,
+      );
+      return;
+    }
+
+    final storedVersion = settings.lastSeenChangelogVersion;
+    final List<ChangelogEntry> newEntries;
+    if (storedVersion.isEmpty) {
+      newEntries = [latest];
+    } else {
+      newEntries =
+          doc.entries.where((e) => e.isNewerThan(storedVersion)).toList();
+      if (newEntries.isEmpty) return; // Already up to date.
+    }
+
+    await settings.setLastSeenChangelog(
+      version: latest.version,
+      date: latest.date,
+    );
+
+    final entriesToShow = newEntries.where((e) => e.hasChanges).toList();
+    if (entriesToShow.isEmpty || !mounted) return;
+
+    await ChangelogDialog.show(
+      context,
+      entries: entriesToShow,
+      isFallback: doc.isFallback,
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -40,7 +107,7 @@ class HomeGate extends StatelessWidget {
         });
 
         return TripsLoader(
-          builder: signedInBuilder,
+          builder: widget.signedInBuilder,
         );
       },
     );

--- a/lib/data/models/changelog.dart
+++ b/lib/data/models/changelog.dart
@@ -1,0 +1,104 @@
+import 'package:yaml/yaml.dart';
+
+/// The kind of change a changelog item describes.
+///
+/// Declaration order is the display order in the changelog dialogue:
+/// features on top, then minor enhancements, then everything else,
+/// with bug fixes at the bottom.
+enum ChangelogChangeType {
+  feature,
+  minor,
+  other,
+  fix;
+
+  /// Unknown or missing types are treated as [other].
+  static ChangelogChangeType fromName(String? name) {
+    final normalized = name?.trim().toLowerCase();
+    return ChangelogChangeType.values.firstWhere(
+      (e) => e.name == normalized,
+      orElse: () => ChangelogChangeType.other,
+    );
+  }
+}
+
+class ChangelogChange {
+  final ChangelogChangeType type;
+  final String text;
+
+  const ChangelogChange({
+    required this.type,
+    required this.text,
+  });
+}
+
+class ChangelogEntry {
+  /// Human version string, e.g. "0.4.1".
+  final String version;
+  final DateTime? date;
+  final List<ChangelogChange> changes;
+
+  const ChangelogEntry({
+    required this.version,
+    required this.date,
+    required this.changes,
+  });
+
+  bool get hasChanges => changes.isNotEmpty;
+
+  factory ChangelogEntry.fromYaml(YamlMap map) {
+    final changes = <ChangelogChange>[];
+    final changesNode = map['changes'];
+    if (changesNode is YamlList) {
+      for (final item in changesNode) {
+        if (item is! YamlMap) continue;
+        final text = item['text']?.toString().trim() ?? '';
+        if (text.isEmpty) continue;
+        changes.add(ChangelogChange(
+          type: ChangelogChangeType.fromName(item['type']?.toString()),
+          text: text,
+        ));
+      }
+    }
+
+    return ChangelogEntry(
+      version: map['version']?.toString().trim() ?? '',
+      date: DateTime.tryParse(map['date']?.toString() ?? ''),
+      changes: changes,
+    );
+  }
+
+  /// Changes grouped by type, keys ordered like [ChangelogChangeType.values]
+  /// (feature → minor → other → fix), regardless of the order in the YAML.
+  /// Types without any change are omitted.
+  Map<ChangelogChangeType, List<ChangelogChange>> get groupedChanges {
+    return {
+      for (final type in ChangelogChangeType.values)
+        if (changes.any((c) => c.type == type))
+          type: changes.where((c) => c.type == type).toList(),
+    };
+  }
+
+  bool isNewerThan(String otherVersion) =>
+      otherVersion.isEmpty || compareVersions(version, otherVersion) > 0;
+
+  /// Numeric dotted-version comparison ("0.10.0" > "0.9.1"). Any build
+  /// metadata suffix ("+21") is ignored; missing segments count as 0.
+  static int compareVersions(String a, String b) {
+    List<int> parse(String v) => v
+        .split('+')
+        .first
+        .split('.')
+        .map((part) => int.tryParse(part.trim()) ?? 0)
+        .toList();
+
+    final partsA = parse(a);
+    final partsB = parse(b);
+    final length = partsA.length > partsB.length ? partsA.length : partsB.length;
+    for (var i = 0; i < length; i++) {
+      final valueA = i < partsA.length ? partsA[i] : 0;
+      final valueB = i < partsB.length ? partsB[i] : 0;
+      if (valueA != valueB) return valueA.compareTo(valueB);
+    }
+    return 0;
+  }
+}

--- a/lib/data/models/changelog.dart
+++ b/lib/data/models/changelog.dart
@@ -21,13 +21,31 @@ enum ChangelogChangeType {
   }
 }
 
+/// The platform a changelog item applies to.
+enum ChangelogOs {
+  ios,
+  android,
+  all;
+
+  /// Unknown or missing values are treated as [all].
+  static ChangelogOs fromName(String? name) {
+    final normalized = name?.trim().toLowerCase();
+    return ChangelogOs.values.firstWhere(
+      (e) => e.name == normalized,
+      orElse: () => ChangelogOs.all,
+    );
+  }
+}
+
 class ChangelogChange {
   final ChangelogChangeType type;
   final String text;
+  final ChangelogOs os;
 
   const ChangelogChange({
     required this.type,
     required this.text,
+    this.os = ChangelogOs.all,
   });
 }
 
@@ -56,6 +74,7 @@ class ChangelogEntry {
         changes.add(ChangelogChange(
           type: ChangelogChangeType.fromName(item['type']?.toString()),
           text: text,
+          os: ChangelogOs.fromName(item['os']?.toString()),
         ));
       }
     }
@@ -77,6 +96,16 @@ class ChangelogEntry {
           type: changes.where((c) => c.type == type).toList(),
     };
   }
+
+  /// Copy of this entry keeping only the changes relevant to [os]: items
+  /// tagged with that platform or with [ChangelogOs.all].
+  ChangelogEntry forOs(ChangelogOs os) => ChangelogEntry(
+        version: version,
+        date: date,
+        changes: changes
+            .where((c) => c.os == ChangelogOs.all || c.os == os)
+            .toList(),
+      );
 
   bool isNewerThan(String otherVersion) =>
       otherVersion.isEmpty || compareVersions(version, otherVersion) > 0;

--- a/lib/features/settings/settings_page.dart
+++ b/lib/features/settings/settings_page.dart
@@ -683,6 +683,21 @@ class _SettingsPageState extends State<SettingsPage> {
             onPressed: () => throw Exception(),
           ),
         ),
+      if (kDebugMode)
+        SettingsTile(
+          icon: AdaptiveIcons.refresh,
+          title: 'Reset changelog',
+          subtitle: 'debug',
+          trailing: AdaptiveButton.build(
+            context: ctx,
+            label: const Text('Reset'),
+            size: AdaptiveButton.small,
+            onPressed: () async {
+              await settings.clearLastSeenChangelog();
+              AdaptiveInformationMessage.showInfo('Changelog reset');
+            },
+          ),
+        ),
     ]);
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -795,5 +795,20 @@
 
   "tapAgainToExit": "Tap again to exit",
   "tripsEmptyList": "No trips yet",
-  "tripCardDateUndefined": "Undefined"
+  "tripCardDateUndefined": "Undefined",
+
+  "changelogTitle": "Changelog v{version}",
+  "@changelogTitle": {
+    "description": "Title of the changelog dialogue, showing the new version number",
+    "placeholders": {
+      "version": {
+        "type": "String",
+        "example": "0.4.1"
+      }
+    }
+  },
+  "changelogTypeFeature": "New features",
+  "changelogTypeMinor": "Improvements",
+  "changelogTypeOther": "Other changes",
+  "changelogTypeFix": "Bug fixes"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -442,5 +442,11 @@
 
   "tapAgainToExit": "Appuyez à nouveau pour quitter",
   "tripsEmptyList": "Aucun trajet",
-  "tripCardDateUndefined": "Indéfinie"
+  "tripCardDateUndefined": "Indéfinie",
+
+  "changelogTitle": "Journal des modifications v{version}",
+  "changelogTypeFeature": "Nouvelles fonctionnalités",
+  "changelogTypeMinor": "Améliorations",
+  "changelogTypeOther": "Autres changements",
+  "changelogTypeFix": "Corrections de bugs"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -444,7 +444,7 @@
   "tripsEmptyList": "Aucun trajet",
   "tripCardDateUndefined": "Indéfinie",
 
-  "changelogTitle": "Journal des modifications v{version}",
+  "changelogTitle": "Note de version v{version}",
   "changelogTypeFeature": "Nouvelles fonctionnalités",
   "changelogTypeMinor": "Améliorations",
   "changelogTypeOther": "Autres changements",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -443,5 +443,11 @@
 
   "tapAgainToExit": "もう一度タップすると終了します",
   "tripsEmptyList": "まだ旅はありません",
-  "tripCardDateUndefined": "未定義"
+  "tripCardDateUndefined": "未定義",
+
+  "changelogTitle": "変更履歴 v{version}",
+  "changelogTypeFeature": "新機能",
+  "changelogTypeMinor": "改善",
+  "changelogTypeOther": "その他の変更",
+  "changelogTypeFix": "不具合修正"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2561,6 +2561,36 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Undefined'**
   String get tripCardDateUndefined;
+
+  /// Title of the changelog dialogue, showing the new version number
+  ///
+  /// In en, this message translates to:
+  /// **'Changelog v{version}'**
+  String changelogTitle(String version);
+
+  /// No description provided for @changelogTypeFeature.
+  ///
+  /// In en, this message translates to:
+  /// **'New features'**
+  String get changelogTypeFeature;
+
+  /// No description provided for @changelogTypeMinor.
+  ///
+  /// In en, this message translates to:
+  /// **'Improvements'**
+  String get changelogTypeMinor;
+
+  /// No description provided for @changelogTypeOther.
+  ///
+  /// In en, this message translates to:
+  /// **'Other changes'**
+  String get changelogTypeOther;
+
+  /// No description provided for @changelogTypeFix.
+  ///
+  /// In en, this message translates to:
+  /// **'Bug fixes'**
+  String get changelogTypeFix;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1515,4 +1515,21 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get tripCardDateUndefined => 'Undefined';
+
+  @override
+  String changelogTitle(String version) {
+    return 'Changelog v$version';
+  }
+
+  @override
+  String get changelogTypeFeature => 'New features';
+
+  @override
+  String get changelogTypeMinor => 'Improvements';
+
+  @override
+  String get changelogTypeOther => 'Other changes';
+
+  @override
+  String get changelogTypeFix => 'Bug fixes';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1530,4 +1530,21 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get tripCardDateUndefined => 'Indéfinie';
+
+  @override
+  String changelogTitle(String version) {
+    return 'Journal des modifications v$version';
+  }
+
+  @override
+  String get changelogTypeFeature => 'Nouvelles fonctionnalités';
+
+  @override
+  String get changelogTypeMinor => 'Améliorations';
+
+  @override
+  String get changelogTypeOther => 'Autres changements';
+
+  @override
+  String get changelogTypeFix => 'Corrections de bugs';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1533,7 +1533,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String changelogTitle(String version) {
-    return 'Journal des modifications v$version';
+    return 'Note de version v$version';
   }
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1481,4 +1481,21 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get tripCardDateUndefined => '未定義';
+
+  @override
+  String changelogTitle(String version) {
+    return '変更履歴 v$version';
+  }
+
+  @override
+  String get changelogTypeFeature => '新機能';
+
+  @override
+  String get changelogTypeMinor => '改善';
+
+  @override
+  String get changelogTypeOther => 'その他の変更';
+
+  @override
+  String get changelogTypeFix => '不具合修正';
 }

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -1498,4 +1498,21 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String get tripCardDateUndefined => 'Hindi natukoy';
+
+  @override
+  String changelogTitle(String version) {
+    return 'Changelog v$version';
+  }
+
+  @override
+  String get changelogTypeFeature => 'Mga bagong feature';
+
+  @override
+  String get changelogTypeMinor => 'Mga pagpapahusay';
+
+  @override
+  String get changelogTypeOther => 'Iba pang pagbabago';
+
+  @override
+  String get changelogTypeFix => 'Mga bug fix';
 }

--- a/lib/l10n/app_tl.arb
+++ b/lib/l10n/app_tl.arb
@@ -601,5 +601,11 @@
 
   "tapAgainToExit": "I-tap muli para lumabas",
   "tripsEmptyList": "Wala pang biyahe",
-  "tripCardDateUndefined": "Hindi natukoy"
+  "tripCardDateUndefined": "Hindi natukoy",
+
+  "changelogTitle": "Changelog v{version}",
+  "changelogTypeFeature": "Mga bagong feature",
+  "changelogTypeMinor": "Mga pagpapahusay",
+  "changelogTypeOther": "Iba pang pagbabago",
+  "changelogTypeFix": "Mga bug fix"
 }

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -49,6 +49,8 @@ class SettingsProvider with ChangeNotifier {
   DateTime _SP_lastNewsVisit = DateTime.now().toUtc();
   DateTime? _SP_lastFetchingTrips;
   String? _SP_lastUsedInstanceUrl;
+  String _SP_lastSeenChangelogVersion = '';
+  DateTime? _SP_lastSeenChangelogDate;
 
   // Map filters
   PolylineYearFilter _SP_mapPolylineYearFilter = PolylineYearFilter.all;
@@ -59,6 +61,9 @@ class SettingsProvider with ChangeNotifier {
   static const _kLastUserLat = 'last_user_lat';
   static const _kLastUserLng = 'last_user_lng';
   static const _kUsernameKey = 'auth.username';
+
+  static const _kLastSeenChangelogVersion = 'last_seen_changelog_version';
+  static const _kLastSeenChangelogDate = 'last_seen_changelog_date';
 
   static const _kMapPolylineYearFilter = 'map_polyline_year_filter';
   static const _kMapPolylineSelectedYears = 'map_polyline_selected_years';
@@ -91,6 +96,8 @@ class SettingsProvider with ChangeNotifier {
   DateTime get lastNewsVisit => _SP_lastNewsVisit;
   DateTime? get lastFetchingTrips => _SP_lastFetchingTrips;
   String? get lastUsedInstanceUrl => _SP_lastUsedInstanceUrl;
+  String get lastSeenChangelogVersion => _SP_lastSeenChangelogVersion;
+  DateTime? get lastSeenChangelogDate => _SP_lastSeenChangelogDate;
 
   PolylineYearFilter get mapPolylineYearFilter => _SP_mapPolylineYearFilter;
   Set<int> get mapPolylineSelectedYears => Set.unmodifiable(_SP_mapPolylineSelectedYears);
@@ -148,6 +155,7 @@ class SettingsProvider with ChangeNotifier {
       _loadLastNewsVisit,
       _loadLastFetchingTrips,
       _loadLastUsedInstanceUrl,
+      _loadLastSeenChangelog,
       _loadMapPolylineFilterState,
     ];
 
@@ -558,6 +566,38 @@ class SettingsProvider with ChangeNotifier {
       await prefs.setString('last_used_instance_url', url);
     } else {
       await prefs.remove('last_used_instance_url');
+    }
+    notifyListeners();
+  }
+
+  // ------------------------------------------------------------------------------
+
+  void _loadLastSeenChangelog(SharedPreferences prefs) {
+    _SP_lastSeenChangelogVersion =
+        prefs.getString(_kLastSeenChangelogVersion) ?? '';
+    final d = prefs.getString(_kLastSeenChangelogDate);
+    _SP_lastSeenChangelogDate = d == null ? null : DateTime.parse(d);
+  }
+
+  /// Records the newest changelog entry already presented to (or skipped for)
+  /// the user, so the changelog dialogue is not shown again until an update
+  /// ships a newer entry.
+  Future<void> setLastSeenChangelog({
+    required String version,
+    DateTime? date,
+  }) async {
+    if (_SP_lastSeenChangelogVersion == version &&
+        _SP_lastSeenChangelogDate == date) {
+      return;
+    }
+    _SP_lastSeenChangelogVersion = version;
+    _SP_lastSeenChangelogDate = date;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_kLastSeenChangelogVersion, version);
+    if (date != null) {
+      await prefs.setString(_kLastSeenChangelogDate, date.toIso8601String());
+    } else {
+      await prefs.remove(_kLastSeenChangelogDate);
     }
     notifyListeners();
   }

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -602,6 +602,21 @@ class SettingsProvider with ChangeNotifier {
     notifyListeners();
   }
 
+  /// Debug helper: forgets the last-seen changelog so the dialogue shows
+  /// again on the next launch.
+  Future<void> clearLastSeenChangelog() async {
+    if (_SP_lastSeenChangelogVersion.isEmpty &&
+        _SP_lastSeenChangelogDate == null) {
+      return;
+    }
+    _SP_lastSeenChangelogVersion = '';
+    _SP_lastSeenChangelogDate = null;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_kLastSeenChangelogVersion);
+    await prefs.remove(_kLastSeenChangelogDate);
+    notifyListeners();
+  }
+
   // ------------------------------------------------------------------------------
 
   void _loadOnboardingCompleted(SharedPreferences prefs) {

--- a/lib/services/changelog_service.dart
+++ b/lib/services/changelog_service.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:yaml/yaml.dart';
+
+import 'package:trainlog_app/data/models/changelog.dart';
+
+/// The parsed content of a changelog asset file.
+class ChangelogDocument {
+  /// Entries sorted by version, newest first.
+  final List<ChangelogEntry> entries;
+
+  /// True when the English file was loaded because no file exists for the
+  /// requested (non-English) language.
+  final bool isFallback;
+
+  const ChangelogDocument({
+    required this.entries,
+    required this.isFallback,
+  });
+
+  ChangelogEntry? get latest => entries.isEmpty ? null : entries.first;
+}
+
+/// Loads release notes from assets/changelog/changelog_<language>.yaml,
+/// falling back to changelog_en.yaml for languages without a translation.
+class ChangelogService {
+  static const _assetDir = 'assets/changelog';
+
+  static Future<ChangelogDocument> load(
+    String languageCode, {
+    AssetBundle? bundle,
+  }) async {
+    final effectiveBundle = bundle ?? rootBundle;
+
+    String data;
+    var isFallback = false;
+    try {
+      data = await effectiveBundle
+          .loadString('$_assetDir/changelog_$languageCode.yaml');
+    } catch (_) {
+      try {
+        data = await effectiveBundle.loadString('$_assetDir/changelog_en.yaml');
+        isFallback = languageCode != 'en';
+      } catch (e) {
+        debugPrint('⚠️ ChangelogService: no changelog asset available: $e');
+        return const ChangelogDocument(entries: [], isFallback: false);
+      }
+    }
+
+    return ChangelogDocument(entries: parse(data), isFallback: isFallback);
+  }
+
+  /// Parses the YAML source. The root is a map with a single
+  /// changelog_<language> key holding the list of version entries; the key
+  /// name is not checked so a copied file with a stale key still loads.
+  @visibleForTesting
+  static List<ChangelogEntry> parse(String yamlSource) {
+    try {
+      final root = loadYaml(yamlSource);
+      if (root is! YamlMap || root.isEmpty) return const [];
+
+      final listNode =
+          root.values.firstWhere((v) => v is YamlList, orElse: () => null);
+      if (listNode is! YamlList) return const [];
+
+      final entries = listNode
+          .whereType<YamlMap>()
+          .map(ChangelogEntry.fromYaml)
+          .where((e) => e.version.isNotEmpty)
+          .toList()
+        ..sort((a, b) => ChangelogEntry.compareVersions(b.version, a.version));
+      return entries;
+    } catch (e) {
+      debugPrint('⚠️ ChangelogService: failed to parse changelog: $e');
+      return const [];
+    }
+  }
+}

--- a/lib/widgets/changelog_dialog.dart
+++ b/lib/widgets/changelog_dialog.dart
@@ -1,0 +1,178 @@
+import 'package:flutter/material.dart';
+
+import 'package:trainlog_app/data/models/changelog.dart';
+import 'package:trainlog_app/l10n/app_localizations.dart';
+import 'package:trainlog_app/platform/adaptive_button.dart';
+import 'package:trainlog_app/platform/adaptive_dialog.dart';
+import 'package:trainlog_app/widgets/error_banner.dart';
+
+/// Adaptive modal window listing the changes of one or more new versions.
+///
+/// The title shows the newest version ("Changelog v0.4.1"). Within a version,
+/// items are grouped by [ChangelogChangeType] and sorted so that features
+/// come first and bug fixes last, whatever their order in the YAML file.
+class ChangelogDialog extends StatelessWidget {
+  /// Entries to display, newest first. Must not be empty.
+  final List<ChangelogEntry> entries;
+
+  /// True when the English changelog was shown to a non-English user.
+  final bool isFallback;
+
+  const ChangelogDialog({
+    super.key,
+    required this.entries,
+    required this.isFallback,
+  });
+
+  static Future<void> show(
+    BuildContext context, {
+    required List<ChangelogEntry> entries,
+    required bool isFallback,
+  }) {
+    if (entries.isEmpty) return Future.value();
+    return AdaptiveDialog.showCustom<void>(
+      context: context,
+      maxHeightFactor: 0.7,
+      builder: (_) => ChangelogDialog(
+        entries: entries,
+        isFallback: isFallback,
+      ),
+    );
+  }
+
+  static IconData _typeIcon(ChangelogChangeType type) {
+    switch (type) {
+      case ChangelogChangeType.feature:
+        return Icons.auto_awesome;
+      case ChangelogChangeType.minor:
+        return Icons.trending_up;
+      case ChangelogChangeType.other:
+        return Icons.more_horiz;
+      case ChangelogChangeType.fix:
+        return Icons.bug_report_outlined;
+    }
+  }
+
+  static String _typeLabel(AppLocalizations loc, ChangelogChangeType type) {
+    switch (type) {
+      case ChangelogChangeType.feature:
+        return loc.changelogTypeFeature;
+      case ChangelogChangeType.minor:
+        return loc.changelogTypeMinor;
+      case ChangelogChangeType.other:
+        return loc.changelogTypeOther;
+      case ChangelogChangeType.fix:
+        return loc.changelogTypeFix;
+    }
+  }
+
+  List<Widget> _buildEntry(
+    BuildContext context,
+    ChangelogEntry entry, {
+    required bool showVersionHeader,
+  }) {
+    final loc = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
+
+    return [
+      if (showVersionHeader) ...[
+        Text(
+          'v${entry.version}',
+          style: theme.textTheme.titleMedium?.copyWith(
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        const SizedBox(height: 4),
+      ],
+      for (final group in entry.groupedChanges.entries) ...[
+        Padding(
+          padding: const EdgeInsets.only(top: 8, bottom: 4),
+          child: Row(
+            children: [
+              Icon(
+                _typeIcon(group.key),
+                size: 18,
+                color: theme.colorScheme.primary,
+              ),
+              const SizedBox(width: 8),
+              Text(
+                _typeLabel(loc, group.key),
+                style: theme.textTheme.titleSmall?.copyWith(
+                  color: theme.colorScheme.primary,
+                ),
+              ),
+            ],
+          ),
+        ),
+        for (final change in group.value)
+          Padding(
+            padding: const EdgeInsets.only(left: 26, bottom: 4),
+            child: Text(
+              '• ${change.text}',
+              style: theme.textTheme.bodyMedium,
+            ),
+          ),
+      ],
+    ];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
+    final locale = Localizations.localeOf(context).languageCode;
+
+    return Padding(
+      padding: const EdgeInsets.all(20),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            loc.changelogTitle(entries.first.version),
+            textAlign: TextAlign.center,
+            style: theme.textTheme.titleLarge?.copyWith(
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          const SizedBox(height: 12),
+          if (isFallback && locale != 'en') ...[
+            ErrorBanner(
+              severity: ErrorSeverity.info,
+              compact: true,
+              message: loc.pageNotAvailableInUserLanguage,
+            ),
+            const SizedBox(height: 8),
+          ],
+          Flexible(
+            child: SingleChildScrollView(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  for (var i = 0; i < entries.length; i++) ...[
+                    if (i > 0) const SizedBox(height: 12),
+                    ..._buildEntry(
+                      context,
+                      entries[i],
+                      showVersionHeader: entries.length > 1,
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          Align(
+            alignment: Alignment.centerRight,
+            child: AdaptiveButton.build(
+              context: context,
+              type: AdaptiveButtonType.primary,
+              onPressed: () => AdaptiveDialog.pop(context),
+              label: Text(MaterialLocalizations.of(context).okButtonLabel),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1451,7 +1451,7 @@ packages:
     source: hosted
     version: "6.6.1"
   yaml:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: yaml
       sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -62,6 +62,7 @@ dependencies:
   google_fonts: ^6.2.1
   country_codes_plus: ^5.1.1
   country_coder: ^1.2.0
+  yaml: ^3.1.3
 
 dev_dependencies:
   flutter_test:
@@ -78,6 +79,7 @@ flutter:
     - assets/icon/
     - assets/migrations/
     - assets/animations/
+    - assets/changelog/
     - assets/licenses/
 
 flutter_launcher_icons:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: trainlog_app
 description: "Your online travel diary"
 publish_to: 'none'
-version: 0.4.0+21
+version: 0.4.1+22
 
 environment:
   sdk: ^3.8.0


### PR DESCRIPTION
## Summary
Implements a changelog feature that automatically displays release notes to users when they update the app. The changelog is loaded from YAML asset files, supports multiple languages with English fallback, and intelligently filters changes by platform (iOS/Android).

## Key Changes

- **New Changelog Models** (`lib/data/models/changelog.dart`):
  - `ChangelogEntry`: Represents a version's release notes with version, date, and changes
  - `ChangelogChange`: Individual change items with type (feature/minor/other/fix), text, and platform targeting
  - `ChangelogChangeType` & `ChangelogOs`: Enums for categorizing and filtering changes
  - Version comparison logic for determining which entries are new

- **Changelog Service** (`lib/services/changelog_service.dart`):
  - Loads and parses YAML changelog files from assets
  - Supports language-specific files with automatic English fallback
  - Handles missing or malformed files gracefully

- **Changelog Dialog Widget** (`lib/widgets/changelog_dialog.dart`):
  - Adaptive modal displaying release notes with platform-specific styling
  - Groups changes by type with icons and localized labels
  - Shows fallback language warning when English is displayed to non-English users
  - Scrollable content for multiple version entries

- **HomeGate Integration** (`lib/app/home_gate.dart`):
  - Converted to `StatefulWidget` to check for new changelog entries on app launch
  - Smart logic to show changelog only for relevant updates:
    - Fresh installs: records version silently without showing dialog
    - Existing users: shows only new entries since last seen version
    - Filters changes by current platform (iOS/Android)

- **Settings Persistence** (`lib/providers/settings_provider.dart`):
  - Stores last seen changelog version and date
  - Prevents repeated display of the same changelog
  - Debug helper to reset changelog state

- **Localization**:
  - Added changelog-related strings to all supported languages (en, fr, ja, tl)
  - Localized change type labels (New features, Improvements, Other changes, Bug fixes)

- **Changelog Assets** (`assets/changelog/`):
  - Created YAML files for v0.4.1 in all supported languages
  - Demonstrates feature and change categorization

- **Debug Tools** (`lib/features/settings/settings_page.dart`):
  - Added "Reset changelog" button in debug settings for testing

## Notable Implementation Details

- Changes are automatically grouped by type and sorted (features → minor → other → fix) regardless of YAML order
- Platform-specific filtering ensures users only see relevant changes for their device
- Version comparison handles semantic versioning with build metadata (e.g., "0.10.0" > "0.9.1")
- Changelog check deferred to post-frame callback to ensure Navigator and localizations are available
- Empty changelog entries are recorded silently without showing the dialog

https://claude.ai/code/session_01C9n8L8ALj5hkeXjU9LYokR