### PR TITLE
Add migration to append UTC designator to timestamp fields

### DIFF
--- a/assets/migrations/0003_utc_timestamp_suffix.sql
+++ b/assets/migrations/0003_utc_timestamp_suffix.sql
@@ -1,0 +1,23 @@
+-- Older versions of the app parsed the server's `created` / `last_modified`
+-- values as local time, so they were cached without the trailing UTC 'Z'
+-- designator. The digits themselves were already UTC, so only the marker is
+-- missing: appending 'Z' is enough and no clock value is shifted.
+-- Rows written by the current app already end with 'Z', and the guards below
+-- skip anything that already carries a zone designator or a numeric offset,
+-- which makes this a no-op on a fresh install (empty table) and on rows that
+-- are already correct.
+UPDATE trips
+SET created = created || 'Z'
+WHERE created IS NOT NULL
+  AND TRIM(created) <> ''
+  AND created NOT LIKE '%Z'
+  AND created NOT GLOB '*[+-][0-9][0-9]:[0-9][0-9]'
+  AND created NOT GLOB '*[+-][0-9][0-9][0-9][0-9]';
+
+UPDATE trips
+SET last_modified = last_modified || 'Z'
+WHERE last_modified IS NOT NULL
+  AND TRIM(last_modified) <> ''
+  AND last_modified NOT LIKE '%Z'
+  AND last_modified NOT GLOB '*[+-][0-9][0-9]:[0-9][0-9]'
+  AND last_modified NOT GLOB '*[+-][0-9][0-9][0-9][0-9]'


### PR DESCRIPTION
## Summary
This migration adds the UTC 'Z' designator to `created` and `last_modified` timestamp fields in the `trips` table that are missing it. Older versions of the app cached these server timestamps as local time without the trailing 'Z' marker, even though the actual values were already in UTC.

## Changes
- **New migration file**: `assets/migrations/0003_utc_timestamp_suffix.sql`
  - Appends 'Z' to `created` timestamps that lack a zone designator
  - Appends 'Z' to `last_modified` timestamps that lack a zone designator
  - Includes guards to skip rows that already have proper timezone information (existing 'Z' or numeric offset like `+00:00` or `+0000`)
  - Safely handles null and empty values

## Implementation Details
- The migration uses SQLite's `GLOB` operator to detect existing timezone offsets in various formats
- The `LIKE '%Z'` check catches timestamps already ending with 'Z'
- The approach is idempotent: running on a fresh install or already-corrected data is a no-op
- No clock values are shifted; only the UTC marker is added to timestamps that were already in UTC

https://claude.ai/code/session_0177LbUxuGTWM4iuiiPSXF84