### PR TITLE
Add trip direction chevrons to map with new layer and setting

### DIFF
--- a/assets/changelog/changelog_en.yaml
+++ b/assets/changelog/changelog_en.yaml
@@ -1,4 +1,9 @@
 changelog_en:
+  - version: 0.4.2
+    date: 2026-07-26
+    changes:
+      - type: feature
+        text: New map setting to display chevrons on the trip paths showing the direction of travel.
   - version: 0.4.1
     date: 2026-07-21
     changes:

--- a/assets/changelog/changelog_en.yaml
+++ b/assets/changelog/changelog_en.yaml
@@ -4,6 +4,8 @@ changelog_en:
     changes:
       - type: feature
         text: New map setting to display chevrons on the trip paths showing the direction of travel.
+      - type: fix
+        text: Added map zoom limits to prevent a crash when zooming out quickly.
   - version: 0.4.1
     date: 2026-07-21
     changes:

--- a/assets/changelog/changelog_fr.yaml
+++ b/assets/changelog/changelog_fr.yaml
@@ -4,6 +4,8 @@ changelog_fr:
     changes:
       - type: feature
         text: Nouveau paramètre de carte pour afficher des chevrons sur les trajets indiquant le sens du voyage.
+      - type: fix
+        text: Ajout de limites de zoom sur la carte pour éviter un plantage lors d'un zoom arrière rapide.
   - version: 0.4.1
     date: 2026-07-21
     changes:

--- a/assets/changelog/changelog_fr.yaml
+++ b/assets/changelog/changelog_fr.yaml
@@ -1,4 +1,9 @@
 changelog_fr:
+  - version: 0.4.2
+    date: 2026-07-26
+    changes:
+      - type: feature
+        text: Nouveau paramètre de carte pour afficher des chevrons sur les trajets indiquant le sens du voyage.
   - version: 0.4.1
     date: 2026-07-21
     changes:

--- a/assets/changelog/changelog_ja.yaml
+++ b/assets/changelog/changelog_ja.yaml
@@ -1,4 +1,9 @@
 changelog_ja:
+  - version: 0.4.2
+    date: 2026-07-26
+    changes:
+      - type: feature
+        text: 地図上の移動経路に進行方向を示すシェブロン（山形マーク）を表示する設定を追加。
   - version: 0.4.1
     date: 2026-07-21
     changes:

--- a/assets/changelog/changelog_ja.yaml
+++ b/assets/changelog/changelog_ja.yaml
@@ -4,6 +4,8 @@ changelog_ja:
     changes:
       - type: feature
         text: 地図上の移動経路に進行方向を示すシェブロン（山形マーク）を表示する設定を追加。
+      - type: fix
+        text: 地図のズームに上限と下限を設定し、素早く縮小した際のクラッシュを修正。
   - version: 0.4.1
     date: 2026-07-21
     changes:

--- a/assets/changelog/changelog_tl.yaml
+++ b/assets/changelog/changelog_tl.yaml
@@ -4,6 +4,8 @@ changelog_tl:
     changes:
       - type: feature
         text: Bagong setting ng mapa para magpakita ng mga chevron sa mga ruta ng biyahe na nagpapakita ng direksyon ng paglalakbay.
+      - type: fix
+        text: Nagdagdag ng limitasyon sa zoom ng mapa para maiwasan ang pag-crash kapag mabilis ang pag-zoom out.
   - version: 0.4.1
     date: 2026-07-21
     changes:

--- a/assets/changelog/changelog_tl.yaml
+++ b/assets/changelog/changelog_tl.yaml
@@ -1,4 +1,9 @@
 changelog_tl:
+  - version: 0.4.2
+    date: 2026-07-26
+    changes:
+      - type: feature
+        text: Bagong setting ng mapa para magpakita ng mga chevron sa mga ruta ng biyahe na nagpapakita ng direksyon ng paglalakbay.
   - version: 0.4.1
     date: 2026-07-21
     changes:

--- a/lib/features/map/map_page.dart
+++ b/lib/features/map/map_page.dart
@@ -227,6 +227,17 @@ class _MapPageState extends State<MapPage>
           options: MapOptions(
             initialCenter: _center,
             initialZoom: _zoom,
+            // Both bounds must stay finite. A fast pinch can make flutter_map
+            // feed a non-positive scale to log() (its guard checks
+            // details.scale, but the value used is details.scale plus an
+            // internal gesture-race corrector), producing an infinite or NaN
+            // zoom. MapCamera then asserts on it. Finite limits let clampZoom
+            // absorb that frame instead: -infinity lands on minZoom, NaN on
+            // maxZoom. 0 is a fully zoomed-out world; 22 is past anything
+            // usable, so over-zoom above OSM's native zoom 19 still works as
+            // before.
+            minZoom: 0,
+            maxZoom: 22,
             keepAlive: true,
             interactionOptions: const InteractionOptions(
               rotationThreshold: 20.0,

--- a/lib/features/map/map_page.dart
+++ b/lib/features/map/map_page.dart
@@ -27,6 +27,7 @@ import 'package:trainlog_app/utils/location_utils.dart';
 import 'package:trainlog_app/utils/platform_utils.dart';
 import 'package:trainlog_app/widgets/osm_mark.dart';
 import 'package:trainlog_app/widgets/rendered_polyline_layer.dart';
+import 'package:trainlog_app/widgets/trip_direction_chevron_layer.dart';
 
 class MapPage extends StatefulWidget {
   final SetPrimaryActions onPrimaryActionsReady;
@@ -254,6 +255,8 @@ class _MapPageState extends State<MapPage>
                 await showAdaptiveTripBottomSheet(context, trip: tappedTrip);
               },
             ),
+            if (settings.mapDisplayTripDirection)
+              const TripDirectionChevronLayer(),
             if (_userPosition != null && settings.mapDisplayUserLocationMarker)
               MarkerLayer(
                 markers: [

--- a/lib/features/settings/settings_page.dart
+++ b/lib/features/settings/settings_page.dart
@@ -469,6 +469,14 @@ class _SettingsPageState extends State<SettingsPage> {
           },
         ),
       ),
+      SettingsTile(
+        icon: AdaptiveIcons.tripDirection,
+        title: l10n.settingsDisplayTripDirection,
+        trailing: AdaptiveSwitch(
+          value: settings.mapDisplayTripDirection,
+          onChanged: settings.setMapDisplayTripDirection,
+        ),
+      ),
     ]);
   }
 

--- a/lib/features/settings/settings_page.dart
+++ b/lib/features/settings/settings_page.dart
@@ -218,6 +218,10 @@ class _SettingsPageState extends State<SettingsPage> {
             _buildDangerSection(ctx, l10n, settings, tripsProvider),
             _sectionHeader(ctx, l10n.menuAboutTitle),
             _buildAboutSection(ctx, l10n, settings, trainlog, tripsProvider),
+            if (kDebugMode) ...[
+              _sectionHeader(ctx, 'Debug'),
+              _buildDebugSection(ctx, l10n, settings, trainlog, tripsProvider),
+            ],
             const SizedBox(height: 24),
           ],
           );
@@ -664,9 +668,22 @@ class _SettingsPageState extends State<SettingsPage> {
             );
           },
       ),
-      if (kDebugMode)
+    ]);
+  }
+
+  Widget _buildDebugSection(
+    BuildContext ctx,
+    AppLocalizations l10n,
+    SettingsProvider settings,
+    TrainlogProvider trainlog,
+    TripsProvider tripsProvider,
+  ) {
+      final cs = Theme.of(ctx).colorScheme;
+      final icon = AdaptiveIcons.debug;
+
+      return SettingsGroup(children: [
         SettingsTile(
-          icon: AdaptiveIcons.refresh,
+          icon: icon,
           title: 'Reset Onboarding',
           subtitle: 'debug',
           trailing: AdaptiveButton.build(
@@ -679,9 +696,8 @@ class _SettingsPageState extends State<SettingsPage> {
             },
           ),
         ),
-      if (kDebugMode)
         SettingsTile(
-          icon: AdaptiveIcons.refresh,
+          icon: icon,
           title: 'Throw Test Exception',
           subtitle: 'debug',
           trailing: AdaptiveButton.build(
@@ -691,9 +707,8 @@ class _SettingsPageState extends State<SettingsPage> {
             onPressed: () => throw Exception(),
           ),
         ),
-      if (kDebugMode)
         SettingsTile(
-          icon: AdaptiveIcons.refresh,
+          icon: icon,
           title: 'Reset changelog',
           subtitle: 'debug',
           trailing: AdaptiveButton.build(
@@ -706,7 +721,7 @@ class _SettingsPageState extends State<SettingsPage> {
             },
           ),
         ),
-    ]);
+      ]);
   }
 }
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -158,6 +158,7 @@
   "settingsCacheClearGeologsToggle": "Also clear all the Geologs",
   "settingsCacheClearedMessage": "Cache cleared successfully.",
   "settingsDisplayUserMarker": "Display current position",
+  "settingsDisplayTripDirection": "Display trip direction",
   "settingsDeleteAccount": "Delete my account",
   "settingsDeleteAccountRequest": "Request",
   "settingsDeleteAccountError": "Unable to open email client, request at {email}",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -121,6 +121,7 @@
   "settingsCacheClearGeologsToggle": "Supprimer aussi tous les Géomémo",
   "settingsCacheClearedMessage": "Cache vidé avec succes.",
   "settingsDisplayUserMarker": "Afficher votre position",
+  "settingsDisplayTripDirection": "Afficher la direction des trajets",
   "settingsDeleteAccount": "Supprimer mon compte",
   "settingsDeleteAccountRequest": "Demander",
   "settingsDeleteAccountError": "Impossible d'ouvrir le client mail, demander à {email}",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -120,6 +120,7 @@
   "settingsCacheClearGeologsToggle": "すべてのジオログも削除する",
   "settingsCacheClearedMessage": "キャッシュが正常に消されました。",
   "settingsDisplayUserMarker": "現在の位置を表示する",
+  "settingsDisplayTripDirection": "移動の方向を表示する",
   "settingsDeleteAccount": "アカウントを削除する",
   "settingsDeleteAccountRequest": "申請",
   "settingsDeleteAccountError": "メールクライアントを開けません。{email} に申請してください",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -828,6 +828,12 @@ abstract class AppLocalizations {
   /// **'Display current position'**
   String get settingsDisplayUserMarker;
 
+  /// No description provided for @settingsDisplayTripDirection.
+  ///
+  /// In en, this message translates to:
+  /// **'Display trip direction'**
+  String get settingsDisplayTripDirection;
+
   /// No description provided for @settingsDeleteAccount.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -388,6 +388,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settingsDisplayUserMarker => 'Display current position';
 
   @override
+  String get settingsDisplayTripDirection => 'Display trip direction';
+
+  @override
   String get settingsDeleteAccount => 'Delete my account';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -390,6 +390,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settingsDisplayUserMarker => 'Afficher votre position';
 
   @override
+  String get settingsDisplayTripDirection =>
+      'Afficher la direction des trajets';
+
+  @override
   String get settingsDeleteAccount => 'Supprimer mon compte';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -379,6 +379,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settingsDisplayUserMarker => '現在の位置を表示する';
 
   @override
+  String get settingsDisplayTripDirection => '移動の方向を表示する';
+
+  @override
   String get settingsDeleteAccount => 'アカウントを削除する';
 
   @override

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -386,6 +386,9 @@ class AppLocalizationsTl extends AppLocalizations {
   String get settingsDisplayUserMarker => 'Ipakita ang kasalukurang lugar';
 
   @override
+  String get settingsDisplayTripDirection => 'Ipakita ang direksyon ng biyahe';
+
+  @override
   String get settingsDeleteAccount => 'Ibura ang account';
 
   @override

--- a/lib/l10n/app_tl.arb
+++ b/lib/l10n/app_tl.arb
@@ -128,6 +128,7 @@
   "settingsCacheClearGeologsToggle": "Burahin din ang lahat ng Geologs",
   "settingsCacheClearedMessage": "Nabura ang cache",
   "settingsDisplayUserMarker": "Ipakita ang kasalukurang lugar",
+  "settingsDisplayTripDirection": "Ipakita ang direksyon ng biyahe",
   "settingsDeleteAccount": "Ibura ang account",
   "settingsDeleteAccountRequest": "Request",
   "settingsDeleteAccountError": "Hindi kaya ibukas ang email client, request sa {email}",

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -31,6 +31,7 @@ class SettingsProvider with ChangeNotifier {
   MapColorPalette _mapColorPalette = MapColorPalette.trainlogWeb;
   bool _shouldReloadPolylines = true;
   bool _mapDisplayUserLocationMarker = true;
+  bool _mapDisplayTripDirection = false;
   bool _hideWarningMessage = false;
   String _currency = "EUR";
   int _sprRadius = 500;
@@ -79,6 +80,7 @@ class SettingsProvider with ChangeNotifier {
   MapColorPalette get mapColorPalette => _mapColorPalette;
   bool get shouldReloadPolylines => _shouldReloadPolylines;
   bool get mapDisplayUserLocationMarker => _mapDisplayUserLocationMarker;
+  bool get mapDisplayTripDirection => _mapDisplayTripDirection;
   bool get hideWarningMessage => _hideWarningMessage;
   String get currency => _currency;
   int get sprRadius => _sprRadius;
@@ -138,6 +140,7 @@ class SettingsProvider with ChangeNotifier {
       _loadMapColorPalette,
       _loadShouldReloadPolylines,
       _loadMapDisplayUserLocationMarker,
+      _loadMapDisplayTripDirection,
       _loadHideWarningMessage,
       _loadCurrency,
       _loadSprRadius,
@@ -327,6 +330,21 @@ class SettingsProvider with ChangeNotifier {
     _mapDisplayUserLocationMarker = maker;
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool('display_user_marker', maker);
+    notifyListeners();
+  }
+
+  // ------------------------------------------------------------------------------
+
+  void _loadMapDisplayTripDirection(SharedPreferences prefs) {
+    final direction = prefs.getBool('map_display_trip_direction');
+    _mapDisplayTripDirection = direction ?? false;
+  }
+
+  void setMapDisplayTripDirection(bool display) async {
+    if (_mapDisplayTripDirection == display) return;
+    _mapDisplayTripDirection = display;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('map_display_trip_direction', display);
     notifyListeners();
   }
 

--- a/lib/utils/platform_utils.dart
+++ b/lib/utils/platform_utils.dart
@@ -39,6 +39,7 @@ class AdaptiveIcons {
   static final IconData refresh =     isA ? CupertinoIcons.refresh : Icons.refresh;
   static final IconData license =     isA ? CupertinoIcons.doc_text : Icons.article;
   static final IconData chevronDown = isA ? CupertinoIcons.chevron_down : Icons.keyboard_arrow_down;
+  static final IconData debug =       isA ? CupertinoIcons.ant_fill : Icons.bug_report;
   
   // Sort
   static final IconData sortAscending = isA ? CupertinoIcons.sort_up : Icons.arrow_upward;

--- a/lib/utils/platform_utils.dart
+++ b/lib/utils/platform_utils.dart
@@ -80,6 +80,7 @@ class AdaptiveIcons {
   static final IconData layers =      isA ? CupertinoIcons.layers : Icons.layers;
   static final IconData palette =     isA ? CupertinoIcons.paintbrush : Icons.palette;
   static final IconData position =    isA ? CupertinoIcons.location : Icons.my_location;
+  static final IconData tripDirection = isA ? CupertinoIcons.chevron_right_2 : Icons.double_arrow;
   static final IconData visibility =  isA ? CupertinoIcons.eye : Icons.visibility;
   static final IconData world =       isA ? CupertinoIcons.map : Icons.public;
   static final IconData cache =       isA ? CupertinoIcons.cloud_download : Icons.cloud_download;

--- a/lib/widgets/trip_direction_chevron_layer.dart
+++ b/lib/widgets/trip_direction_chevron_layer.dart
@@ -329,8 +329,8 @@ class _TripDirectionChevronPainter extends CustomPainter {
   /// Appends one chevron (two strokes meeting at a tip pointing along the
   /// travel direction) to [path].
   void _addChevron(Path path, double posX, double posY, double dirX, double dirY) {
-    const halfLength = 3.0; // Along the travel direction.
-    const halfSpan = 4.5; // Across the line.
+    const halfLength = 2.5; // Along the travel direction. Spread: 3.0
+    const halfSpan = 2.0; // Across the line. Spread: 4.5
 
     final tipX = posX + dirX * halfLength;
     final tipY = posY + dirY * halfLength;

--- a/lib/widgets/trip_direction_chevron_layer.dart
+++ b/lib/widgets/trip_direction_chevron_layer.dart
@@ -14,7 +14,14 @@ import 'package:trainlog_app/providers/polyline_provider.dart';
 /// per trip, and trips too short on screen get none at all. Each chevron is
 /// black or white, whichever contrasts best with the trip's line colour.
 ///
-/// Must be placed inside [FlutterMap.children], above the polyline layer.
+/// Chevrons respect the stacking order of the trips: the layer walks the
+/// rendered polylines in their paint order and re-strokes each line over the
+/// chevrons already drawn for the trips below it, so where two trips overlap
+/// the chevrons of the lower one are hidden by the upper line, exactly like
+/// the line itself.
+///
+/// Must be placed inside [FlutterMap.children], directly above the polyline
+/// layer.
 class TripDirectionChevronLayer extends StatelessWidget {
   const TripDirectionChevronLayer({super.key});
 
@@ -49,9 +56,15 @@ class _TripDirectionChevronPainter extends CustomPainter {
   /// On-screen distance between two consecutive chevrons, in logical pixels.
   static const double _spacing = 72.0;
 
-  /// A polyline whose on-screen bounding box is smaller than this is skipped
-  /// entirely, so zoomed-out short trips are not covered by a lone chevron.
+  /// A polyline whose on-screen bounding box is smaller than this gets no
+  /// chevrons, so zoomed-out short trips are not covered by a lone chevron.
   static const double _minOnScreenSize = _spacing * 0.75;
+
+  /// Points closer than this (squared, in screen pixels) to the previously
+  /// kept point are dropped while walking a path: a cheap stand-in for the
+  /// polyline layer's simplification when re-stroking lines every frame. Kept
+  /// at ~1 px so the re-stroked line stays visually on top of the original.
+  static const double _decimationSq = 1.0;
 
   /// WCAG relative-luminance pivot: above it black offers the better contrast,
   /// below it white does (sqrt(1.05 * 0.05) - 0.05).
@@ -78,57 +91,50 @@ class _TripDirectionChevronPainter extends CustomPainter {
         ? const [0.0]
         : [0.0, -worldWidth, worldWidth];
 
-    final blackPath = Path();
-    final whitePath = Path();
-    var hasBlack = false;
-    var hasWhite = false;
+    // Until the first chevron is on the canvas there is nothing to cover, so
+    // the polylines themselves do not need to be re-stroked yet.
+    var anyChevronDrawn = false;
 
-    for (final polyline in polylines) {
-      // Future trips are rendered as two stacked polylines: the coloured base
-      // and a white dashed overlay. Only draw chevrons once per trip — on the
-      // solid coloured line — and pick their colour to contrast with it.
+    var i = 0;
+    while (i < polylines.length) {
+      final polyline = polylines[i];
+
+      // Only solid lines carry chevrons; a dashed/dotted line at this position
+      // has no preceding base (never produced by the render pipeline) and is
+      // skipped defensively.
       final pattern = polyline.pattern;
-      if (pattern.segments != null || pattern.spacingFactor != null) continue;
+      if (pattern.segments != null || pattern.spacingFactor != null) {
+        i++;
+        continue;
+      }
+
+      // The white dashed overlay of a future trip immediately follows its
+      // base polyline and shares its points list.
+      Polyline<int>? overlay;
+      if (i + 1 < polylines.length &&
+          identical(polylines[i + 1].points, polyline.points) &&
+          polylines[i + 1].pattern.segments != null) {
+        overlay = polylines[i + 1];
+      }
+      i += overlay == null ? 1 : 2;
 
       final projected = _project(polyline);
       if (projected == null) continue;
 
-      final useBlack = polyline.color.computeLuminance() > _luminancePivot;
-      final target = useBlack ? blackPath : whitePath;
-
       for (final shift in worldShifts) {
-        final added = _addChevronsForWorld(
-          target,
+        final drewChevrons = _drawPolylineWorld(
+          canvas,
+          polyline,
+          overlay,
           projected,
           shift: shift,
           zoomScale: zoomScale,
           origin: origin,
           cullRect: cullRect,
+          redrawLine: anyChevronDrawn,
         );
-        if (added) {
-          if (useBlack) {
-            hasBlack = true;
-          } else {
-            hasWhite = true;
-          }
-        }
+        anyChevronDrawn = anyChevronDrawn || drewChevrons;
       }
-    }
-
-    final strokeWidth = polylines.isEmpty ? 4.0 : polylines.first.strokeWidth;
-    final paint = Paint()
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = math.max(strokeWidth * 0.5, 1.8)
-      ..strokeCap = StrokeCap.round
-      ..strokeJoin = StrokeJoin.round;
-
-    // White first, black on top: where two trips overlap the upper chevrons
-    // stay readable.
-    if (hasWhite) {
-      canvas.drawPath(whitePath, paint..color = Colors.white);
-    }
-    if (hasBlack) {
-      canvas.drawPath(blackPath, paint..color = Colors.black);
     }
   }
 
@@ -164,42 +170,57 @@ class _TripDirectionChevronPainter extends CustomPainter {
     return projected;
   }
 
-  /// Walks one world copy of [projected] in screen space and appends a chevron
-  /// to [target] every [_spacing] pixels along the way.
+  /// Draws one world copy of a trip: optionally its line (border, core and
+  /// dashed overlay, mirroring the polyline layer below to cover chevrons of
+  /// earlier trips), then its own chevrons.
   ///
-  /// Returns whether at least one chevron was added.
-  bool _addChevronsForWorld(
-    Path target,
+  /// Returns whether at least one chevron was drawn.
+  bool _drawPolylineWorld(
+    Canvas canvas,
+    Polyline<int> polyline,
+    Polyline<int>? overlay,
     _ProjectedPath projected, {
     required double shift,
     required double zoomScale,
     required Offset origin,
     required Rect cullRect,
+    required bool redrawLine,
   }) {
     final crs = camera.crs;
 
     // Cheap whole-polyline culling: transform only the two bounding-box
     // corners to screen space before touching the individual points.
     final b = projected.bounds;
-    final (left, top) = crs.transform(b.left + shift, b.top, zoomScale);
-    final (right, bottom) = crs.transform(b.right + shift, b.bottom, zoomScale);
-    final screenBounds = Rect.fromPoints(
-      Offset(left, top) - origin,
-      Offset(right, bottom) - origin,
-    );
+    final (l, t) = crs.transform(b.left + shift, b.top, zoomScale);
+    final (r, bo) = crs.transform(b.right + shift, b.bottom, zoomScale);
+    final screenBounds = Rect.fromPoints(Offset(l, t) - origin, Offset(r, bo) - origin);
     if (!screenBounds.overlaps(cullRect)) return false;
-    if (screenBounds.longestSide < _minOnScreenSize) return false;
+
+    final wantChevrons = screenBounds.longestSide >= _minOnScreenSize;
+    if (!wantChevrons && !redrawLine) return false;
+
+    final linePath = redrawLine ? Path() : null;
+    final dashPath = redrawLine && overlay != null ? Path() : null;
+    final chevronPath = wantChevrons ? Path() : null;
+
+    final dashSegments = overlay?.pattern.segments;
+    final dashLen = dashSegments != null ? dashSegments[0] : 0.0;
+    final gapLen = dashSegments != null ? dashSegments[1] : 0.0;
+    var dashOn = true;
+    var dashRemaining = dashLen;
+
+    // Phase the first chevron half a spacing in, so short-but-visible paths
+    // still get one near their middle.
+    var untilChevron = _spacing * 0.5;
+    var drewChevrons = false;
 
     final offsets = projected.offsets;
     var (prevX, prevY) =
         crs.transform(offsets.first.dx + shift, offsets.first.dy, zoomScale);
     prevX -= origin.dx;
     prevY -= origin.dy;
-
-    // Phase the first chevron half a spacing in, so short-but-visible paths
-    // still get one near their middle.
-    var untilNext = _spacing * 0.5;
-    var addedAny = false;
+    linePath?.moveTo(prevX, prevY);
+    dashPath?.moveTo(prevX, prevY);
 
     for (var i = 1; i < offsets.length; i++) {
       var (x, y) =
@@ -209,50 +230,117 @@ class _TripDirectionChevronPainter extends CustomPainter {
 
       final dx = x - prevX;
       final dy = y - prevY;
-      final segLen = math.sqrt(dx * dx + dy * dy);
+      final segSq = dx * dx + dy * dy;
 
-      if (segLen > 0) {
-        final dirX = dx / segLen;
-        final dirY = dy / segLen;
+      // Drop nearly-coincident points (except the final one, so the path
+      // always reaches the arrival).
+      if (segSq < _decimationSq && i < offsets.length - 1) continue;
+      if (segSq == 0) continue;
+
+      final segLen = math.sqrt(segSq);
+      final dirX = dx / segLen;
+      final dirY = dy / segLen;
+
+      linePath?.lineTo(x, y);
+
+      if (chevronPath != null) {
         var travelled = 0.0;
+        while (segLen - travelled >= untilChevron) {
+          travelled += untilChevron;
+          untilChevron = _spacing;
 
-        while (segLen - travelled >= untilNext) {
-          travelled += untilNext;
-          untilNext = _spacing;
-
-          final pos = Offset(prevX + dirX * travelled, prevY + dirY * travelled);
-          if (cullRect.contains(pos)) {
-            _addChevron(target, pos, dirX, dirY);
-            addedAny = true;
+          final posX = prevX + dirX * travelled;
+          final posY = prevY + dirY * travelled;
+          if (cullRect.contains(Offset(posX, posY))) {
+            _addChevron(chevronPath, posX, posY, dirX, dirY);
+            drewChevrons = true;
           }
         }
-        untilNext -= segLen - travelled;
+        untilChevron -= segLen - travelled;
+      }
+
+      if (dashPath != null) {
+        var travelled = 0.0;
+        while (segLen - travelled >= dashRemaining) {
+          travelled += dashRemaining;
+          final posX = prevX + dirX * travelled;
+          final posY = prevY + dirY * travelled;
+          if (dashOn) {
+            dashPath.lineTo(posX, posY);
+          } else {
+            dashPath.moveTo(posX, posY);
+          }
+          dashOn = !dashOn;
+          dashRemaining = dashOn ? dashLen : gapLen;
+        }
+        dashRemaining -= segLen - travelled;
+        if (dashOn) dashPath.lineTo(x, y);
       }
 
       prevX = x;
       prevY = y;
     }
 
-    return addedAny;
+    final paint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeCap = StrokeCap.round
+      ..strokeJoin = StrokeJoin.round;
+
+    if (linePath != null) {
+      // Mirror the polyline layer's stacking: border underneath, then the
+      // coloured core, then the white dashed overlay of future trips.
+      if (polyline.borderStrokeWidth > 0) {
+        canvas.drawPath(
+          linePath,
+          paint
+            ..color = polyline.borderColor
+            ..strokeWidth = polyline.strokeWidth + polyline.borderStrokeWidth,
+        );
+      }
+      canvas.drawPath(
+        linePath,
+        paint
+          ..color = polyline.color
+          ..strokeWidth = polyline.strokeWidth,
+      );
+      if (dashPath != null && overlay != null) {
+        canvas.drawPath(
+          dashPath,
+          paint
+            ..color = overlay.color
+            ..strokeWidth = overlay.strokeWidth,
+        );
+      }
+    }
+
+    if (chevronPath != null && drewChevrons) {
+      final useBlack = polyline.color.computeLuminance() > _luminancePivot;
+      canvas.drawPath(
+        chevronPath,
+        paint
+          ..color = useBlack ? Colors.black : Colors.white
+          ..strokeWidth = math.max(polyline.strokeWidth * 0.5, 1.8),
+      );
+    }
+
+    return drewChevrons;
   }
 
   /// Appends one chevron (two strokes meeting at a tip pointing along the
   /// travel direction) to [path].
-  void _addChevron(Path path, Offset pos, double dirX, double dirY) {
+  void _addChevron(Path path, double posX, double posY, double dirX, double dirY) {
     const halfLength = 3.0; // Along the travel direction.
     const halfSpan = 4.5; // Across the line.
 
-    final tip = Offset(pos.dx + dirX * halfLength, pos.dy + dirY * halfLength);
-    final backX = pos.dx - dirX * halfLength;
-    final backY = pos.dy - dirY * halfLength;
+    final tipX = posX + dirX * halfLength;
+    final tipY = posY + dirY * halfLength;
+    final backX = posX - dirX * halfLength;
+    final backY = posY - dirY * halfLength;
     // Perpendicular of (dirX, dirY) is (-dirY, dirX).
-    final wing1 = Offset(backX - dirY * halfSpan, backY + dirX * halfSpan);
-    final wing2 = Offset(backX + dirY * halfSpan, backY - dirX * halfSpan);
-
     path
-      ..moveTo(wing1.dx, wing1.dy)
-      ..lineTo(tip.dx, tip.dy)
-      ..lineTo(wing2.dx, wing2.dy);
+      ..moveTo(backX - dirY * halfSpan, backY + dirX * halfSpan)
+      ..lineTo(tipX, tipY)
+      ..lineTo(backX + dirY * halfSpan, backY - dirX * halfSpan);
   }
 
   @override

--- a/lib/widgets/trip_direction_chevron_layer.dart
+++ b/lib/widgets/trip_direction_chevron_layer.dart
@@ -1,4 +1,5 @@
 import 'dart:math' as math;
+import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
@@ -19,6 +20,15 @@ import 'package:trainlog_app/providers/polyline_provider.dart';
 /// chevrons already drawn for the trips below it, so where two trips overlap
 /// the chevrons of the lower one are hidden by the upper line, exactly like
 /// the line itself.
+///
+/// That re-stroke is the layer's main cost, so it is kept off the hot path in
+/// two ways:
+///
+///  * each polyline's simplified geometry is cached per zoom level, mirroring
+///    what the polyline layer below already does, so panning only rescales a
+///    thinned point list instead of walking every stored point;
+///  * the screen area actually covered by chevrons is tracked as the layer
+///    paints, and only the trips passing over that area are re-stroked.
 ///
 /// Must be placed inside [FlutterMap.children], directly above the polyline
 /// layer.
@@ -60,11 +70,15 @@ class _TripDirectionChevronPainter extends CustomPainter {
   /// chevrons, so zoomed-out short trips are not covered by a lone chevron.
   static const double _minOnScreenSize = _spacing * 0.75;
 
-  /// Points closer than this (squared, in screen pixels) to the previously
-  /// kept point are dropped while walking a path: a cheap stand-in for the
-  /// polyline layer's simplification when re-stroking lines every frame. Kept
-  /// at ~1 px so the re-stroked line stays visually on top of the original.
-  static const double _decimationSq = 1.0;
+  /// Points closer than this (in screen pixels) to the previously kept point
+  /// are dropped: a cheap stand-in for the polyline layer's simplification
+  /// when re-stroking lines. Kept at ~1 px so the re-stroked line stays
+  /// visually on top of the original.
+  static const double _decimationPx = 1.0;
+
+  /// How far from its anchor a chevron's geometry reaches, before its stroke
+  /// is taken into account. Half-diagonal of the shape drawn by [_addChevron].
+  static const double _chevronReach = 3.2;
 
   /// WCAG relative-luminance pivot: above it black offers the better contrast,
   /// below it white does (sqrt(1.05 * 0.05) - 0.05).
@@ -72,7 +86,9 @@ class _TripDirectionChevronPainter extends CustomPainter {
 
   /// Caches the zoom-independent planar projection of each polyline, keyed by
   /// its (stable) points list, so panning/zooming only rescales cheap offsets
-  /// instead of re-projecting every LatLng on each frame.
+  /// instead of re-projecting every LatLng on each frame. Each entry also
+  /// carries the simplified point list for the last zoom level it was asked
+  /// for.
   static final Expando<_ProjectedPath> _projectionCache = Expando();
 
   @override
@@ -85,15 +101,24 @@ class _TripDirectionChevronPainter extends CustomPainter {
     final zoomScale = crs.scale(camera.zoom);
     final origin = camera.pixelOrigin;
 
+    // Simplification happens in planar space so its result can be reused for
+    // every pan at this zoom. The tolerance is derived at the *next* whole
+    // zoom, which keeps it at or below one screen pixel for every fractional
+    // zoom sharing the key: a cached list is then never coarser than the
+    // per-frame decimation it replaces.
+    final zoomKey = camera.zoom.ceil();
+    final planarToleranceSq = _planarToleranceSq(zoomKey);
+
     final worldWidth =
         crs.replicatesWorldLongitude ? crs.projection.getWorldWidth() : 0.0;
     final worldShifts = worldWidth == 0.0
         ? const [0.0]
         : [0.0, -worldWidth, worldWidth];
 
-    // Until the first chevron is on the canvas there is nothing to cover, so
-    // the polylines themselves do not need to be re-stroked yet.
-    var anyChevronDrawn = false;
+    // Screen area covered by the chevrons drawn so far. A trip only needs to
+    // be re-stroked where it can actually paint over one of them, so trips
+    // clear of this area keep the cheap early exit.
+    final chevronRegion = _ChevronRegion.forArea(cullRect);
 
     var i = 0;
     while (i < polylines.length) {
@@ -120,22 +145,46 @@ class _TripDirectionChevronPainter extends CustomPainter {
 
       final projected = _project(polyline);
       if (projected == null) continue;
+      final offsets = projected.simplified(zoomKey, planarToleranceSq);
 
+      List<Rect>? drawnChevrons;
       for (final shift in worldShifts) {
-        final drewChevrons = _drawPolylineWorld(
+        final drawn = _drawPolylineWorld(
           canvas,
           polyline,
           overlay,
           projected,
+          offsets,
           shift: shift,
           zoomScale: zoomScale,
           origin: origin,
           cullRect: cullRect,
-          redrawLine: anyChevronDrawn,
+          chevronRegion: chevronRegion,
         );
-        anyChevronDrawn = anyChevronDrawn || drewChevrons;
+        if (drawn != null) (drawnChevrons ??= []).add(drawn);
+      }
+
+      // Registered only once every world copy is drawn, so a trip is never
+      // re-stroked over chevrons it drew itself — those belong on top of it.
+      if (drawnChevrons != null) {
+        for (final rect in drawnChevrons) {
+          chevronRegion.add(rect);
+        }
       }
     }
+  }
+
+  /// Squared simplification tolerance in planar units, equivalent to
+  /// [_decimationPx] screen pixels at zoom [zoomKey].
+  double _planarToleranceSq(int zoomKey) {
+    final crs = camera.crs;
+    final scale = crs.scale(zoomKey.toDouble());
+    final (x0, _) = crs.transform(0.0, 0.0, scale);
+    final (x1, _) = crs.transform(1.0, 0.0, scale);
+    final pixelsPerPlanarUnit = (x1 - x0).abs();
+    if (pixelsPerPlanarUnit <= 0) return 0.0;
+    final tolerance = _decimationPx / pixelsPerPlanarUnit;
+    return tolerance * tolerance;
   }
 
   /// Projects (and caches) the polyline into zoom-independent planar space.
@@ -174,17 +223,22 @@ class _TripDirectionChevronPainter extends CustomPainter {
   /// dashed overlay, mirroring the polyline layer below to cover chevrons of
   /// earlier trips), then its own chevrons.
   ///
-  /// Returns whether at least one chevron was drawn.
-  bool _drawPolylineWorld(
+  /// [offsets] is the simplified planar geometry to walk; [projected] is only
+  /// consulted for the (unsimplified) bounding box used to cull.
+  ///
+  /// Returns the screen area covered by the chevrons it drew, or null if it
+  /// drew none.
+  Rect? _drawPolylineWorld(
     Canvas canvas,
     Polyline<int> polyline,
     Polyline<int>? overlay,
-    _ProjectedPath projected, {
+    _ProjectedPath projected,
+    List<Offset> offsets, {
     required double shift,
     required double zoomScale,
     required Offset origin,
     required Rect cullRect,
-    required bool redrawLine,
+    required _ChevronRegion chevronRegion,
   }) {
     final crs = camera.crs;
 
@@ -194,14 +248,23 @@ class _TripDirectionChevronPainter extends CustomPainter {
     final (l, t) = crs.transform(b.left + shift, b.top, zoomScale);
     final (r, bo) = crs.transform(b.right + shift, b.bottom, zoomScale);
     final screenBounds = Rect.fromPoints(Offset(l, t) - origin, Offset(r, bo) - origin);
-    if (!screenBounds.overlaps(cullRect)) return false;
+    if (!screenBounds.overlaps(cullRect)) return null;
 
     final wantChevrons = screenBounds.longestSide >= _minOnScreenSize;
-    if (!wantChevrons && !redrawLine) return false;
+
+    // The bounding box tracks the centre line, so widen it by the stroke to
+    // cover everything this trip can actually paint over.
+    final halfStroke = (polyline.strokeWidth + polyline.borderStrokeWidth) * 0.5;
+    final redrawLine = chevronRegion.overlaps(screenBounds.inflate(halfStroke));
+
+    if (!wantChevrons && !redrawLine) return null;
 
     final linePath = redrawLine ? Path() : null;
     final dashPath = redrawLine && overlay != null ? Path() : null;
     final chevronPath = wantChevrons ? Path() : null;
+
+    final chevronStroke = math.max(polyline.strokeWidth * 0.5, 1.8);
+    final chevronRadius = _chevronReach + chevronStroke * 0.5;
 
     final dashSegments = overlay?.pattern.segments;
     final dashLen = dashSegments != null ? dashSegments[0] : 0.0;
@@ -212,9 +275,8 @@ class _TripDirectionChevronPainter extends CustomPainter {
     // Phase the first chevron half a spacing in, so short-but-visible paths
     // still get one near their middle.
     var untilChevron = _spacing * 0.5;
-    var drewChevrons = false;
+    Rect? chevronBounds;
 
-    final offsets = projected.offsets;
     var (prevX, prevY) =
         crs.transform(offsets.first.dx + shift, offsets.first.dy, zoomScale);
     prevX -= origin.dx;
@@ -232,9 +294,6 @@ class _TripDirectionChevronPainter extends CustomPainter {
       final dy = y - prevY;
       final segSq = dx * dx + dy * dy;
 
-      // Drop nearly-coincident points (except the final one, so the path
-      // always reaches the arrival).
-      if (segSq < _decimationSq && i < offsets.length - 1) continue;
       if (segSq == 0) continue;
 
       final segLen = math.sqrt(segSq);
@@ -253,7 +312,11 @@ class _TripDirectionChevronPainter extends CustomPainter {
           final posY = prevY + dirY * travelled;
           if (cullRect.contains(Offset(posX, posY))) {
             _addChevron(chevronPath, posX, posY, dirX, dirY);
-            drewChevrons = true;
+            final drawn = Rect.fromCircle(
+              center: Offset(posX, posY),
+              radius: chevronRadius,
+            );
+            chevronBounds = chevronBounds?.expandToInclude(drawn) ?? drawn;
           }
         }
         untilChevron -= segLen - travelled;
@@ -313,17 +376,17 @@ class _TripDirectionChevronPainter extends CustomPainter {
       }
     }
 
-    if (chevronPath != null && drewChevrons) {
+    if (chevronPath != null && chevronBounds != null) {
       final useBlack = polyline.color.computeLuminance() > _luminancePivot;
       canvas.drawPath(
         chevronPath,
         paint
           ..color = useBlack ? Colors.black : Colors.white
-          ..strokeWidth = math.max(polyline.strokeWidth * 0.5, 1.8),
+          ..strokeWidth = chevronStroke,
       );
     }
 
-    return drewChevrons;
+    return chevronBounds;
   }
 
   /// Appends one chevron (two strokes meeting at a tip pointing along the
@@ -351,9 +414,133 @@ class _TripDirectionChevronPainter extends CustomPainter {
 
 /// A polyline projected into zoom-independent planar (CRS) space, with its
 /// planar bounding box for fast culling.
+///
+/// Also memoises the simplified point list for the zoom level it was last
+/// asked about. One entry is enough: the map sits at a single zoom between
+/// gestures, which is when panning repaints matter most.
 class _ProjectedPath {
   final List<Offset> offsets;
   final Rect bounds;
 
-  const _ProjectedPath({required this.offsets, required this.bounds});
+  int? _simplifiedZoomKey;
+  List<Offset>? _simplifiedOffsets;
+
+  _ProjectedPath({required this.offsets, required this.bounds});
+
+  /// The point list thinned to [toleranceSq] (squared planar units), cached
+  /// against [zoomKey].
+  List<Offset> simplified(int zoomKey, double toleranceSq) {
+    final cached = _simplifiedOffsets;
+    if (cached != null && _simplifiedZoomKey == zoomKey) return cached;
+
+    final result = _thin(offsets, toleranceSq);
+    _simplifiedZoomKey = zoomKey;
+    _simplifiedOffsets = result;
+    return result;
+  }
+
+  /// Drops points closer than [toleranceSq] to the previously kept one. The
+  /// first and last points are always kept, so the path still spans departure
+  /// to arrival.
+  static List<Offset> _thin(List<Offset> points, double toleranceSq) {
+    if (toleranceSq <= 0 || points.length < 3) return points;
+
+    final kept = <Offset>[points.first];
+    var prev = points.first;
+    for (var i = 1; i < points.length - 1; i++) {
+      final p = points[i];
+      final dx = p.dx - prev.dx;
+      final dy = p.dy - prev.dy;
+      if (dx * dx + dy * dy < toleranceSq) continue;
+      kept.add(p);
+      prev = p;
+    }
+    kept.add(points.last);
+
+    // Nothing dropped: keep sharing the original list rather than a copy.
+    return kept.length == points.length ? points : kept;
+  }
+}
+
+/// Coarse record of where chevrons have been drawn on screen, used to decide
+/// which trips have to be re-stroked over them.
+///
+/// A single union rectangle would swell to the whole viewport as soon as two
+/// trips sit in opposite corners, so occupancy is kept per cell instead.
+/// Cells are marked outward, making the test conservative: it may ask for a
+/// re-stroke that was not needed, never skip one that was.
+class _ChevronRegion {
+  static const double _cellSize = 32.0;
+
+  final Rect _area;
+  final int _columns;
+  final int _rows;
+  final Uint8List _cells;
+
+  /// Union of everything added so far, letting the common "nowhere near a
+  /// chevron" case be rejected without touching [_cells]. Null while empty.
+  Rect? _markedBounds;
+
+  _ChevronRegion._(this._area, this._columns, this._rows, this._cells);
+
+  factory _ChevronRegion.forArea(Rect area) {
+    final columns = math.max(1, (area.width / _cellSize).ceil());
+    final rows = math.max(1, (area.height / _cellSize).ceil());
+    return _ChevronRegion._(
+      Rect.fromLTWH(
+        area.left,
+        area.top,
+        columns * _cellSize,
+        rows * _cellSize,
+      ),
+      columns,
+      rows,
+      Uint8List(columns * rows),
+    );
+  }
+
+  void add(Rect rect) {
+    if (!rect.overlaps(_area)) return;
+
+    final (c0, r0, c1, r1) = _cellRange(rect);
+    for (var row = r0; row <= r1; row++) {
+      final rowStart = row * _columns;
+      for (var column = c0; column <= c1; column++) {
+        _cells[rowStart + column] = 1;
+      }
+    }
+
+    final marked = _markedBounds;
+    _markedBounds = marked == null ? rect : marked.expandToInclude(rect);
+  }
+
+  bool overlaps(Rect rect) {
+    final marked = _markedBounds;
+    if (marked == null || !rect.overlaps(marked)) return false;
+
+    final (c0, r0, c1, r1) = _cellRange(rect);
+    for (var row = r0; row <= r1; row++) {
+      final rowStart = row * _columns;
+      for (var column = c0; column <= c1; column++) {
+        if (_cells[rowStart + column] != 0) return true;
+      }
+    }
+    return false;
+  }
+
+  /// Inclusive (column, row) bounds of the cells [rect] touches, clamped to
+  /// the grid. Only call for a rect known to overlap [_area].
+  (int, int, int, int) _cellRange(Rect rect) {
+    int column(double x) =>
+        ((x - _area.left) / _cellSize).floor().clamp(0, _columns - 1);
+    int row(double y) =>
+        ((y - _area.top) / _cellSize).floor().clamp(0, _rows - 1);
+
+    return (
+      column(rect.left),
+      row(rect.top),
+      column(rect.right),
+      row(rect.bottom),
+    );
+  }
 }

--- a/lib/widgets/trip_direction_chevron_layer.dart
+++ b/lib/widgets/trip_direction_chevron_layer.dart
@@ -1,0 +1,271 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:provider/provider.dart';
+
+import 'package:trainlog_app/providers/polyline_provider.dart';
+
+/// Map layer drawing small chevrons along the rendered trip polylines to show
+/// the direction of travel (departure → arrival).
+///
+/// Chevrons are spaced at a constant *screen* distance, so their density stays
+/// the same at every zoom level: zooming out naturally shows fewer chevrons
+/// per trip, and trips too short on screen get none at all. Each chevron is
+/// black or white, whichever contrasts best with the trip's line colour.
+///
+/// Must be placed inside [FlutterMap.children], above the polyline layer.
+class TripDirectionChevronLayer extends StatelessWidget {
+  const TripDirectionChevronLayer({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final camera = MapCamera.of(context);
+    final poly = context.watch<PolylineProvider>();
+
+    return IgnorePointer(
+      child: MobileLayerTransformer(
+        child: CustomPaint(
+          painter: _TripDirectionChevronPainter(
+            camera: camera,
+            polylines: poly.renderedPolylines,
+          ),
+          size: camera.size,
+        ),
+      ),
+    );
+  }
+}
+
+class _TripDirectionChevronPainter extends CustomPainter {
+  final MapCamera camera;
+  final List<Polyline<int>> polylines;
+
+  _TripDirectionChevronPainter({
+    required this.camera,
+    required this.polylines,
+  });
+
+  /// On-screen distance between two consecutive chevrons, in logical pixels.
+  static const double _spacing = 72.0;
+
+  /// A polyline whose on-screen bounding box is smaller than this is skipped
+  /// entirely, so zoomed-out short trips are not covered by a lone chevron.
+  static const double _minOnScreenSize = _spacing * 0.75;
+
+  /// WCAG relative-luminance pivot: above it black offers the better contrast,
+  /// below it white does (sqrt(1.05 * 0.05) - 0.05).
+  static const double _luminancePivot = 0.179;
+
+  /// Caches the zoom-independent planar projection of each polyline, keyed by
+  /// its (stable) points list, so panning/zooming only rescales cheap offsets
+  /// instead of re-projecting every LatLng on each frame.
+  static final Expando<_ProjectedPath> _projectionCache = Expando();
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    // Cull to the canvas plus a margin, so a chevron whose anchor sits just
+    // outside the edge does not visibly pop in while panning.
+    final cullRect = (Offset.zero & size).inflate(24);
+
+    final crs = camera.crs;
+    final zoomScale = crs.scale(camera.zoom);
+    final origin = camera.pixelOrigin;
+
+    final worldWidth =
+        crs.replicatesWorldLongitude ? crs.projection.getWorldWidth() : 0.0;
+    final worldShifts = worldWidth == 0.0
+        ? const [0.0]
+        : [0.0, -worldWidth, worldWidth];
+
+    final blackPath = Path();
+    final whitePath = Path();
+    var hasBlack = false;
+    var hasWhite = false;
+
+    for (final polyline in polylines) {
+      // Future trips are rendered as two stacked polylines: the coloured base
+      // and a white dashed overlay. Only draw chevrons once per trip — on the
+      // solid coloured line — and pick their colour to contrast with it.
+      final pattern = polyline.pattern;
+      if (pattern.segments != null || pattern.spacingFactor != null) continue;
+
+      final projected = _project(polyline);
+      if (projected == null) continue;
+
+      final useBlack = polyline.color.computeLuminance() > _luminancePivot;
+      final target = useBlack ? blackPath : whitePath;
+
+      for (final shift in worldShifts) {
+        final added = _addChevronsForWorld(
+          target,
+          projected,
+          shift: shift,
+          zoomScale: zoomScale,
+          origin: origin,
+          cullRect: cullRect,
+        );
+        if (added) {
+          if (useBlack) {
+            hasBlack = true;
+          } else {
+            hasWhite = true;
+          }
+        }
+      }
+    }
+
+    final strokeWidth = polylines.isEmpty ? 4.0 : polylines.first.strokeWidth;
+    final paint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = math.max(strokeWidth * 0.5, 1.8)
+      ..strokeCap = StrokeCap.round
+      ..strokeJoin = StrokeJoin.round;
+
+    // White first, black on top: where two trips overlap the upper chevrons
+    // stay readable.
+    if (hasWhite) {
+      canvas.drawPath(whitePath, paint..color = Colors.white);
+    }
+    if (hasBlack) {
+      canvas.drawPath(blackPath, paint..color = Colors.black);
+    }
+  }
+
+  /// Projects (and caches) the polyline into zoom-independent planar space.
+  _ProjectedPath? _project(Polyline<int> polyline) {
+    final points = polyline.points;
+    if (points.length < 2) return null;
+
+    final cached = _projectionCache[points];
+    if (cached != null) return cached;
+
+    final projection = camera.crs.projection;
+    final offsets = List<Offset>.generate(
+      points.length,
+      (i) => projection.project(points[i]),
+      growable: false,
+    );
+
+    var minX = offsets.first.dx, maxX = offsets.first.dx;
+    var minY = offsets.first.dy, maxY = offsets.first.dy;
+    for (final o in offsets) {
+      if (o.dx < minX) minX = o.dx;
+      if (o.dx > maxX) maxX = o.dx;
+      if (o.dy < minY) minY = o.dy;
+      if (o.dy > maxY) maxY = o.dy;
+    }
+
+    final projected = _ProjectedPath(
+      offsets: offsets,
+      bounds: Rect.fromLTRB(minX, minY, maxX, maxY),
+    );
+    _projectionCache[points] = projected;
+    return projected;
+  }
+
+  /// Walks one world copy of [projected] in screen space and appends a chevron
+  /// to [target] every [_spacing] pixels along the way.
+  ///
+  /// Returns whether at least one chevron was added.
+  bool _addChevronsForWorld(
+    Path target,
+    _ProjectedPath projected, {
+    required double shift,
+    required double zoomScale,
+    required Offset origin,
+    required Rect cullRect,
+  }) {
+    final crs = camera.crs;
+
+    // Cheap whole-polyline culling: transform only the two bounding-box
+    // corners to screen space before touching the individual points.
+    final b = projected.bounds;
+    final (left, top) = crs.transform(b.left + shift, b.top, zoomScale);
+    final (right, bottom) = crs.transform(b.right + shift, b.bottom, zoomScale);
+    final screenBounds = Rect.fromPoints(
+      Offset(left, top) - origin,
+      Offset(right, bottom) - origin,
+    );
+    if (!screenBounds.overlaps(cullRect)) return false;
+    if (screenBounds.longestSide < _minOnScreenSize) return false;
+
+    final offsets = projected.offsets;
+    var (prevX, prevY) =
+        crs.transform(offsets.first.dx + shift, offsets.first.dy, zoomScale);
+    prevX -= origin.dx;
+    prevY -= origin.dy;
+
+    // Phase the first chevron half a spacing in, so short-but-visible paths
+    // still get one near their middle.
+    var untilNext = _spacing * 0.5;
+    var addedAny = false;
+
+    for (var i = 1; i < offsets.length; i++) {
+      var (x, y) =
+          crs.transform(offsets[i].dx + shift, offsets[i].dy, zoomScale);
+      x -= origin.dx;
+      y -= origin.dy;
+
+      final dx = x - prevX;
+      final dy = y - prevY;
+      final segLen = math.sqrt(dx * dx + dy * dy);
+
+      if (segLen > 0) {
+        final dirX = dx / segLen;
+        final dirY = dy / segLen;
+        var travelled = 0.0;
+
+        while (segLen - travelled >= untilNext) {
+          travelled += untilNext;
+          untilNext = _spacing;
+
+          final pos = Offset(prevX + dirX * travelled, prevY + dirY * travelled);
+          if (cullRect.contains(pos)) {
+            _addChevron(target, pos, dirX, dirY);
+            addedAny = true;
+          }
+        }
+        untilNext -= segLen - travelled;
+      }
+
+      prevX = x;
+      prevY = y;
+    }
+
+    return addedAny;
+  }
+
+  /// Appends one chevron (two strokes meeting at a tip pointing along the
+  /// travel direction) to [path].
+  void _addChevron(Path path, Offset pos, double dirX, double dirY) {
+    const halfLength = 3.0; // Along the travel direction.
+    const halfSpan = 4.5; // Across the line.
+
+    final tip = Offset(pos.dx + dirX * halfLength, pos.dy + dirY * halfLength);
+    final backX = pos.dx - dirX * halfLength;
+    final backY = pos.dy - dirY * halfLength;
+    // Perpendicular of (dirX, dirY) is (-dirY, dirX).
+    final wing1 = Offset(backX - dirY * halfSpan, backY + dirX * halfSpan);
+    final wing2 = Offset(backX + dirY * halfSpan, backY - dirX * halfSpan);
+
+    path
+      ..moveTo(wing1.dx, wing1.dy)
+      ..lineTo(tip.dx, tip.dy)
+      ..lineTo(wing2.dx, wing2.dy);
+  }
+
+  @override
+  bool shouldRepaint(covariant _TripDirectionChevronPainter oldDelegate) =>
+      oldDelegate.camera != camera ||
+      !identical(oldDelegate.polylines, polylines);
+}
+
+/// A polyline projected into zoom-independent planar (CRS) space, with its
+/// planar bounding box for fast culling.
+class _ProjectedPath {
+  final List<Offset> offsets;
+  final Rect bounds;
+
+  const _ProjectedPath({required this.offsets, required this.bounds});
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: trainlog_app
 description: "Your online travel diary"
 publish_to: 'none'
-version: 0.4.1+22
+version: 0.4.2+23
 
 environment:
   sdk: ^3.8.0


### PR DESCRIPTION
## Summary
This PR adds a new map feature that displays directional chevrons (arrow-like markers) along trip polylines to indicate the direction of travel. It includes a new customizable map layer, a user-facing settings toggle, and fixes a map zoom crash.

## Key Changes

- **New `TripDirectionChevronLayer`**: A custom Flutter map layer that renders chevrons along polylines showing travel direction (departure → arrival)
  - Chevrons are spaced at constant screen distance for consistent density across zoom levels
  - Automatically selects black or white chevrons based on polyline color contrast (WCAG luminance)
  - Respects trip stacking order by re-stroking lines over previously drawn chevrons
  - Implements performance optimizations:
    - Caches zoom-independent planar projections per polyline
    - Simplifies geometry per zoom level to avoid re-projecting on every pan
    - Tracks chevron screen area to only re-stroke affected trips
    - Uses spatial grid-based occupancy tracking for efficient overlap detection

- **Settings Integration**:
  - Added `mapDisplayTripDirection` boolean setting to `SettingsProvider`
  - New toggle in map settings UI: "Display trip direction"
  - Persisted to local storage with load/save methods

- **Map Page Integration**:
  - Integrated `TripDirectionChevronLayer` into map children stack (above polyline layer)
  - Added map zoom bounds to prevent crashes during rapid zoom-out gestures

- **Debug Section Refactoring**:
  - Extracted debug settings into dedicated `_buildDebugSection` method
  - Organized debug tools under a collapsible "Debug" section in settings

- **Localization**:
  - Added `settingsDisplayTripDirection` string key across all supported languages (English, French, Japanese, Tagalog)

- **Changelog & Version**:
  - Updated version to 0.4.2
  - Added changelog entries in all language variants documenting the new feature and zoom crash fix

## Implementation Details

The chevron layer uses a sophisticated caching and culling strategy:
- Polyline projections are cached in an `Expando` keyed by the points list, allowing pans to reuse cached geometry
- Simplified point lists are memoized per zoom level to avoid redundant thinning
- A `_ChevronRegion` grid tracks where chevrons have been drawn to minimize unnecessary line re-stroking
- Chevrons are positioned at half-spacing intervals initially, ensuring short paths still get at least one chevron near their midpoint

https://claude.ai/code/session_01ACcSG4f4BBPpmEECoGtCmz